### PR TITLE
feat: ship installer hardening + floo update command (F4.1/F4.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Check installer syntax
+        run: bash -n install.sh
+
+      - name: Run installer script tests
+        run: bash tests/install_script_test.sh
+
+      - name: Run installer script e2e
+        run: bash tests/install_script_e2e.sh
+
       - name: Run tests
         run: cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+  pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
+      - "cli-v*"
   workflow_dispatch:
 
 env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +379,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -465,6 +503,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -553,6 +592,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1651,6 +1700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +2025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2095,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = "0.8"
 reqwest = { version = "0.12", features = ["blocking", "multipart", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tar = "0.4"
 thiserror = "2"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -5,10 +5,20 @@ The command-line interface for [Floo](https://getfloo.com) — deploy, manage, a
 ## Install
 
 ```bash
-curl -fsSL https://getfloo.com/install.sh | sh
+curl -fsSL https://getfloo.com/install.sh | bash
 ```
 
 Or download a binary directly from [Releases](https://github.com/getfloo/floo-cli/releases).
+
+### Installer options
+
+```bash
+# Install a specific release tag
+curl -fsSL https://getfloo.com/install.sh | FLOO_INSTALL_VERSION=v0.1.0 bash
+
+# Install to a custom directory
+curl -fsSL https://getfloo.com/install.sh | FLOO_INSTALL_DIR="$HOME/.local/bin" bash
+```
 
 ### Supported platforms
 
@@ -21,6 +31,19 @@ Or download a binary directly from [Releases](https://github.com/getfloo/floo-cl
 | Windows | x86_64 | `floo-x86_64-pc-windows-msvc.exe` |
 
 **Windows:** Download `floo-x86_64-pc-windows-msvc.exe` from [Releases](https://github.com/getfloo/floo-cli/releases) and add it to your PATH.
+
+## Updating
+
+```bash
+# Show installed version
+floo version
+
+# Update to latest release
+floo update
+
+# Update to a specific release tag
+floo update --version v0.1.0
+```
 
 ## Quick start
 
@@ -46,6 +69,8 @@ floo domains add app.example.com --app my-app
 floo domains list --app my-app
 ```
 
+All commands are invoked with the production alias: `floo`.
+
 ## Agent / programmatic use
 
 Every command supports `--json` for structured output:
@@ -68,6 +93,18 @@ cd floo-cli
 cargo build --release
 # Binary at target/release/floo
 ```
+
+## Local development vs installed CLI
+
+Keep your installed production CLI on `floo`, and use the dev wrapper for local builds:
+
+```bash
+cd floo-cli
+cargo build
+./scripts/floo-dev --help
+```
+
+`scripts/floo-dev` runs `target/debug/floo` (or `FLOO_DEV_BIN` if set) so local development does not replace your installed `floo` binary.
 
 ## Contributing
 

--- a/install.sh
+++ b/install.sh
@@ -115,6 +115,7 @@ install_binary() {
         fail "Write permission denied for ${INSTALL_DIR}. Re-run with a writable FLOO_INSTALL_DIR."
     fi
 
+    sudo mkdir -p "$INSTALL_DIR" || fail "Failed to create install directory ${INSTALL_DIR} with sudo."
     sudo mv "$source_path" "$destination_path"
     sudo chmod 755 "$destination_path"
 }

--- a/install.sh
+++ b/install.sh
@@ -1,95 +1,187 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Floo CLI installer
-# Usage: curl -fsSL https://getfloo.com/install.sh | sh
+# Usage: curl -fsSL https://getfloo.com/install.sh | bash
 
-set -e
+set -euo pipefail
 
-REPO="getfloo/floo-cli"
-INSTALL_DIR="/usr/local/bin"
+REPO="${FLOO_INSTALL_REPO:-getfloo/floo-cli}"
+INSTALL_DIR="${FLOO_INSTALL_DIR:-/usr/local/bin}"
+REQUESTED_VERSION="${FLOO_INSTALL_VERSION:-}"
 BINARY_NAME="floo"
+TMP_DIR=""
 
-# Detect OS
-OS="$(uname -s)"
-case "$OS" in
-    Darwin) OS="apple-darwin" ;;
-    Linux)  OS="unknown-linux-musl" ;;
-    MINGW*|MSYS*|CYGWIN*)
-        echo "Error: This install script does not support Windows."
-        echo "Download floo.exe from https://github.com/${REPO}/releases"
-        exit 1
-        ;;
-    *)
-        echo "Error: Unsupported operating system: $OS"
-        echo "Floo supports macOS, Linux, and Windows."
-        exit 1
-        ;;
-esac
+log() {
+    echo "$*" >&2
+}
 
-# Detect architecture
-ARCH="$(uname -m)"
-case "$ARCH" in
-    x86_64|amd64) ARCH="x86_64" ;;
-    arm64|aarch64) ARCH="aarch64" ;;
-    *)
-        echo "Error: Unsupported architecture: $ARCH"
-        echo "Floo supports x86_64 and arm64."
-        exit 1
-        ;;
-esac
-
-TARGET="${ARCH}-${OS}"
-BINARY="floo-${TARGET}"
-
-echo "Detected platform: ${TARGET}"
-
-# Get latest release URL
-LATEST_URL="https://api.github.com/repos/${REPO}/releases/latest"
-DOWNLOAD_URL=$(curl -fsSL "$LATEST_URL" | grep "browser_download_url.*${BINARY}\"" | head -1 | cut -d '"' -f 4)
-
-if [ -z "$DOWNLOAD_URL" ]; then
-    echo "Error: Could not find a release for ${TARGET}"
-    echo "Check https://github.com/${REPO}/releases for available binaries."
+fail() {
+    echo "Error: $*" >&2
     exit 1
-fi
+}
 
-CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
-
-echo "Downloading ${BINARY}..."
-TMP_DIR=$(mktemp -d)
-curl -fsSL -o "${TMP_DIR}/${BINARY}" "$DOWNLOAD_URL"
-
-# Verify checksum if available
-if curl -fsSL -o "${TMP_DIR}/${BINARY}.sha256" "$CHECKSUM_URL" 2>/dev/null; then
-    echo "Verifying checksum..."
-    cd "$TMP_DIR"
-    if command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 -c "${BINARY}.sha256"
-    elif command -v sha256sum >/dev/null 2>&1; then
-        sha256sum -c "${BINARY}.sha256"
-    else
-        echo "Warning: No checksum tool found, skipping verification."
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        fail "Required command '$1' is not installed."
     fi
-    cd - >/dev/null
-fi
+}
 
-# Install
-echo "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
-chmod +x "${TMP_DIR}/${BINARY}"
+sha256_file() {
+    local file="$1"
 
-if [ -w "$INSTALL_DIR" ]; then
-    mv "${TMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY_NAME}"
-else
-    sudo mv "${TMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY_NAME}"
-fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print tolower($1)}'
+        return
+    fi
 
-rm -rf "$TMP_DIR"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print tolower($1)}'
+        return
+    fi
 
-echo ""
-echo "Floo CLI installed successfully!"
-echo ""
-echo "Get started:"
-echo "  floo login          # Authenticate"
-echo "  floo deploy         # Deploy your project"
-echo "  floo --help         # See all commands"
-echo ""
-echo "Docs: https://docs.getfloo.com"
+    if command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$file" | awk '{print tolower($NF)}'
+        return
+    fi
+
+    fail "No SHA256 tool found (need shasum, sha256sum, or openssl)."
+}
+
+detect_target() {
+    local uname_s="${FLOO_INSTALL_OS:-$(uname -s)}"
+    local uname_m="${FLOO_INSTALL_ARCH:-$(uname -m)}"
+    local os=""
+    local arch=""
+
+    case "$uname_s" in
+        Darwin) os="apple-darwin" ;;
+        Linux) os="unknown-linux-musl" ;;
+        MINGW*|MSYS*|CYGWIN*|Windows_NT)
+            fail "Windows install is not supported by this script. Download floo.exe from https://github.com/${REPO}/releases"
+            ;;
+        *)
+            fail "Unsupported operating system: ${uname_s}. Supported: macOS, Linux."
+            ;;
+    esac
+
+    case "$uname_m" in
+        x86_64|amd64) arch="x86_64" ;;
+        arm64|aarch64) arch="aarch64" ;;
+        *)
+            fail "Unsupported architecture: ${uname_m}. Supported: x86_64, arm64."
+            ;;
+    esac
+
+    echo "${arch}-${os}"
+}
+
+release_binary_url() {
+    local asset="$1"
+
+    if [[ -n "${FLOO_INSTALL_BINARY_URL:-}" ]]; then
+        echo "${FLOO_INSTALL_BINARY_URL}"
+        return
+    fi
+
+    if [[ -n "$REQUESTED_VERSION" ]]; then
+        echo "https://github.com/${REPO}/releases/download/${REQUESTED_VERSION}/${asset}"
+    else
+        echo "https://github.com/${REPO}/releases/latest/download/${asset}"
+    fi
+}
+
+release_checksum_url() {
+    local binary_url="$1"
+
+    if [[ -n "${FLOO_INSTALL_CHECKSUM_URL:-}" ]]; then
+        echo "${FLOO_INSTALL_CHECKSUM_URL}"
+    else
+        echo "${binary_url}.sha256"
+    fi
+}
+
+install_binary() {
+    local source_path="$1"
+    local destination_path="${INSTALL_DIR}/${BINARY_NAME}"
+
+    mkdir -p "$INSTALL_DIR" 2>/dev/null || true
+
+    if [[ -w "$INSTALL_DIR" ]]; then
+        mv "$source_path" "$destination_path"
+        chmod 755 "$destination_path"
+        return
+    fi
+
+    if ! command -v sudo >/dev/null 2>&1; then
+        fail "Write permission denied for ${INSTALL_DIR}. Re-run with a writable FLOO_INSTALL_DIR."
+    fi
+
+    sudo mv "$source_path" "$destination_path"
+    sudo chmod 755 "$destination_path"
+}
+
+cleanup() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+main() {
+    need_cmd curl
+    need_cmd uname
+    need_cmd mktemp
+    need_cmd awk
+
+    local target
+    target="$(detect_target)"
+    local asset="floo-${target}"
+
+    log "Detected platform: ${target}"
+
+    local binary_url
+    binary_url="$(release_binary_url "$asset")"
+    local checksum_url
+    checksum_url="$(release_checksum_url "$binary_url")"
+
+    TMP_DIR="$(mktemp -d)"
+    trap cleanup EXIT
+
+    local binary_path="${TMP_DIR}/${asset}"
+    local checksum_path="${TMP_DIR}/${asset}.sha256"
+
+    log "Downloading ${asset}..."
+    curl -fsSL -o "$binary_path" "$binary_url" || fail "Failed to download binary from ${binary_url}"
+
+    log "Downloading checksum..."
+    curl -fsSL -o "$checksum_path" "$checksum_url" || fail "Failed to download checksum from ${checksum_url}"
+
+    local expected_checksum
+    expected_checksum="$(awk 'NF {print tolower($1); exit}' "$checksum_path")"
+    [[ -n "$expected_checksum" ]] || fail "Checksum file is empty or invalid."
+
+    local actual_checksum
+    actual_checksum="$(sha256_file "$binary_path")"
+
+    if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+        fail "Checksum mismatch for ${asset}. Expected ${expected_checksum}, got ${actual_checksum}."
+    fi
+
+    chmod +x "$binary_path"
+
+    log "Installing ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}..."
+    install_binary "$binary_path"
+
+    local version_output
+    version_output="$(${INSTALL_DIR}/${BINARY_NAME} --version 2>/dev/null || true)"
+    [[ -n "$version_output" ]] || fail "Installation completed but '${INSTALL_DIR}/${BINARY_NAME} --version' failed."
+
+    echo
+    echo "Floo CLI installed successfully."
+    echo "Version: ${version_output}"
+    echo
+    echo "Get started:"
+    echo "  floo login"
+    echo "  floo deploy"
+    echo "  floo update"
+}
+
+main "$@"

--- a/scripts/floo-dev
+++ b/scripts/floo-dev
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_BIN="${REPO_ROOT}/target/debug/floo"
+DEV_BIN="${FLOO_DEV_BIN:-$DEFAULT_BIN}"
+
+if [[ ! -x "$DEV_BIN" ]]; then
+    echo "floo-dev: binary not found at $DEV_BIN" >&2
+    echo "Build it first: cd ${REPO_ROOT} && cargo build" >&2
+    exit 1
+fi
+
+exec "$DEV_BIN" "$@"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,16 @@ pub enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
+
+    /// Print installed CLI version.
+    Version,
+
+    /// Update the CLI binary in-place.
+    Update {
+        /// Specific release tag to install (e.g. v0.2.0).
+        #[arg(long)]
+        version: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -258,5 +268,7 @@ pub fn run() {
             };
             commands::logs::logs(&app, tail, since.as_deref(), sev, output.as_deref());
         }
+        Commands::Version => commands::update::version(),
+        Commands::Update { version } => commands::update::update(version.as_deref()),
     }
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -88,7 +88,7 @@ pub fn logs(
             output::error(
                 "Unexpected response format from the API.",
                 "PARSE_ERROR",
-                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | sh"),
+                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | bash"),
             );
             process::exit(1);
         }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod domains;
 pub mod env;
 pub mod logs;
 pub mod rollbacks;
+pub mod update;

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -59,7 +59,7 @@ pub fn list(app_name: &str) {
             output::error(
                 "Unexpected response format from the API.",
                 "PARSE_ERROR",
-                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | sh"),
+                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | bash"),
             );
             process::exit(1);
         }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,0 +1,47 @@
+use std::process;
+
+use crate::constants::VERSION;
+use crate::output;
+use crate::updater;
+
+pub fn version() {
+    output::success(
+        &format!("floo {VERSION}"),
+        Some(serde_json::json!({"version": VERSION})),
+    );
+}
+
+pub fn update(version: Option<&str>) {
+    if !output::is_json_mode() {
+        let label = version.unwrap_or("latest");
+        output::info(&format!("Checking for Floo updates ({label})..."), None);
+    }
+
+    match updater::run_update(version) {
+        Ok(result) => {
+            output::success(
+                &format!("Updated Floo to {}.", result.version),
+                Some(serde_json::json!({
+                    "version": result.version,
+                    "path": result.install_path,
+                })),
+            );
+        }
+        Err(err) => {
+            output::error(&err.message, &err.code, err.suggestion.as_deref());
+            process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::output;
+
+    #[test]
+    fn test_version_in_json_mode_does_not_panic() {
+        output::set_json_mode(true);
+        super::version();
+        output::set_json_mode(false);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod errors;
 mod names;
 mod output;
 mod resolve;
+mod updater;
 
 fn main() {
     cli::run();

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,499 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use reqwest::blocking::Client;
+use reqwest::header::{ACCEPT, USER_AGENT};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::errors::FlooError;
+
+const DEFAULT_RELEASES_API_BASE: &str = "https://api.github.com/repos/getfloo/floo-cli/releases";
+
+#[derive(Debug, Clone)]
+struct ReleaseAsset {
+    version: String,
+    asset_name: String,
+    binary_url: String,
+    checksum_url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateResult {
+    pub version: String,
+    pub install_path: PathBuf,
+}
+
+fn releases_api_base() -> String {
+    env::var("FLOO_UPDATE_API_BASE").unwrap_or_else(|_| DEFAULT_RELEASES_API_BASE.to_string())
+}
+
+fn target_asset_name() -> Result<String, FlooError> {
+    let os = env::consts::OS;
+    let arch = env::consts::ARCH;
+
+    let target = match (os, arch) {
+        ("macos", "x86_64") => "x86_64-apple-darwin",
+        ("macos", "aarch64") => "aarch64-apple-darwin",
+        ("linux", "x86_64") => "x86_64-unknown-linux-musl",
+        ("linux", "aarch64") => "aarch64-unknown-linux-musl",
+        ("windows", "x86_64") => "x86_64-pc-windows-msvc.exe",
+        _ => {
+            return Err(FlooError::with_suggestion(
+                "UNSUPPORTED_PLATFORM",
+                format!("Platform '{os}/{arch}' is not supported for automatic updates."),
+                "Download a release binary manually from https://github.com/getfloo/floo-cli/releases",
+            ));
+        }
+    };
+
+    Ok(format!("floo-{target}"))
+}
+
+fn build_release_url(api_base: &str, version: Option<&str>) -> String {
+    match version {
+        Some(v) if !v.trim().is_empty() => format!("{api_base}/tags/{v}"),
+        _ => format!("{api_base}/latest"),
+    }
+}
+
+fn build_http_client() -> Result<Client, FlooError> {
+    Client::builder().build().map_err(|e| {
+        FlooError::with_suggestion(
+            "UPDATE_HTTP_CLIENT_ERROR",
+            format!("Failed to initialize update client: {e}"),
+            "Try again. If it persists, reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+        )
+    })
+}
+
+fn fetch_release_json(
+    client: &Client,
+    api_base: &str,
+    version: Option<&str>,
+) -> Result<Value, FlooError> {
+    let url = build_release_url(api_base, version);
+    let response = client
+        .get(url)
+        .header(USER_AGENT, "floo-cli-updater")
+        .header(ACCEPT, "application/vnd.github+json")
+        .send()
+        .map_err(|e| {
+            FlooError::with_suggestion(
+                "RELEASE_LOOKUP_FAILED",
+                format!("Failed to fetch release metadata: {e}"),
+                "Check your network and try again.",
+            )
+        })?;
+
+    if !response.status().is_success() {
+        return Err(FlooError::with_suggestion(
+            "RELEASE_LOOKUP_FAILED",
+            format!("Release lookup failed with status {}.", response.status()),
+            "Verify the version tag exists, or run 'floo update' without --version.",
+        ));
+    }
+
+    response.json::<Value>().map_err(|e| {
+        FlooError::with_suggestion(
+            "RELEASE_PARSE_ERROR",
+            format!("Failed to parse release metadata: {e}"),
+            "Try again. If it persists, reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+        )
+    })
+}
+
+fn release_asset_from_json(release: &Value, asset_name: &str) -> Result<ReleaseAsset, FlooError> {
+    let version = release
+        .get("tag_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let assets = release
+        .get("assets")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            FlooError::with_suggestion(
+                "RELEASE_ASSET_MISSING",
+                "Release metadata did not include assets.".to_string(),
+                "Try again shortly after the release publishes.",
+            )
+        })?;
+
+    let binary_url = assets
+        .iter()
+        .find(|asset| asset.get("name").and_then(Value::as_str) == Some(asset_name))
+        .and_then(|asset| asset.get("browser_download_url"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            FlooError::with_suggestion(
+                "RELEASE_ASSET_MISSING",
+                format!("No binary asset found for '{asset_name}'."),
+                "Check https://github.com/getfloo/floo-cli/releases for available artifacts.",
+            )
+        })?;
+
+    let checksum_name = format!("{asset_name}.sha256");
+    let checksum_url = assets
+        .iter()
+        .find(|asset| asset.get("name").and_then(Value::as_str) == Some(checksum_name.as_str()))
+        .and_then(|asset| asset.get("browser_download_url"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            FlooError::with_suggestion(
+                "CHECKSUM_MISSING",
+                format!("No checksum asset found for '{asset_name}'."),
+                "Try again once release artifacts are fully published.",
+            )
+        })?;
+
+    Ok(ReleaseAsset {
+        version,
+        asset_name: asset_name.to_string(),
+        binary_url,
+        checksum_url,
+    })
+}
+
+fn download_bytes(client: &Client, url: &str) -> Result<Vec<u8>, FlooError> {
+    let response = client
+        .get(url)
+        .header(USER_AGENT, "floo-cli-updater")
+        .send()
+        .map_err(|e| {
+            FlooError::with_suggestion(
+                "DOWNLOAD_FAILED",
+                format!("Failed to download update asset: {e}"),
+                "Check your network and try again.",
+            )
+        })?;
+
+    if !response.status().is_success() {
+        return Err(FlooError::with_suggestion(
+            "DOWNLOAD_FAILED",
+            format!("Asset download failed with status {}.", response.status()),
+            "Check the release artifacts and try again.",
+        ));
+    }
+
+    response.bytes().map(|bytes| bytes.to_vec()).map_err(|e| {
+        FlooError::with_suggestion(
+            "DOWNLOAD_FAILED",
+            format!("Failed to read downloaded bytes: {e}"),
+            "Try again.",
+        )
+    })
+}
+
+fn parse_checksum(checksum_contents: &str) -> Result<String, FlooError> {
+    for line in checksum_contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(token) = trimmed.split_whitespace().next() {
+            let normalized = token.to_ascii_lowercase();
+            if normalized.len() == 64 && normalized.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Ok(normalized);
+            }
+        }
+    }
+
+    Err(FlooError::with_suggestion(
+        "CHECKSUM_PARSE_ERROR",
+        "Checksum file did not contain a valid SHA256 hash.".to_string(),
+        "Try again. If this persists, reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+    ))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), FlooError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .map_err(|e| FlooError::new("UPDATE_INSTALL_FAILED", format!("Failed to stat file: {e}")))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).map_err(|e| {
+        FlooError::new(
+            "UPDATE_INSTALL_FAILED",
+            format!("Failed to set executable permissions: {e}"),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), FlooError> {
+    Ok(())
+}
+
+fn install_path_override() -> Option<PathBuf> {
+    env::var("FLOO_UPDATE_TARGET_PATH").ok().map(PathBuf::from)
+}
+
+fn install_binary(binary_bytes: &[u8], destination: &Path) -> Result<(), FlooError> {
+    let destination_dir = destination.parent().ok_or_else(|| {
+        FlooError::new(
+            "UPDATE_INSTALL_FAILED",
+            "Failed to determine destination directory.".to_string(),
+        )
+    })?;
+
+    fs::create_dir_all(destination_dir).map_err(|e| {
+        FlooError::new(
+            "UPDATE_INSTALL_FAILED",
+            format!("Failed to prepare destination directory: {e}"),
+        )
+    })?;
+
+    let temp_name = format!(
+        ".{}.tmp-update-{}",
+        destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("floo"),
+        std::process::id()
+    );
+    let temp_path = destination_dir.join(temp_name);
+
+    fs::write(&temp_path, binary_bytes).map_err(|e| {
+        FlooError::new(
+            "UPDATE_INSTALL_FAILED",
+            format!("Failed to write update file: {e}"),
+        )
+    })?;
+    set_executable(&temp_path)?;
+
+    fs::rename(&temp_path, destination).map_err(|e| {
+        let _ = fs::remove_file(&temp_path);
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            FlooError::with_suggestion(
+                "UPDATE_PERMISSION_DENIED",
+                format!("Permission denied while writing to '{}'.", destination.display()),
+                "Re-run with appropriate permissions, or reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+            )
+        } else {
+            FlooError::new(
+                "UPDATE_INSTALL_FAILED",
+                format!("Failed to replace existing binary: {e}"),
+            )
+        }
+    })
+}
+
+fn run_update_with(
+    client: &Client,
+    version: Option<&str>,
+    api_base: &str,
+    install_path: &Path,
+) -> Result<UpdateResult, FlooError> {
+    let asset_name = target_asset_name()?;
+    let release_json = fetch_release_json(client, api_base, version)?;
+    let release_asset = release_asset_from_json(&release_json, &asset_name)?;
+
+    let binary_bytes = download_bytes(client, &release_asset.binary_url)?;
+    let checksum_bytes = download_bytes(client, &release_asset.checksum_url)?;
+    let expected_checksum = parse_checksum(&String::from_utf8_lossy(&checksum_bytes))?;
+    let actual_checksum = sha256_hex(&binary_bytes);
+
+    if actual_checksum != expected_checksum {
+        return Err(FlooError::with_suggestion(
+            "CHECKSUM_MISMATCH",
+            format!(
+                "Checksum mismatch for '{}': expected {}, got {}.",
+                release_asset.asset_name, expected_checksum, actual_checksum
+            ),
+            "Do not run this binary. Retry update later or reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+        ));
+    }
+
+    install_binary(&binary_bytes, install_path)?;
+
+    Ok(UpdateResult {
+        version: release_asset.version,
+        install_path: install_path.to_path_buf(),
+    })
+}
+
+pub fn run_update(version: Option<&str>) -> Result<UpdateResult, FlooError> {
+    let client = build_http_client()?;
+    let api_base = releases_api_base();
+    let install_path = install_path_override().unwrap_or_else(|| {
+        env::current_exe().unwrap_or_else(|_| {
+            if cfg!(windows) {
+                PathBuf::from("floo.exe")
+            } else {
+                PathBuf::from("floo")
+            }
+        })
+    });
+
+    run_update_with(&client, version, &api_base, &install_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::{Matcher, Server};
+
+    fn sample_release_json(asset_name: &str, base_url: &str) -> Value {
+        serde_json::json!({
+            "tag_name": "v0.2.0",
+            "assets": [
+                {
+                    "name": asset_name,
+                    "browser_download_url": format!("{base_url}/download/{asset_name}"),
+                },
+                {
+                    "name": format!("{asset_name}.sha256"),
+                    "browser_download_url": format!("{base_url}/download/{asset_name}.sha256"),
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn test_parse_checksum_ok() {
+        let value = parse_checksum(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  floo-x86_64-unknown-linux-musl",
+        )
+        .unwrap();
+        assert_eq!(value.len(), 64);
+    }
+
+    #[test]
+    fn test_parse_checksum_invalid() {
+        let result = parse_checksum("not-a-checksum");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, "CHECKSUM_PARSE_ERROR");
+    }
+
+    #[test]
+    fn test_run_update_with_mock_server_success() {
+        let asset_name = target_asset_name().unwrap();
+        let binary_bytes = b"fake-binary-content";
+        let checksum = sha256_hex(binary_bytes);
+
+        let mut server = Server::new();
+        let release = sample_release_json(&asset_name, &server.url());
+
+        let _release_mock = server
+            .mock("GET", "/releases/latest")
+            .match_header("user-agent", "floo-cli-updater")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(release.to_string())
+            .create();
+
+        let _binary_mock = server
+            .mock("GET", format!("/download/{asset_name}").as_str())
+            .match_header("user-agent", "floo-cli-updater")
+            .with_status(200)
+            .with_body(binary_bytes.as_slice())
+            .create();
+
+        let _checksum_mock = server
+            .mock("GET", format!("/download/{asset_name}.sha256").as_str())
+            .match_header("user-agent", "floo-cli-updater")
+            .with_status(200)
+            .with_body(format!("{checksum}  {asset_name}"))
+            .create();
+
+        let client = build_http_client().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let install_path = temp_dir.path().join("floo");
+
+        let result = run_update_with(
+            &client,
+            None,
+            &format!("{}/releases", server.url()),
+            &install_path,
+        )
+        .unwrap();
+
+        assert_eq!(result.version, "v0.2.0");
+        assert_eq!(result.install_path, install_path);
+        assert!(install_path.exists());
+        assert_eq!(fs::read(install_path).unwrap(), binary_bytes.as_slice());
+    }
+
+    #[test]
+    fn test_run_update_with_checksum_mismatch() {
+        let asset_name = target_asset_name().unwrap();
+        let binary_bytes = b"fake-binary-content";
+        let wrong_checksum = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        let mut server = Server::new();
+        let release = sample_release_json(&asset_name, &server.url());
+
+        let _release_mock = server
+            .mock("GET", "/releases/latest")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(release.to_string())
+            .create();
+
+        let _binary_mock = server
+            .mock("GET", format!("/download/{asset_name}").as_str())
+            .with_status(200)
+            .with_body(binary_bytes.as_slice())
+            .create();
+
+        let _checksum_mock = server
+            .mock("GET", format!("/download/{asset_name}.sha256").as_str())
+            .with_status(200)
+            .with_body(format!("{wrong_checksum}  {asset_name}"))
+            .create();
+
+        let client = build_http_client().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let install_path = temp_dir.path().join("floo");
+
+        let result = run_update_with(
+            &client,
+            None,
+            &format!("{}/releases", server.url()),
+            &install_path,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, "CHECKSUM_MISMATCH");
+        assert!(!install_path.exists());
+    }
+
+    #[test]
+    fn test_release_lookup_404() {
+        let mut server = Server::new();
+        let _release_mock = server
+            .mock("GET", "/releases/tags/v9.9.9")
+            .match_query(Matcher::Any)
+            .with_status(404)
+            .with_body("not found")
+            .create();
+
+        let client = build_http_client().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let install_path = temp_dir.path().join("floo");
+
+        let result = run_update_with(
+            &client,
+            Some("v9.9.9"),
+            &format!("{}/releases", server.url()),
+            &install_path,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, "RELEASE_LOOKUP_FAILED");
+    }
+}

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, USER_AGENT};
@@ -59,7 +60,11 @@ fn build_release_url(api_base: &str, version: Option<&str>) -> String {
 }
 
 fn build_http_client() -> Result<Client, FlooError> {
-    Client::builder().build().map_err(|e| {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| {
         FlooError::with_suggestion(
             "UPDATE_HTTP_CLIENT_ERROR",
             format!("Failed to initialize update client: {e}"),
@@ -242,6 +247,20 @@ fn install_path_override() -> Option<PathBuf> {
     env::var("FLOO_UPDATE_TARGET_PATH").ok().map(PathBuf::from)
 }
 
+fn resolve_install_path() -> Result<PathBuf, FlooError> {
+    if let Some(path) = install_path_override() {
+        return Ok(path);
+    }
+
+    env::current_exe().map_err(|e| {
+        FlooError::with_suggestion(
+            "UPDATE_INSTALL_PATH_UNRESOLVED",
+            format!("Failed to determine installed CLI path: {e}"),
+            "Set FLOO_UPDATE_TARGET_PATH to the floo binary path or reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+        )
+    })
+}
+
 fn install_binary(binary_bytes: &[u8], destination: &Path) -> Result<(), FlooError> {
     let destination_dir = destination.parent().ok_or_else(|| {
         FlooError::new(
@@ -329,15 +348,7 @@ fn run_update_with(
 pub fn run_update(version: Option<&str>) -> Result<UpdateResult, FlooError> {
     let client = build_http_client()?;
     let api_base = releases_api_base();
-    let install_path = install_path_override().unwrap_or_else(|| {
-        env::current_exe().unwrap_or_else(|_| {
-            if cfg!(windows) {
-                PathBuf::from("floo.exe")
-            } else {
-                PathBuf::from("floo")
-            }
-        })
-    });
+    let install_path = resolve_install_path()?;
 
     run_update_with(&client, version, &api_base, &install_path)
 }
@@ -346,6 +357,9 @@ pub fn run_update(version: Option<&str>) -> Result<UpdateResult, FlooError> {
 mod tests {
     use super::*;
     use mockito::{Matcher, Server};
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
     fn sample_release_json(asset_name: &str, base_url: &str) -> Value {
         serde_json::json!({
@@ -495,5 +509,35 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code, "RELEASE_LOOKUP_FAILED");
+    }
+
+    #[test]
+    fn test_resolve_install_path_override() {
+        let _guard = ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let old_value = env::var("FLOO_UPDATE_TARGET_PATH").ok();
+        env::set_var("FLOO_UPDATE_TARGET_PATH", "/tmp/floo-test-path");
+
+        let resolved = resolve_install_path().unwrap();
+        assert_eq!(resolved, PathBuf::from("/tmp/floo-test-path"));
+
+        if let Some(value) = old_value {
+            env::set_var("FLOO_UPDATE_TARGET_PATH", value);
+        } else {
+            env::remove_var("FLOO_UPDATE_TARGET_PATH");
+        }
+    }
+
+    #[test]
+    fn test_resolve_install_path_uses_current_exe_path() {
+        let _guard = ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let old_value = env::var("FLOO_UPDATE_TARGET_PATH").ok();
+        env::remove_var("FLOO_UPDATE_TARGET_PATH");
+
+        let resolved = resolve_install_path().unwrap();
+        assert!(resolved.is_absolute());
+
+        if let Some(value) = old_value {
+            env::set_var("FLOO_UPDATE_TARGET_PATH", value);
+        }
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -29,6 +29,25 @@ fn test_version() {
 }
 
 #[test]
+fn test_version_command_human() {
+    floo()
+        .arg("version")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("floo 0.1.0"));
+}
+
+#[test]
+fn test_version_command_json() {
+    floo()
+        .args(["--json", "version"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""version":"0.1.0""#));
+}
+
+#[test]
 fn test_no_args_shows_help() {
     floo()
         .assert()
@@ -136,6 +155,15 @@ fn test_deploy_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Deploy a project to Floo"));
+}
+
+#[test]
+fn test_update_help() {
+    floo()
+        .args(["update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Update the CLI binary in-place"));
 }
 
 // --- Deploy (unauthenticated) ---

--- a/tests/install_script_e2e.sh
+++ b/tests/install_script_e2e.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALLER="${REPO_ROOT}/install.sh"
+TMP_DIR=""
+
+fail() {
+    echo "[fail] $*" >&2
+    exit 1
+}
+
+sha256_file() {
+    local file="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print tolower($1)}'
+        return
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print tolower($1)}'
+        return
+    fi
+    if command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$file" | awk '{print tolower($NF)}'
+        return
+    fi
+    fail "No SHA256 tool available for tests"
+}
+
+detect_target() {
+    local os
+    os="$(uname -s)"
+    local arch
+    arch="$(uname -m)"
+
+    case "$os" in
+        Darwin) os="apple-darwin" ;;
+        Linux) os="unknown-linux-musl" ;;
+        *) fail "Unsupported OS for e2e test: ${os}" ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64) arch="x86_64" ;;
+        arm64|aarch64) arch="aarch64" ;;
+        *) fail "Unsupported architecture for e2e test: ${arch}" ;;
+    esac
+
+    echo "${arch}-${os}"
+}
+
+cleanup() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+main() {
+    cd "$REPO_ROOT"
+
+    local target
+    target="$(detect_target)"
+    local asset_name="floo-${target}"
+    local binary_source="${FLOO_E2E_BINARY:-${REPO_ROOT}/target/debug/floo}"
+
+    if [[ ! -x "$binary_source" ]]; then
+        cargo build >/dev/null
+    fi
+
+    [[ -x "$binary_source" ]] || fail "Could not find executable floo binary for e2e test"
+
+    TMP_DIR="$(mktemp -d)"
+    trap cleanup EXIT
+
+    local asset_path="${TMP_DIR}/${asset_name}"
+    local checksum_path="${asset_path}.sha256"
+    local install_dir="${TMP_DIR}/install"
+
+    cp "$binary_source" "$asset_path"
+    chmod +x "$asset_path"
+
+    local checksum
+    checksum="$(sha256_file "$asset_path")"
+    echo "${checksum}  ${asset_name}" >"$checksum_path"
+
+    FLOO_INSTALL_BINARY_URL="file://${asset_path}" \
+    FLOO_INSTALL_CHECKSUM_URL="file://${checksum_path}" \
+    FLOO_INSTALL_DIR="$install_dir" \
+    bash "$INSTALLER" >/dev/null
+
+    [[ -x "${install_dir}/floo" ]] || fail "Installed binary missing"
+
+    "${install_dir}/floo" --help | grep -q "Deploy, manage, and observe web apps." \
+        || fail "Installed binary failed help output check"
+
+    echo "[pass] install_script_e2e"
+}
+
+main "$@"

--- a/tests/install_script_test.sh
+++ b/tests/install_script_test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALLER="${REPO_ROOT}/install.sh"
+
+pass() {
+    echo "[pass] $*"
+}
+
+fail() {
+    echo "[fail] $*" >&2
+    exit 1
+}
+
+sha256_file() {
+    local file="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print tolower($1)}'
+        return
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print tolower($1)}'
+        return
+    fi
+    if command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$file" | awk '{print tolower($NF)}'
+        return
+    fi
+    fail "No SHA256 tool available for tests"
+}
+
+make_mock_uname() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat >"${dir}/uname" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -s) echo "${MOCK_UNAME_S:-Linux}" ;;
+    -m) echo "${MOCK_UNAME_M:-x86_64}" ;;
+    *) /usr/bin/uname "$@" ;;
+esac
+SH
+    chmod +x "${dir}/uname"
+}
+
+run_installer_expect_success() {
+    local name="$1"
+    local mock_os="$2"
+    local mock_arch="$3"
+    local binary_url="$4"
+    local checksum_url="$5"
+
+    local tmp
+    tmp="$(mktemp -d)"
+    local install_dir="${tmp}/bin"
+    local mock_dir="${tmp}/mockbin"
+    local log_path="${tmp}/run.log"
+
+    make_mock_uname "$mock_dir"
+
+    if ! env \
+        MOCK_UNAME_S="$mock_os" \
+        MOCK_UNAME_M="$mock_arch" \
+        PATH="${mock_dir}:${PATH}" \
+        FLOO_INSTALL_BINARY_URL="$binary_url" \
+        FLOO_INSTALL_CHECKSUM_URL="$checksum_url" \
+        FLOO_INSTALL_DIR="$install_dir" \
+        bash "$INSTALLER" >"$log_path" 2>&1; then
+        cat "$log_path" >&2
+        fail "${name}: installer failed unexpectedly"
+    fi
+
+    [[ -x "${install_dir}/floo" ]] || fail "${name}: installed binary missing"
+    "${install_dir}/floo" --version >/dev/null 2>&1 || fail "${name}: installed binary not executable"
+
+    pass "${name}"
+    rm -rf "$tmp"
+}
+
+run_installer_expect_failure() {
+    local name="$1"
+    local mock_os="$2"
+    local mock_arch="$3"
+    local binary_url="$4"
+    local checksum_url="$5"
+    local expected_text="$6"
+
+    local tmp
+    tmp="$(mktemp -d)"
+    local install_dir="${tmp}/bin"
+    local mock_dir="${tmp}/mockbin"
+    local log_path="${tmp}/run.log"
+
+    make_mock_uname "$mock_dir"
+
+    if env \
+        MOCK_UNAME_S="$mock_os" \
+        MOCK_UNAME_M="$mock_arch" \
+        PATH="${mock_dir}:${PATH}" \
+        FLOO_INSTALL_BINARY_URL="$binary_url" \
+        FLOO_INSTALL_CHECKSUM_URL="$checksum_url" \
+        FLOO_INSTALL_DIR="$install_dir" \
+        bash "$INSTALLER" >"$log_path" 2>&1; then
+        cat "$log_path" >&2
+        fail "${name}: installer succeeded unexpectedly"
+    fi
+
+    grep -q "$expected_text" "$log_path" || {
+        cat "$log_path" >&2
+        fail "${name}: expected error text not found: ${expected_text}"
+    }
+
+    pass "${name}"
+    rm -rf "$tmp"
+}
+
+main() {
+    local fixture_dir
+    fixture_dir="$(mktemp -d)"
+
+    local asset="${fixture_dir}/floo-x86_64-unknown-linux-musl"
+    cat >"$asset" <<'SH'
+#!/usr/bin/env bash
+echo "floo test-0.0.0"
+SH
+    chmod +x "$asset"
+
+    local checksum
+    checksum="$(sha256_file "$asset")"
+    local checksum_file="${asset}.sha256"
+    echo "${checksum}  $(basename "$asset")" >"$checksum_file"
+
+    local bad_checksum_file="${asset}.bad.sha256"
+    echo "0000000000000000000000000000000000000000000000000000000000000000  $(basename "$asset")" >"$bad_checksum_file"
+
+    run_installer_expect_success \
+        "linux x86_64 success" \
+        "Linux" \
+        "x86_64" \
+        "file://${asset}" \
+        "file://${checksum_file}"
+
+    run_installer_expect_failure \
+        "unsupported os" \
+        "FreeBSD" \
+        "x86_64" \
+        "file://${asset}" \
+        "file://${checksum_file}" \
+        "Unsupported operating system"
+
+    run_installer_expect_failure \
+        "unsupported arch" \
+        "Linux" \
+        "mips64" \
+        "file://${asset}" \
+        "file://${checksum_file}" \
+        "Unsupported architecture"
+
+    run_installer_expect_failure \
+        "checksum mismatch" \
+        "Linux" \
+        "x86_64" \
+        "file://${asset}" \
+        "file://${bad_checksum_file}" \
+        "Checksum mismatch"
+
+    rm -rf "$fixture_dir"
+    pass "install_script_test suite"
+}
+
+main "$@"

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use mockito::{Matcher, Mock, Server};
 use predicates::prelude::*;
+use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
 const TEST_APP_ID: &str = "app-uuid-1234";
@@ -31,6 +32,24 @@ fn app_json() -> String {
     format!(
         r#"{{"id":"{TEST_APP_ID}","name":"{TEST_APP_NAME}","status":"live","url":"https://test.floo.app","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z"}}"#
     )
+}
+
+fn update_asset_name() -> Option<String> {
+    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "x86_64") => "x86_64-apple-darwin",
+        ("macos", "aarch64") => "aarch64-apple-darwin",
+        ("linux", "x86_64") => "x86_64-unknown-linux-musl",
+        ("linux", "aarch64") => "aarch64-unknown-linux-musl",
+        ("windows", "x86_64") => "x86_64-pc-windows-msvc.exe",
+        _ => return None,
+    };
+    Some(format!("floo-{target}"))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
 }
 
 /// Mock resolve_app (name-based): UUID lookup -> 404, list -> found.
@@ -542,4 +561,91 @@ fn test_app_not_found_json() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("APP_NOT_FOUND"));
+}
+
+// ───────────────────────── Update ─────────────────────────
+
+#[test]
+fn test_update_json_release_lookup_failure() {
+    let mut server = Server::new();
+    let _m_release = server
+        .mock("GET", "/releases/latest")
+        .with_status(404)
+        .with_body("not found")
+        .create();
+
+    let install_dir = TempDir::new().unwrap();
+    let install_path = install_dir.path().join("floo");
+
+    floo()
+        .args(["--json", "update"])
+        .env("FLOO_UPDATE_API_BASE", format!("{}/releases", server.url()))
+        .env("FLOO_UPDATE_TARGET_PATH", install_path.as_os_str())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"RELEASE_LOOKUP_FAILED""#,
+        ));
+}
+
+#[test]
+fn test_update_json_success() {
+    let Some(asset_name) = update_asset_name() else {
+        return;
+    };
+
+    let binary_bytes = b"#!/usr/bin/env bash\necho floo v0.2.0\n";
+    let checksum = sha256_hex(binary_bytes);
+
+    let mut server = Server::new();
+    let _m_release = server
+        .mock("GET", "/releases/latest")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "tag_name": "v0.2.0",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": format!("{}/downloads/{}", server.url(), asset_name),
+                    },
+                    {
+                        "name": format!("{asset_name}.sha256"),
+                        "browser_download_url": format!("{}/downloads/{}.sha256", server.url(), asset_name),
+                    }
+                ],
+            })
+            .to_string(),
+        )
+        .create();
+
+    let _m_binary = server
+        .mock("GET", format!("/downloads/{asset_name}").as_str())
+        .with_status(200)
+        .with_body(binary_bytes.as_slice())
+        .create();
+
+    let _m_checksum = server
+        .mock("GET", format!("/downloads/{asset_name}.sha256").as_str())
+        .with_status(200)
+        .with_body(format!("{checksum}  {asset_name}"))
+        .create();
+
+    let install_dir = TempDir::new().unwrap();
+    let install_path = install_dir.path().join("floo");
+
+    floo()
+        .args(["--json", "update"])
+        .env("FLOO_UPDATE_API_BASE", format!("{}/releases", server.url()))
+        .env("FLOO_UPDATE_TARGET_PATH", install_path.as_os_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""version":"v0.2.0""#));
+
+    assert_eq!(
+        std::fs::read(install_path).unwrap(),
+        binary_bytes.as_slice()
+    );
 }


### PR DESCRIPTION
## Summary
- harden `install.sh` for `curl -fsSL https://getfloo.com/install.sh | bash` with strict checksum verification and better permission handling
- add `floo version` and `floo update --version <tag>` with release resolution, checksum validation, and in-place binary replacement
- add installer validation coverage (mocked shell tests + local installer E2E), plus CI/release workflow updates

## Review follow-up fixes
- add updater HTTP timeouts to avoid indefinite hangs
- remove unsafe relative-path fallback for update destination and return structured error instead
- ensure installer sudo path creates target install dir before move
- run CI automatically on `pull_request` and `push` to `main`

## Test plan
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `bash tests/install_script_test.sh`
- `bash tests/install_script_e2e.sh`

## Notes
- Homebrew tap automation is deferred and tracked separately.
