### PR TITLE
[Chore] Enforce workspace issue-closure policy in CLI repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+- <1-3 bullet points>
+
+## Issue Closure (Required)
+Closes getfloo/floo-workspace#<issue-number>
+
+If this PR should not close an issue, write `N/A` and explain why in one sentence.
+Do not use bare references like `Closes #123` in this repo.
+
+## Changes
+- <files changed and why>
+
+## Test Plan
+- [ ] <tests run>
+
+## Discovered Issues
+None
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,10 @@ Packs source into `.tar.gz`, respects `.flooignore`. 500MB size limit.
 - No hardcoded API URLs — use config or `FLOO_API_URL` env var
 - Unit tests inline (`#[cfg(test)] mod tests`), integration tests in `tests/`
 - Reset `output::set_json_mode(false)` at the start of every test (global state leaks)
+- Issue tracker source of truth: `getfloo/floo-workspace` (do not leave active issues in `getfloo/floo-cli`)
+- PR closure language is mandatory for issue-driven work:
+  - Use fully-qualified references, e.g. `Closes getfloo/floo-workspace#46`
+  - Do not use bare `Closes #46` in this repo
 
 ## Release Flow
 


### PR DESCRIPTION
## Summary
- Add an explicit workspace issue-tracking policy to this repo's `CLAUDE.md`.
- Add a PR template that requires fully-qualified workspace issue closure syntax.

## Issue Closure (Required)
N/A - maintenance workflow update requested directly; this PR does not implement a single existing issue.

## Changes
- `CLAUDE.md`: require issue source-of-truth in `getfloo/floo-workspace` and require fully-qualified closure references.
- `.github/PULL_REQUEST_TEMPLATE.md`: adds required `Issue Closure` section with `Closes getfloo/floo-workspace#<issue-number>` format.

## Test Plan
- [x] Docs/template-only change (no runtime code changes)

## Discovered Issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)