### PR TITLE
chore: disable CI and release workflows for local development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Switches CI workflow trigger from `push`/`pull_request` to `workflow_dispatch` (manual-only)
- Switches release workflow trigger from `push` on `v*` tags to `workflow_dispatch` (manual-only)
- No workflow logic changed — can be re-enabled by reverting the triggers

## Test plan
- [ ] Verify CI no longer runs on push/PR
- [ ] Verify release no longer triggers on version tags
- [ ] Verify both workflows can still be triggered manually from GitHub Actions UI if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)