### PR TITLE
[Feature] [F12.1] Add floo db info command

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -250,6 +250,69 @@ impl FlooClient {
         Ok(())
     }
 
+    // --- Databases ---
+
+    fn parse_database_response(&self, response: &Value) -> Result<Value, FlooApiError> {
+        if response.get("host").is_some()
+            && response.get("port").is_some()
+            && response.get("database").is_some()
+        {
+            return Ok(response.clone());
+        }
+
+        if let Some(database) = response.get("database") {
+            if database.is_object() {
+                return Ok(database.clone());
+            }
+        }
+
+        Err(FlooApiError::new(
+            500,
+            "PARSE_ERROR",
+            "Failed to parse database info response from API.",
+        ))
+    }
+
+    fn parse_database_from_list_response(&self, response: &Value) -> Result<Value, FlooApiError> {
+        let databases = response
+            .get("databases")
+            .and_then(|value| value.as_array())
+            .ok_or_else(|| {
+                FlooApiError::new(
+                    500,
+                    "PARSE_ERROR",
+                    "Failed to parse database list response from API.",
+                )
+            })?;
+
+        let database = databases
+            .iter()
+            .find(|value| value.get("name").and_then(|v| v.as_str()) == Some("default"))
+            .or_else(|| databases.first())
+            .ok_or_else(|| {
+                FlooApiError::new(
+                    404,
+                    "DATABASE_NOT_FOUND",
+                    "Database not found for this app.",
+                )
+            })?;
+
+        Ok(database.clone())
+    }
+
+    pub fn get_database_info(&self, app_id: &str) -> Result<Value, FlooApiError> {
+        let db_info_response = self.get(&format!("/v1/apps/{app_id}/db"))?;
+        match self.handle_response(db_info_response) {
+            Ok(response) => self.parse_database_response(&response),
+            Err(error) if error.status_code == 404 => {
+                let list_response = self.get(&format!("/v1/apps/{app_id}/databases"))?;
+                let list_body = self.handle_response(list_response)?;
+                self.parse_database_from_list_response(&list_body)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     // --- Domains ---
 
     pub fn add_domain(&self, app_id: &str, hostname: &str) -> Result<Value, FlooApiError> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,10 @@ pub enum Commands {
     #[command(subcommand)]
     Env(EnvCommands),
 
+    /// Show database details for an app.
+    #[command(subcommand)]
+    Db(DbCommands),
+
     /// Manage custom domains.
     #[command(subcommand)]
     Domains(DomainsCommands),
@@ -204,6 +208,15 @@ pub enum DomainsCommands {
 }
 
 #[derive(Subcommand)]
+pub enum DbCommands {
+    /// Show database connection details for an app.
+    Info {
+        /// App name or ID.
+        app: String,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum RollbacksCommands {
     /// List deploys available for rollback.
     List {
@@ -235,6 +248,10 @@ pub fn run() {
             EnvCommands::Set { key_value, app } => commands::env::set(&key_value, &app),
             EnvCommands::List { app } => commands::env::list(&app),
             EnvCommands::Remove { key, app } => commands::env::remove(&key, &app),
+        },
+
+        Commands::Db(sub) => match sub {
+            DbCommands::Info { app } => commands::db::info(&app),
         },
 
         Commands::Domains(sub) => match sub {

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -1,0 +1,156 @@
+use std::process;
+
+use serde_json::Value;
+
+use crate::api_client::FlooClient;
+use crate::config::load_config;
+use crate::errors::FlooApiError;
+use crate::output;
+use crate::resolve::resolve_app;
+
+struct DatabaseInfo {
+    host: String,
+    port: u16,
+    database: String,
+    status: String,
+    username: Option<String>,
+    schema_name: Option<String>,
+}
+
+fn require_auth() {
+    let config = load_config();
+    if config.api_key.is_none() {
+        output::error(
+            "Not logged in.",
+            "NOT_AUTHENTICATED",
+            Some("Run 'floo login' to authenticate."),
+        );
+        process::exit(1);
+    }
+}
+
+fn parse_required_string(value: &Value, key: &str) -> Result<String, FlooApiError> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            FlooApiError::new(
+                500,
+                "PARSE_ERROR",
+                "Failed to parse database info response from API.",
+            )
+        })
+}
+
+fn parse_required_port(value: &Value) -> Result<u16, FlooApiError> {
+    let raw_port = value.get("port").and_then(|v| v.as_u64()).ok_or_else(|| {
+        FlooApiError::new(
+            500,
+            "PARSE_ERROR",
+            "Failed to parse database info response from API.",
+        )
+    })?;
+
+    u16::try_from(raw_port).map_err(|_| {
+        FlooApiError::new(
+            500,
+            "PARSE_ERROR",
+            "Failed to parse database info response from API.",
+        )
+    })
+}
+
+fn parse_database_info(value: &Value) -> Result<DatabaseInfo, FlooApiError> {
+    Ok(DatabaseInfo {
+        host: parse_required_string(value, "host")?,
+        port: parse_required_port(value)?,
+        database: parse_required_string(value, "database")?,
+        status: parse_required_string(value, "status")?,
+        username: value
+            .get("username")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        schema_name: value
+            .get("schema_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
+}
+
+pub fn info(app_identifier: &str) {
+    require_auth();
+
+    let client = FlooClient::new(None);
+    let app_data = match resolve_app(&client, app_identifier) {
+        Ok(app) => app,
+        Err(error) => {
+            if error.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_identifier}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&error.message, &error.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = match app_data.get("id").and_then(|v| v.as_str()) {
+        Some(id) if !id.is_empty() => id,
+        _ => {
+            output::error(
+                "Failed to read app ID from API response.",
+                "PARSE_ERROR",
+                Some("This may indicate a CLI/API version mismatch. Try updating the CLI."),
+            );
+            process::exit(1);
+        }
+    };
+    let app_name = app_data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(app_identifier);
+
+    let db_data = match client.get_database_info(app_id) {
+        Ok(db) => db,
+        Err(error) => {
+            output::error(&error.message, &error.code, None);
+            process::exit(1);
+        }
+    };
+
+    let parsed = match parse_database_info(&db_data) {
+        Ok(details) => details,
+        Err(error) => {
+            output::error(
+                &error.message,
+                &error.code,
+                Some("This may indicate a CLI/API version mismatch. Try updating the CLI."),
+            );
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(&format!("Database for {app_name}"), Some(db_data));
+        return;
+    }
+
+    output::info(&format!("Database for {app_name}:"), None);
+    output::info(&format!("  Host:     {}", parsed.host), None);
+    output::info(&format!("  Port:     {}", parsed.port), None);
+    output::info(&format!("  Database: {}", parsed.database), None);
+    output::info(&format!("  Status:   {}", parsed.status), None);
+    if let Some(username) = parsed.username {
+        output::info(&format!("  Username: {username}"), None);
+    }
+    if let Some(schema_name) = parsed.schema_name {
+        output::info(&format!("  Schema:   {schema_name}"), None);
+    }
+    output::info("", None);
+    output::info("DATABASE_URL is injected as an environment variable.", None);
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod apps;
 pub mod auth;
+pub mod db;
 pub mod deploy;
 pub mod domains;
 pub mod env;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -149,6 +149,15 @@ fn test_domains_help() {
 }
 
 #[test]
+fn test_db_help() {
+    floo()
+        .args(["db", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Show database details"));
+}
+
+#[test]
 fn test_deploy_help() {
     floo()
         .args(["deploy", "--help"])
@@ -230,6 +239,28 @@ fn test_domains_list_not_authenticated() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Not logged in."));
+}
+
+// --- Database (unauthenticated) ---
+
+#[test]
+fn test_db_info_not_authenticated() {
+    floo()
+        .args(["db", "info", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
+}
+
+#[test]
+fn test_db_info_json_not_authenticated() {
+    floo()
+        .args(["--json", "db", "info", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
 }
 
 // --- Env format validation ---

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -476,6 +476,131 @@ fn test_logs_human() {
         .stderr(predicate::str::contains("Server started"));
 }
 
+// ───────────────────────── Databases ─────────────────────────
+
+#[test]
+fn test_db_info_json_uses_db_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_db = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/db").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"host":"db.example.internal","port":5432,"database":"floo_apps","status":"READY","username":"floo_user","schema_name":"app_1234"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "db", "info", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("db.example.internal"))
+        .stdout(predicate::str::contains(r#""database":"floo_apps""#));
+}
+
+#[test]
+fn test_db_info_json_falls_back_to_databases_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_db_not_found = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/db").as_str())
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"NOT_FOUND","message":"Not found"}}"#)
+        .create();
+
+    let _m_databases = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/databases").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"databases":[{"id":"db-1","name":"default","host":"fallback-db.internal","port":5432,"database":"floo_apps","status":"READY","username":"floo_user","schema_name":"app_5678"}],"total":1}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "db", "info", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fallback-db.internal"))
+        .stdout(predicate::str::contains(r#""name":"default""#));
+}
+
+#[test]
+fn test_db_info_json_app_not_found() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m_list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"apps":[]}"#)
+        .create();
+
+    floo()
+        .args(["--json", "db", "info", "missing-app"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("APP_NOT_FOUND"));
+}
+
+#[test]
+fn test_db_info_json_surfaces_api_errors() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_db = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/db").as_str())
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"INTERNAL_ERROR","message":"Server error"}}"#)
+        .create();
+
+    floo()
+        .args(["--json", "db", "info", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("INTERNAL_ERROR"))
+        .stdout(predicate::str::contains("APP_NOT_FOUND").not());
+}
+
+#[test]
+fn test_db_info_json_returns_parse_error_for_malformed_payload() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_db = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/db").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"host":"db.example.internal","port":"bad","database":"floo_apps","status":"READY"}"#)
+        .create();
+
+    floo()
+        .args(["--json", "db", "info", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("PARSE_ERROR"));
+}
+
 // ───────────────────────── Deploy ─────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- add `floo db info APP` command with auth + app resolution + human/json output
- add API client `get_database_info()` with compatibility fallback from `/v1/apps/{id}/db` to `/v1/apps/{id}/databases`
- add unit/integration coverage for db info success, fallback, auth, app-not-found, API-error, and parse-error paths

## Changes
- `src/cli.rs`: add `db` command group with `info` subcommand and dispatch
- `src/commands/mod.rs`: export new `db` module
- `src/commands/db.rs`: implement `db info` command behavior and parsing
- `src/api_client.rs`: add database info retrieval and response parsing helpers
- `tests/cli_tests.rs`: add help + unauthenticated db command tests
- `tests/mock_api_tests.rs`: add mock API tests for db info behavior

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

## Discovered issues
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)