### PR TITLE
[Bug] [#64-68] CLI error handling — unwrap_or, panics, silent discards

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -14,18 +14,24 @@ pub struct FlooClient {
 }
 
 impl FlooClient {
-    pub fn new(config: Option<FlooConfig>) -> Self {
+    pub fn new(config: Option<FlooConfig>) -> Result<Self, FlooApiError> {
         let config = config.unwrap_or_else(load_config);
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
-            .expect("failed to build HTTP client");
+            .map_err(|e| {
+                FlooApiError::new(
+                    0,
+                    "CLIENT_INIT_FAILED",
+                    format!("Failed to initialize HTTP client: {e}"),
+                )
+            })?;
 
-        Self {
+        Ok(Self {
             client,
             base_url: config.api_url.clone(),
             api_key: config.api_key.clone(),
-        }
+        })
     }
 
     fn url(&self, path: &str) -> String {

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -22,20 +22,24 @@ const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
     ".next",  // Next.js build cache
 ];
 
-fn load_flooignore(path: &Path) -> Vec<String> {
+fn load_flooignore(path: &Path) -> Result<Vec<String>, FlooError> {
     let ignore_file = path.join(".flooignore");
     if !ignore_file.exists() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    match fs::read_to_string(&ignore_file) {
-        Ok(content) => content
-            .lines()
-            .map(|l| l.trim())
-            .filter(|l| !l.is_empty() && !l.starts_with('#'))
-            .map(|l| l.to_string())
-            .collect(),
-        Err(_) => Vec::new(),
-    }
+    let content = fs::read_to_string(&ignore_file).map_err(|e| {
+        FlooError::with_suggestion(
+            "FLOOIGNORE_READ_FAILED",
+            format!("Failed to read {}: {e}", ignore_file.display()),
+            "Fix .flooignore permissions or symlink target and try again.",
+        )
+    })?;
+    Ok(content
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|l| l.to_string())
+        .collect())
 }
 
 fn matches_pattern(name: &str, pattern: &str) -> bool {
@@ -85,7 +89,7 @@ pub fn create_archive(path: &Path) -> Result<PathBuf, FlooError> {
         .iter()
         .map(|s| s.to_string())
         .collect();
-    patterns.extend(load_flooignore(path));
+    patterns.extend(load_flooignore(path)?);
 
     let tmp = std::env::temp_dir().join(format!(
         "floo-{}-{}.tar.gz",
@@ -162,6 +166,8 @@ fn add_dir_to_tar<W: std::io::Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
 
     #[test]
@@ -258,6 +264,25 @@ mod tests {
         assert!(!names.iter().any(|n| n.contains("build")));
 
         let _ = fs::remove_file(&archive);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_unreadable_flooignore_fails() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("app.js"), "").unwrap();
+        let ignore_path = dir.path().join(".flooignore");
+        fs::write(&ignore_path, "*.log\n").unwrap();
+
+        let original_mode = fs::metadata(&ignore_path).unwrap().permissions().mode();
+        fs::set_permissions(&ignore_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = create_archive(dir.path());
+
+        fs::set_permissions(&ignore_path, fs::Permissions::from_mode(original_mode)).unwrap();
+        let error = result.unwrap_err();
+        assert_eq!(error.code, "FLOOIGNORE_READ_FAILED");
+        assert!(error.message.contains(".flooignore"));
     }
 
     #[test]

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -1,6 +1,5 @@
 use std::process;
 
-use crate::api_client::FlooClient;
 use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
@@ -19,7 +18,7 @@ fn require_auth() {
 
 pub fn list() {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let result = match client.list_apps(1, 20) {
         Ok(r) => r,
         Err(e) => {
@@ -80,7 +79,7 @@ pub fn list() {
 
 pub fn status(app_name: &str) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {
@@ -134,7 +133,7 @@ pub fn status(app_name: &str) {
 
 pub fn delete(app_name: &str, force: bool) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -2,7 +2,6 @@ use std::process;
 
 use dialoguer::{Input, Password};
 
-use crate::api_client::FlooClient;
 use crate::config::{clear_config, load_config, save_config};
 use crate::output;
 
@@ -22,7 +21,7 @@ pub fn login(email: Option<String>, password: Option<String>) {
     });
 
     let spinner = output::Spinner::new("Logging in...");
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     match client.login(&email, &password) {
         Ok(result) => {
             spinner.finish();

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -2,7 +2,6 @@ use std::process;
 
 use serde_json::Value;
 
-use crate::api_client::FlooClient;
 use crate::config::load_config;
 use crate::errors::FlooApiError;
 use crate::output;
@@ -82,7 +81,7 @@ fn parse_database_info(value: &Value) -> Result<DatabaseInfo, FlooApiError> {
 pub fn info(app_identifier: &str) {
     require_auth();
 
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_identifier) {
         Ok(app) => app,
         Err(error) => {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -3,7 +3,6 @@ use std::process;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::api_client::FlooClient;
 use crate::archive::create_archive;
 use crate::config::load_config;
 use crate::detection::detect;
@@ -21,6 +20,20 @@ fn status_label(status: &str) -> &str {
         "building" => "Building...",
         "deploying" => "Deploying...",
         _ => "Deploying...",
+    }
+}
+
+fn required_response_id<'a>(value: &'a serde_json::Value, object_name: &str) -> &'a str {
+    match value.get("id").and_then(|v| v.as_str()) {
+        Some(id) if !id.is_empty() => id,
+        _ => {
+            output::error(
+                &format!("Unexpected API response: {object_name} is missing required 'id'."),
+                "INVALID_RESPONSE",
+                Some("This may indicate a CLI/API mismatch. Check for updates with `floo update`."),
+            );
+            process::exit(1);
+        }
     }
 }
 
@@ -100,7 +113,7 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         }
     };
 
-    let client = FlooClient::new(Some(config));
+    let client = super::init_client(Some(config));
 
     // Resolve or create app
     let app_data = if let Some(ref app_ident) = app {
@@ -140,11 +153,12 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
             }
         }
     };
+    let app_id = required_response_id(&app_data, "app").to_string();
 
     // Deploy
     let spinner = output::Spinner::new("Uploading...");
     let mut deploy_data = match client.create_deploy(
-        app_data.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+        &app_id,
         &archive_path,
         &detection.runtime,
         detection.framework.as_deref(),
@@ -196,14 +210,7 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         thread::sleep(POLL_INTERVAL);
 
         if poll_start.elapsed() >= POLL_TIMEOUT {
-            let app_id = app_data
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            let deploy_id = deploy_data
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
+            let deploy_id = required_response_id(&deploy_data, "deploy");
             output::error(
                 "Deploy timed out after 10 minutes",
                 "DEPLOY_TIMEOUT",
@@ -215,9 +222,8 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
             process::exit(1);
         }
 
-        let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
-        let deploy_id = deploy_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
-        deploy_data = match client.get_deploy(app_id, deploy_id) {
+        let deploy_id = required_response_id(&deploy_data, "deploy").to_string();
+        deploy_data = match client.get_deploy(&app_id, &deploy_id) {
             Ok(d) => d,
             Err(e) => {
                 output::error(&e.message, &e.code, None);
@@ -244,7 +250,20 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
                 }
             }
         }
-        output::error("Deploy failed.", "DEPLOY_FAILED", None);
+        let build_logs = deploy_data
+            .get("build_logs")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        output::error_with_data(
+            "Deploy failed.",
+            "DEPLOY_FAILED",
+            Some("Check build output above, or run `floo logs` for details."),
+            Some(serde_json::json!({
+                "app": app_data,
+                "deploy": deploy_data,
+                "build_logs": build_logs,
+            })),
+        );
         process::exit(1);
     }
 
@@ -265,6 +284,13 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
 
 fn cleanup(path: &PathBuf) {
     if path.exists() {
-        let _ = std::fs::remove_file(path);
+        if let Err(error) = std::fs::remove_file(path) {
+            if !output::is_json_mode() {
+                eprintln!(
+                    "Warning: failed to remove temporary archive {}: {error}",
+                    path.display()
+                );
+            }
+        }
     }
 }

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -1,6 +1,5 @@
 use std::process;
 
-use crate::api_client::FlooClient;
 use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
@@ -19,7 +18,7 @@ fn require_auth() {
 
 pub fn add(hostname: &str, app_name: &str) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {
@@ -67,7 +66,7 @@ pub fn add(hostname: &str, app_name: &str) {
 
 pub fn list(app_name: &str) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {
@@ -147,7 +146,7 @@ pub fn list(app_name: &str) {
 
 pub fn remove(hostname: &str, app_name: &str) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -1,6 +1,5 @@
 use std::process;
 
-use crate::api_client::FlooClient;
 use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
@@ -32,7 +31,7 @@ pub fn set(key_value: &str, app_name: &str) {
     let (key, value) = key_value.split_once('=').unwrap();
     let key = key.to_uppercase();
 
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {
@@ -68,7 +67,7 @@ pub fn set(key_value: &str, app_name: &str) {
 
 pub fn list(app_name: &str) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {
@@ -146,7 +145,7 @@ pub fn remove(key: &str, app_name: &str) {
     let key = key.to_uppercase();
     require_auth();
 
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
         Err(e) => {

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -3,7 +3,6 @@ use std::process;
 
 use colored::Colorize;
 
-use crate::api_client::FlooClient;
 use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
@@ -48,7 +47,7 @@ pub fn logs(
     output_path: Option<&Path>,
 ) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
 
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,9 @@
+use std::process;
+
+use crate::api_client::FlooClient;
+use crate::config::FlooConfig;
+use crate::output;
+
 pub mod apps;
 pub mod auth;
 pub mod db;
@@ -7,3 +13,17 @@ pub mod env;
 pub mod logs;
 pub mod rollbacks;
 pub mod update;
+
+pub(crate) fn init_client(config: Option<FlooConfig>) -> FlooClient {
+    match FlooClient::new(config) {
+        Ok(client) => client,
+        Err(error) => {
+            output::error(
+                &error.message,
+                &error.code,
+                Some("Check your network/TLS setup and try again."),
+            );
+            process::exit(1);
+        }
+    }
+}

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -1,6 +1,5 @@
 use std::process;
 
-use crate::api_client::FlooClient;
 use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
@@ -19,7 +18,7 @@ fn require_auth() {
 
 pub fn list(app_name: &str) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
 
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -114,7 +113,7 @@ pub fn list(app_name: &str) {
 
 pub fn rollback(app_name: &str, deploy_id: &str, force: bool) {
     require_auth();
-    let client = FlooClient::new(None);
+    let client = super::init_client(None);
 
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,

--- a/src/output.rs
+++ b/src/output.rs
@@ -46,6 +46,23 @@ pub fn error(message: &str, code: &str, suggestion: Option<&str>) {
     }
 }
 
+pub fn error_with_data(message: &str, code: &str, suggestion: Option<&str>, data: Option<Value>) {
+    if is_json_mode() {
+        let mut err = serde_json::json!({"code": code, "message": message});
+        if let Some(sug) = suggestion {
+            err.as_object_mut()
+                .unwrap()
+                .insert("suggestion".to_string(), Value::String(sug.to_string()));
+        }
+        print_json(&serde_json::json!({"success": false, "error": err, "data": data}));
+    } else {
+        eprintln!("{} {message}", "Error:".red());
+        if let Some(sug) = suggestion {
+            eprintln!("  \u{2192} {sug}");
+        }
+    }
+}
+
 pub fn info(message: &str, data: Option<Value>) {
     if is_json_mode() {
         print_json(&serde_json::json!({"success": true, "data": data}));

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -702,6 +702,95 @@ fn test_deploy_existing_app_by_name_json() {
         .stdout(predicate::str::contains(r#""deploy""#));
 }
 
+#[test]
+fn test_deploy_fails_with_invalid_response_when_app_id_missing() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let _m_create_app = server
+        .mock("POST", "/v1/apps")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"test-deploy","status":"created","runtime":"nodejs"}"#)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploy",
+            project.path().to_str().unwrap(),
+            "--name",
+            "test-deploy",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"INVALID_RESPONSE""#))
+        .stdout(predicate::str::contains("missing required 'id'"));
+}
+
+#[test]
+fn test_deploy_failed_json_includes_logs_and_suggestion() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let _m_list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"apps":[{app}]}}"#, app = app_json()))
+        .create();
+
+    let _m_deploy = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"deploy-001","status":"failed","url":"https://my-app.floo.app","build_logs":"build failed: npm ci exited 1"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploy",
+            project.path().to_str().unwrap(),
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"DEPLOY_FAILED""#))
+        .stdout(predicate::str::contains(
+            r#""suggestion":"Check build output above, or run `floo logs` for details.""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""build_logs":"build failed: npm ci exited 1""#,
+        ));
+}
+
 // ───────────────────────── App Not Found ─────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- make `FlooClient::new` return `Result` with `CLIENT_INIT_FAILED` instead of panicking
- hard-fail deploy flow on malformed API responses missing required IDs with `INVALID_RESPONSE`
- make `.flooignore` read failures explicit via `FLOOIGNORE_READ_FAILED`
- surface non-fatal temp archive cleanup failures in human mode instead of silently discarding errors
- include actionable suggestion and `build_logs` payload for `DEPLOY_FAILED` in JSON mode

## Testing
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test

Closes getfloo/floo-workspace#64
Closes getfloo/floo-workspace#65
Closes getfloo/floo-workspace#66
Closes getfloo/floo-workspace#67
Closes getfloo/floo-workspace#68
