### PR TITLE
[Bug] [#46] Fix resolve_app error propagation

### DIFF
--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -82,13 +82,17 @@ pub fn status(app_name: &str) {
     require_auth();
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };
@@ -132,13 +136,17 @@ pub fn delete(app_name: &str, force: bool) {
     require_auth();
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -21,13 +21,17 @@ pub fn add(hostname: &str, app_name: &str) {
     require_auth();
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };
@@ -65,13 +69,17 @@ pub fn list(app_name: &str) {
     require_auth();
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };
@@ -141,13 +149,17 @@ pub fn remove(hostname: &str, app_name: &str) {
     require_auth();
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -34,13 +34,17 @@ pub fn set(key_value: &str, app_name: &str) {
 
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };
@@ -66,13 +70,17 @@ pub fn list(app_name: &str) {
     require_auth();
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };
@@ -140,13 +148,17 @@ pub fn remove(key: &str, app_name: &str) {
 
     let client = FlooClient::new(None);
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -51,13 +51,17 @@ pub fn logs(
     let client = FlooClient::new(None);
 
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -22,13 +22,17 @@ pub fn list(app_name: &str) {
     let client = FlooClient::new(None);
 
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };
@@ -113,13 +117,17 @@ pub fn rollback(app_name: &str, deploy_id: &str, force: bool) {
     let client = FlooClient::new(None);
 
     let app_data = match resolve_app(&client, app_name) {
-        Some(a) => a,
-        None => {
-            output::error(
-                &format!("App '{app_name}' not found."),
-                "APP_NOT_FOUND",
-                Some("Check the app name or ID and try again."),
-            );
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
             process::exit(1);
         }
     };

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -41,29 +41,49 @@ fn is_uuid_identifier(identifier: &str) -> bool {
     true
 }
 
-fn resolve_app_with_client<C: AppResolverClient>(client: &C, identifier: &str) -> Option<Value> {
+fn match_app_from_list_response(
+    list_response: &Value,
+    identifier: &str,
+) -> Result<Value, FlooApiError> {
+    let apps = list_response
+        .get("apps")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| {
+            FlooApiError::new(
+                500,
+                "PARSE_ERROR",
+                "Failed to parse app list response from API.",
+            )
+        })?;
+
+    for app in apps {
+        if app.get("name").and_then(|value| value.as_str()) == Some(identifier) {
+            return Ok(app.clone());
+        }
+    }
+
+    Err(FlooApiError::new(404, "APP_NOT_FOUND", "App not found."))
+}
+
+fn resolve_app_with_client<C: AppResolverClient>(
+    client: &C,
+    identifier: &str,
+) -> Result<Value, FlooApiError> {
     // Only hit the /apps/{id} endpoint for UUID identifiers.
     if is_uuid_identifier(identifier) {
-        if let Ok(app) = client.get_app(identifier) {
-            return Some(app);
+        match client.get_app(identifier) {
+            Ok(app) => return Ok(app),
+            Err(error) if error.status_code == 404 => {}
+            Err(error) => return Err(error),
         }
     }
 
     // Fall back to name match via list.
-    if let Ok(resp) = client.list_apps(1, 100) {
-        if let Some(apps) = resp.get("apps").and_then(|v| v.as_array()) {
-            for app in apps {
-                if app.get("name").and_then(|v| v.as_str()) == Some(identifier) {
-                    return Some(app.clone());
-                }
-            }
-        }
-    }
-
-    None
+    let response = client.list_apps(1, 100)?;
+    match_app_from_list_response(&response, identifier)
 }
 
-pub fn resolve_app(client: &FlooClient, identifier: &str) -> Option<Value> {
+pub fn resolve_app(client: &FlooClient, identifier: &str) -> Result<Value, FlooApiError> {
     resolve_app_with_client(client, identifier)
 }
 
@@ -76,52 +96,76 @@ mod tests {
     use super::*;
 
     struct FakeClient {
-        app_lookup_success: bool,
-        app_response: Value,
-        list_response: Value,
+        app_lookup_result: Result<Value, (u16, String, String)>,
+        list_lookup_result: Result<Value, (u16, String, String)>,
         app_lookup_calls: RefCell<Vec<String>>,
         list_lookup_calls: Cell<u32>,
     }
 
     impl FakeClient {
-        fn new(app_lookup_success: bool, app_response: Value, list_response: Value) -> Self {
+        fn new(
+            app_lookup_result: Result<Value, (u16, String, String)>,
+            list_lookup_result: Result<Value, (u16, String, String)>,
+        ) -> Self {
             Self {
-                app_lookup_success,
-                app_response,
-                list_response,
+                app_lookup_result,
+                list_lookup_result,
                 app_lookup_calls: RefCell::new(Vec::new()),
                 list_lookup_calls: Cell::new(0),
             }
+        }
+
+        fn ok_app(app: Value) -> Result<Value, (u16, String, String)> {
+            Ok(app)
+        }
+
+        fn err(
+            status_code: u16,
+            code: &str,
+            message: &str,
+        ) -> Result<Value, (u16, String, String)> {
+            Err((status_code, code.to_string(), message.to_string()))
         }
     }
 
     impl AppResolverClient for FakeClient {
         fn get_app(&self, app_id: &str) -> Result<Value, FlooApiError> {
             self.app_lookup_calls.borrow_mut().push(app_id.to_string());
-            if self.app_lookup_success {
-                Ok(self.app_response.clone())
-            } else {
-                Err(FlooApiError::new(404, "APP_NOT_FOUND", "App not found."))
+            match &self.app_lookup_result {
+                Ok(value) => Ok(value.clone()),
+                Err((status_code, code, message)) => Err(FlooApiError::new(
+                    *status_code,
+                    code.clone(),
+                    message.clone(),
+                )),
             }
         }
 
         fn list_apps(&self, _page: u32, _per_page: u32) -> Result<Value, FlooApiError> {
             self.list_lookup_calls.set(self.list_lookup_calls.get() + 1);
-            Ok(self.list_response.clone())
+            match &self.list_lookup_result {
+                Ok(value) => Ok(value.clone()),
+                Err((status_code, code, message)) => Err(FlooApiError::new(
+                    *status_code,
+                    code.clone(),
+                    message.clone(),
+                )),
+            }
         }
     }
 
     #[test]
     fn non_uuid_identifier_skips_id_endpoint_lookup() {
         let client = FakeClient::new(
-            false,
-            json!({"id":"11111111-1111-1111-1111-111111111111","name":"unused"}),
-            json!({"apps":[{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"my-app"}]}),
+            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_app(
+                json!({"apps":[{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"my-app"}]}),
+            ),
         );
 
         let resolved = resolve_app_with_client(&client, "my-app");
 
-        assert!(resolved.is_some());
+        assert!(resolved.is_ok());
         assert!(client.app_lookup_calls.borrow().is_empty());
         assert_eq!(client.list_lookup_calls.get(), 1);
     }
@@ -130,14 +174,15 @@ mod tests {
     fn uuid_identifier_uses_id_endpoint_first() {
         let app_id = "11111111-1111-1111-1111-111111111111";
         let client = FakeClient::new(
-            true,
-            json!({"id":app_id,"name":"uuid-app"}),
-            json!({"apps":[{"id":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","name":"fallback-app"}]}),
+            FakeClient::ok_app(json!({"id":app_id,"name":"uuid-app"})),
+            FakeClient::ok_app(
+                json!({"apps":[{"id":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","name":"fallback-app"}]}),
+            ),
         );
 
         let resolved = resolve_app_with_client(&client, app_id);
 
-        assert!(resolved.is_some());
+        assert!(resolved.is_ok());
         assert_eq!(
             client.app_lookup_calls.borrow().as_slice(),
             &[app_id.to_string()]
@@ -149,18 +194,71 @@ mod tests {
     fn uuid_identifier_falls_back_to_name_lookup_when_id_lookup_fails() {
         let identifier = "22222222-2222-2222-2222-222222222222";
         let client = FakeClient::new(
-            false,
-            json!({"id":"unused","name":"unused"}),
-            json!({"apps":[{"id":identifier,"name":identifier}]}),
+            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":identifier}]})),
         );
 
         let resolved = resolve_app_with_client(&client, identifier);
 
-        assert!(resolved.is_some());
+        assert!(resolved.is_ok());
         assert_eq!(
             client.app_lookup_calls.borrow().as_slice(),
             &[identifier.to_string()]
         );
         assert_eq!(client.list_lookup_calls.get(), 1);
+    }
+
+    #[test]
+    fn uuid_identifier_propagates_non_404_lookup_errors() {
+        let identifier = "33333333-3333-3333-3333-333333333333";
+        let client = FakeClient::new(
+            FakeClient::err(500, "INTERNAL_ERROR", "Server error"),
+            FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":identifier}]})),
+        );
+
+        let error = resolve_app_with_client(&client, identifier).unwrap_err();
+
+        assert_eq!(error.status_code, 500);
+        assert_eq!(error.code, "INTERNAL_ERROR");
+        assert_eq!(client.list_lookup_calls.get(), 0);
+    }
+
+    #[test]
+    fn non_uuid_identifier_propagates_list_errors() {
+        let client = FakeClient::new(
+            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::err(401, "UNAUTHORIZED", "Unauthorized"),
+        );
+
+        let error = resolve_app_with_client(&client, "my-app").unwrap_err();
+
+        assert_eq!(error.status_code, 401);
+        assert_eq!(error.code, "UNAUTHORIZED");
+    }
+
+    #[test]
+    fn returns_app_not_found_when_name_lookup_misses() {
+        let client = FakeClient::new(
+            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_app(json!({"apps":[{"id":"id-1","name":"other-app"}]})),
+        );
+
+        let error = resolve_app_with_client(&client, "my-app").unwrap_err();
+
+        assert_eq!(error.status_code, 404);
+        assert_eq!(error.code, "APP_NOT_FOUND");
+    }
+
+    #[test]
+    fn returns_parse_error_when_list_response_is_malformed() {
+        let client = FakeClient::new(
+            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_app(json!({"unexpected":"payload"})),
+        );
+
+        let error = resolve_app_with_client(&client, "my-app").unwrap_err();
+
+        assert_eq!(error.status_code, 500);
+        assert_eq!(error.code, "PARSE_ERROR");
     }
 }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -563,6 +563,53 @@ fn test_app_not_found_json() {
         .stdout(predicate::str::contains("APP_NOT_FOUND"));
 }
 
+#[test]
+fn test_apps_status_uuid_surfaces_get_app_api_error() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let app_id = "11111111-1111-1111-1111-111111111111";
+
+    let _m_get = server
+        .mock("GET", format!("/v1/apps/{app_id}").as_str())
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"INTERNAL_ERROR","message":"Server error"}}"#)
+        .create();
+
+    floo()
+        .args(["--json", "apps", "status", app_id])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("INTERNAL_ERROR"))
+        .stdout(predicate::str::contains("APP_NOT_FOUND").not());
+}
+
+#[test]
+fn test_apps_status_name_surfaces_list_apps_api_error() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m_list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"INTERNAL_ERROR","message":"Server error"}}"#)
+        .create();
+
+    floo()
+        .args(["--json", "apps", "status", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("INTERNAL_ERROR"))
+        .stdout(predicate::str::contains("APP_NOT_FOUND").not());
+}
+
 // ───────────────────────── Update ─────────────────────────
 
 #[test]


### PR DESCRIPTION
Summary:
- change resolve_app to return Result instead of Option
- only fallback to name lookup when UUID get_app returns 404
- propagate non-404 API errors instead of collapsing to APP_NOT_FOUND
- preserve friendly not-found messaging when resolver returns APP_NOT_FOUND
- add resolver unit tests and integration regressions for swallowed 500s

Verification:
- cargo test
- cargo clippy -- -D warnings
- cargo fmt --check