### PR TITLE
[Bug] [#46] Remove fallback-based app resolution

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -9,6 +9,7 @@ use crate::config::load_config;
 use crate::detection::detect;
 use crate::names::generate_name;
 use crate::output;
+use crate::resolve::resolve_app;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
@@ -104,47 +105,20 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
     // Resolve or create app
     let app_data = if let Some(ref app_ident) = app {
         let spinner = output::Spinner::new("Looking up app...");
-        let result = match client.get_app(app_ident) {
-            Ok(a) => a,
-            Err(e) if e.status_code == 404 || e.status_code == 0 => {
-                // ID lookup failed (not found or invalid UUID format) — try name match
-                match client.list_apps(1, 20) {
-                    Ok(resp) => {
-                        let found = resp
-                            .get("apps")
-                            .and_then(|v| v.as_array())
-                            .and_then(|apps| {
-                                apps.iter().find(|a| {
-                                    a.get("name").and_then(|v| v.as_str()) == Some(app_ident)
-                                })
-                            })
-                            .cloned();
-                        match found {
-                            Some(a) => a,
-                            None => {
-                                spinner.finish();
-                                cleanup(&archive_path);
-                                output::error(
-                                    &format!("App '{app_ident}' not found."),
-                                    "APP_NOT_FOUND",
-                                    Some("Check the app ID or name and try again."),
-                                );
-                                process::exit(1);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        spinner.finish();
-                        cleanup(&archive_path);
-                        output::error(&e.message, &e.code, None);
-                        process::exit(1);
-                    }
-                }
-            }
-            Err(e) => {
+        let result = match resolve_app(&client, app_ident) {
+            Ok(app_data) => app_data,
+            Err(error) => {
                 spinner.finish();
                 cleanup(&archive_path);
-                output::error(&e.message, &e.code, None);
+                if error.code == "APP_NOT_FOUND" {
+                    output::error(
+                        &format!("App '{app_ident}' not found."),
+                        "APP_NOT_FOUND",
+                        Some("Check the app name or ID and try again."),
+                    );
+                } else {
+                    output::error(&error.message, &error.code, None);
+                }
                 process::exit(1);
             }
         };

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -71,14 +71,10 @@ fn resolve_app_with_client<C: AppResolverClient>(
 ) -> Result<Value, FlooApiError> {
     // Only hit the /apps/{id} endpoint for UUID identifiers.
     if is_uuid_identifier(identifier) {
-        match client.get_app(identifier) {
-            Ok(app) => return Ok(app),
-            Err(error) if error.status_code == 404 => {}
-            Err(error) => return Err(error),
-        }
+        return client.get_app(identifier);
     }
 
-    // Fall back to name match via list.
+    // Name lookup via list for non-UUID identifiers.
     let response = client.list_apps(1, 100)?;
     match_app_from_list_response(&response, identifier)
 }
@@ -191,21 +187,22 @@ mod tests {
     }
 
     #[test]
-    fn uuid_identifier_falls_back_to_name_lookup_when_id_lookup_fails() {
+    fn uuid_identifier_does_not_fall_back_when_id_lookup_fails() {
         let identifier = "22222222-2222-2222-2222-222222222222";
         let client = FakeClient::new(
             FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
             FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":identifier}]})),
         );
 
-        let resolved = resolve_app_with_client(&client, identifier);
+        let error = resolve_app_with_client(&client, identifier).unwrap_err();
 
-        assert!(resolved.is_ok());
+        assert_eq!(error.status_code, 404);
+        assert_eq!(error.code, "APP_NOT_FOUND");
         assert_eq!(
             client.app_lookup_calls.borrow().as_slice(),
             &[identifier.to_string()]
         );
-        assert_eq!(client.list_lookup_calls.get(), 1);
+        assert_eq!(client.list_lookup_calls.get(), 0);
     }
 
     #[test]
@@ -220,6 +217,21 @@ mod tests {
 
         assert_eq!(error.status_code, 500);
         assert_eq!(error.code, "INTERNAL_ERROR");
+        assert_eq!(client.list_lookup_calls.get(), 0);
+    }
+
+    #[test]
+    fn uuid_identifier_propagates_validation_errors_without_fallback() {
+        let identifier = "44444444-4444-4444-4444-444444444444";
+        let client = FakeClient::new(
+            FakeClient::err(422, "VALIDATION_ERROR", "Invalid UUID"),
+            FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":"uuid-app"}]})),
+        );
+
+        let error = resolve_app_with_client(&client, identifier).unwrap_err();
+
+        assert_eq!(error.status_code, 422);
+        assert_eq!(error.code, "VALIDATION_ERROR");
         assert_eq!(client.list_lookup_calls.get(), 0);
     }
 

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -52,15 +52,9 @@ fn sha256_hex(bytes: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-/// Mock resolve_app (name-based): UUID lookup -> 404, list -> found.
+/// Mock resolve_app (name-based): list -> found.
 fn mock_resolve_app(server: &mut Server) -> Vec<Mock> {
-    let m1 = server
-        .mock("GET", format!("/v1/apps/{TEST_APP_NAME}").as_str())
-        .with_status(404)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{"detail":{"code":"NOT_FOUND","message":"Not found"}}"#)
-        .create();
-    let m2 = server
+    let m = server
         .mock("GET", "/v1/apps")
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
@@ -70,7 +64,7 @@ fn mock_resolve_app(server: &mut Server) -> Vec<Mock> {
         .with_header("content-type", "application/json")
         .with_body(format!(r#"{{"apps":[{app}]}}"#, app = app_json()))
         .create();
-    vec![m1, m2]
+    vec![m]
 }
 
 // ───────────────────────── Apps ─────────────────────────
@@ -653,6 +647,59 @@ fn test_deploy_new_app_json() {
         .stdout(predicate::str::contains(r#""app""#))
         .stdout(predicate::str::contains(r#""deploy""#))
         .stdout(predicate::str::contains(r#""detection""#));
+}
+
+#[test]
+fn test_deploy_existing_app_by_name_json() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    // Create a temp project with package.json for detection
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let _m_list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"apps":[{app}]}}"#, app = app_json()))
+        .create();
+
+    // Return status "live" immediately to skip the polling loop
+    let _m_deploy = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"deploy-001","status":"live","url":"https://{TEST_APP_NAME}.floo.app","build_logs":""}}"#
+        ))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploy",
+            project.path().to_str().unwrap(),
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""id":"app-uuid-1234""#))
+        .stdout(predicate::str::contains(r#""deploy""#));
 }
 
 // ───────────────────────── App Not Found ─────────────────────────


### PR DESCRIPTION
## Summary
- Remove fallback behavior from app resolution so identifier handling is deterministic.
- Use shared `resolve_app` in deploy instead of bespoke fallback logic.
- Add regression coverage for deploy-by-name and strict UUID error propagation.

Closes #46

## Changes
- `src/resolve.rs`: UUID identifiers now resolve only via `GET /v1/apps/{id}`; non-UUID identifiers resolve only via app list name lookup.
- `src/commands/deploy.rs`: replace inline `get_app` + fallback logic with shared `resolve_app`.
- `tests/mock_api_tests.rs`: update resolver mock for no-fallback behavior and add `deploy --app <name>` regression test.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

## Discovered issues
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)