### PR TITLE
[Bug] [#43] [#45] [#49] CLI: deploy timeout, archive ignores, remove dead code

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-
-use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -98,19 +95,6 @@ impl FlooClient {
             .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
     }
 
-    fn patch_json(
-        &self,
-        path: &str,
-        body: &Value,
-    ) -> Result<reqwest::blocking::Response, FlooApiError> {
-        let mut req = self.client.patch(self.url(path)).json(body);
-        if let Some(auth) = self.auth_header() {
-            req = req.header("Authorization", auth);
-        }
-        req.send()
-            .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
-    }
-
     fn delete(&self, path: &str) -> Result<reqwest::blocking::Response, FlooApiError> {
         let mut req = self.client.delete(self.url(path));
         if let Some(auth) = self.auth_header() {
@@ -121,12 +105,6 @@ impl FlooClient {
     }
 
     // --- Auth ---
-
-    pub fn register(&self, email: &str, password: &str) -> Result<Value, FlooApiError> {
-        let body = serde_json::json!({"email": email, "password": password});
-        let resp = self.post_json("/v1/auth/register", &body)?;
-        self.handle_response(resp)
-    }
 
     pub fn login(&self, email: &str, password: &str) -> Result<Value, FlooApiError> {
         let body = serde_json::json!({"email": email, "password": password});
@@ -154,16 +132,6 @@ impl FlooClient {
 
     pub fn get_app(&self, app_id: &str) -> Result<Value, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}"))?;
-        self.handle_response(resp)
-    }
-
-    pub fn update_app(
-        &self,
-        app_id: &str,
-        fields: &HashMap<String, String>,
-    ) -> Result<Value, FlooApiError> {
-        let body = serde_json::to_value(fields).unwrap_or(Value::Object(Default::default()));
-        let resp = self.patch_json(&format!("/v1/apps/{app_id}"), &body)?;
         self.handle_response(resp)
     }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -16,6 +16,10 @@ const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
     ".env",
     "*.pyc",
     ".DS_Store",
+    "target", // Rust/Maven build output
+    "dist",   // JS/Python distribution output
+    "build",  // Generic build output
+    ".next",  // Next.js build cache
 ];
 
 fn load_flooignore(path: &Path) -> Vec<String> {
@@ -285,5 +289,37 @@ mod tests {
         assert!(matches_pattern("node_modules", "node_modules"));
         assert!(!matches_pattern("app.js", "*.pyc"));
         assert!(matches_pattern(".DS_Store", ".DS_Store"));
+    }
+
+    #[test]
+    fn test_build_dirs_excluded() {
+        let dir = TempDir::new().unwrap();
+
+        for build_dir in &["target", "dist", "build", ".next"] {
+            fs::create_dir(dir.path().join(build_dir)).unwrap();
+            fs::write(dir.path().join(build_dir).join("output.js"), "").unwrap();
+        }
+        fs::write(dir.path().join("app.js"), "").unwrap();
+
+        let archive = create_archive(dir.path()).unwrap();
+        let file = File::open(&archive).unwrap();
+        let dec = flate2::read::GzDecoder::new(file);
+        let mut tar = tar::Archive::new(dec);
+        let names: Vec<String> = tar
+            .entries()
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path().unwrap().to_string_lossy().to_string())
+            .collect();
+
+        assert!(names.contains(&"app.js".to_string()));
+        for build_dir in &["target", "dist", "build", ".next"] {
+            assert!(
+                !names.iter().any(|n| n.starts_with(build_dir)),
+                "{build_dir} should be excluded"
+            );
+        }
+
+        let _ = fs::remove_file(&archive);
     }
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -222,10 +222,21 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         thread::sleep(POLL_INTERVAL);
 
         if poll_start.elapsed() >= POLL_TIMEOUT {
+            let app_id = app_data
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let deploy_id = deploy_data
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
             output::error(
                 "Deploy timed out after 10 minutes",
                 "DEPLOY_TIMEOUT",
-                Some("The deploy may still complete — check status with `floo apps status`"),
+                Some(&format!(
+                    "The deploy may still complete — check status with \
+                     `floo apps status {app_id}` (deploy ID: {deploy_id})"
+                )),
             );
             process::exit(1);
         }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::api_client::FlooClient;
 use crate::archive::create_archive;
@@ -11,6 +11,7 @@ use crate::names::generate_name;
 use crate::output;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
+const POLL_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
 const TERMINAL_STATUSES: &[&str] = &["live", "failed"];
 
 fn status_label(status: &str) -> &str {
@@ -184,6 +185,7 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
     cleanup(&archive_path);
 
     // Poll until terminal status
+    let poll_start = Instant::now();
     let mut last_log_len: usize = 0;
     while !TERMINAL_STATUSES.contains(
         &deploy_data
@@ -212,6 +214,16 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         }
 
         thread::sleep(POLL_INTERVAL);
+
+        if poll_start.elapsed() >= POLL_TIMEOUT {
+            output::error(
+                "Deploy timed out after 10 minutes",
+                "DEPLOY_TIMEOUT",
+                Some("The deploy may still complete — check status with `floo apps status`"),
+            );
+            process::exit(1);
+        }
+
         let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
         let deploy_id = deploy_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
         deploy_data = match client.get_deploy(app_id, deploy_id) {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -106,8 +106,8 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         let spinner = output::Spinner::new("Looking up app...");
         let result = match client.get_app(app_ident) {
             Ok(a) => a,
-            Err(_) => {
-                // Try name match
+            Err(e) if e.status_code == 404 || e.status_code == 0 => {
+                // ID lookup failed (not found or invalid UUID format) — try name match
                 match client.list_apps(1, 20) {
                     Ok(resp) => {
                         let found = resp
@@ -140,6 +140,12 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
                         process::exit(1);
                     }
                 }
+            }
+            Err(e) => {
+                spinner.finish();
+                cleanup(&archive_path);
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
             }
         };
         spinner.finish();


### PR DESCRIPTION
## Summary

- **#43**: Add 10-minute `POLL_TIMEOUT` to deploy polling loop to prevent infinite hangs
- **#45**: Add `target`, `dist`, `build`, `.next` to default archive ignore patterns; excludes Rust/JS/generic build artifacts from upload tarballs
- **#49**: Remove `#![allow(dead_code)]` from `api_client.rs`; delete unused `register()`, `update_app()`, `patch_json()` methods

Closes getfloo/floo-workspace#43
Closes getfloo/floo-workspace#45
Closes getfloo/floo-workspace#49

## Changes

- `src/commands/deploy.rs` — `POLL_TIMEOUT` constant, `Instant::now()` tracking before polling loop, timeout check+exit after each sleep with app ID + deploy ID in the suggestion; fix pre-existing silent failure where non-404/non-connection errors from `get_app` were swallowed and fell through to the name-match path (a 401 would show "App not found" instead of "Not authenticated")
- `src/archive.rs` — 4 new default ignore patterns + `test_build_dirs_excluded` unit test asserting all four are excluded
- `src/api_client.rs` — removed blanket `dead_code` suppression, deleted 3 unused methods and the orphaned `HashMap` import

## Test plan

- [x] `cargo test` — 105 tests pass (43 unit, 36 integration, 26 mock API)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `test_build_dirs_excluded` asserts all 4 new patterns exclude their target directories

## Discovered issues

Pre-existing bugs surfaced by `silent-failure-hunter` during review (filed as separate workspace issues, not in scope for this PR):

- getfloo/floo-workspace#64 — `unwrap_or("")` on app/deploy IDs silently sends requests to malformed URLs
- getfloo/floo-workspace#65 — `FlooClient::new` panics on HTTP client build failure instead of structured error
- getfloo/floo-workspace#66 — `.flooignore` read failure silently drops user's ignore rules (potential secret upload)
- getfloo/floo-workspace#67 — `DEPLOY_FAILED` error has no suggestion and JSON mode omits build logs
- getfloo/floo-workspace#68 — `cleanup()` silently discards `remove_file` errors — orphaned archives accumulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)