### PR TITLE
[Feature] [#20] Restructure auth commands + device code login + register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "mockito",
+ "open",
  "predicates",
  "rand 0.8.5",
  "reqwest",
@@ -990,6 +991,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1288,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.10"
 tar = "0.4"
 thiserror = "2"
 anyhow = "1"
+open = "5"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -128,10 +128,26 @@ impl FlooClient {
         let resp = self.post_json("/v1/auth/device/token", &body)?;
         let status = resp.status().as_u16();
         if status == 202 {
+            let resp_body: Value = resp.json().map_err(|e| {
+                FlooApiError::new(
+                    500,
+                    "PARSE_ERROR",
+                    format!("Failed to parse 202 response: {e}"),
+                )
+            })?;
+            let poll_status = resp_body
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("pending");
+            let code = if poll_status == "slow_down" {
+                "DEVICE_SLOW_DOWN"
+            } else {
+                "DEVICE_PENDING"
+            };
             return Err(FlooApiError::new(
                 202,
-                "DEVICE_PENDING",
-                "Authorization pending",
+                code,
+                format!("Authorization {poll_status}"),
             ));
         }
         self.handle_response(resp)

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -112,9 +112,28 @@ impl FlooClient {
 
     // --- Auth ---
 
-    pub fn login(&self, email: &str, password: &str) -> Result<Value, FlooApiError> {
+    pub fn register(&self, email: &str, password: &str) -> Result<Value, FlooApiError> {
         let body = serde_json::json!({"email": email, "password": password});
-        let resp = self.post_json("/v1/auth/login", &body)?;
+        let resp = self.post_json("/v1/auth/register", &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn device_authorize(&self) -> Result<Value, FlooApiError> {
+        let resp = self.post_json("/v1/auth/device", &serde_json::json!({}))?;
+        self.handle_response(resp)
+    }
+
+    pub fn device_token(&self, device_code: &str) -> Result<Value, FlooApiError> {
+        let body = serde_json::json!({"device_code": device_code});
+        let resp = self.post_json("/v1/auth/device/token", &body)?;
+        let status = resp.status().as_u16();
+        if status == 202 {
+            return Err(FlooApiError::new(
+                202,
+                "DEVICE_PENDING",
+                "Authorization pending",
+            ));
+        }
         self.handle_response(resp)
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,22 +38,9 @@ pub enum Commands {
         app: Option<String>,
     },
 
-    /// Authenticate with the Floo API and store credentials.
-    Login {
-        /// Account email.
-        #[arg(short, long)]
-        email: Option<String>,
-
-        /// Account password.
-        #[arg(short, long)]
-        password: Option<String>,
-    },
-
-    /// Clear stored credentials.
-    Logout,
-
-    /// Show the currently authenticated user.
-    Whoami,
+    /// Authenticate and manage your account.
+    #[command(subcommand)]
+    Auth(AuthCommands),
 
     /// Manage your apps.
     #[command(subcommand)]
@@ -122,6 +109,21 @@ pub enum Commands {
         /// Specific release tag to install (e.g. v0.2.0).
         #[arg(long)]
         version: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthCommands {
+    /// Authenticate with the Floo API (opens browser).
+    Login,
+    /// Clear stored credentials.
+    Logout,
+    /// Show the currently authenticated user.
+    Whoami,
+    /// Create a new Floo account.
+    Register {
+        /// Account email address.
+        email: String,
     },
 }
 
@@ -234,9 +236,12 @@ pub fn run() {
 
     match cli.command {
         Commands::Deploy { path, name, app } => commands::deploy::deploy(path, name, app),
-        Commands::Login { email, password } => commands::auth::login(email, password),
-        Commands::Logout => commands::auth::logout(),
-        Commands::Whoami => commands::auth::whoami(),
+        Commands::Auth(sub) => match sub {
+            AuthCommands::Login => commands::auth::login(),
+            AuthCommands::Logout => commands::auth::logout(),
+            AuthCommands::Whoami => commands::auth::whoami(),
+            AuthCommands::Register { email } => commands::auth::register(&email),
+        },
 
         Commands::Apps(sub) => match sub {
             AppsCommands::List => commands::apps::list(),

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,28 +1,161 @@
 use std::process;
+use std::thread;
+use std::time::Duration;
 
-use dialoguer::{Input, Password};
+use colored::Colorize;
+use dialoguer::Password;
 
 use crate::config::{clear_config, load_config, save_config};
 use crate::output;
 
-pub fn login(email: Option<String>, password: Option<String>) {
-    let email = email.unwrap_or_else(|| {
-        Input::new()
-            .with_prompt("Email")
-            .interact_text()
-            .unwrap_or_else(|_| process::exit(1))
-    });
-
-    let password = password.unwrap_or_else(|| {
-        Password::new()
-            .with_prompt("Password")
-            .interact()
-            .unwrap_or_else(|_| process::exit(1))
-    });
-
-    let spinner = output::Spinner::new("Logging in...");
+pub fn login() {
     let client = super::init_client(None);
-    match client.login(&email, &password) {
+
+    // Step 1: Initiate device code flow
+    let spinner = output::Spinner::new("Requesting device code...");
+    let auth = match client.device_authorize() {
+        Ok(result) => {
+            spinner.finish();
+            result
+        }
+        Err(e) => {
+            spinner.finish();
+            output::error(&e.message, &e.code, Some("Check your network connection."));
+            process::exit(1);
+        }
+    };
+
+    let user_code = auth
+        .get("user_code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let verification_uri_complete = auth
+        .get("verification_uri_complete")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let device_code = auth
+        .get("device_code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let interval = auth
+        .get("interval")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(5);
+
+    // Step 2: Display code and open browser
+    if output::is_json_mode() {
+        output::info(
+            "Awaiting browser authentication",
+            Some(serde_json::json!({
+                "status": "awaiting_auth",
+                "user_code": user_code,
+                "verification_uri_complete": verification_uri_complete,
+            })),
+        );
+    } else {
+        eprintln!();
+        eprintln!(
+            "  Your one-time code is:  {}",
+            user_code.bold()
+        );
+        eprintln!();
+        eprintln!(
+            "  Opening browser to: {}",
+            verification_uri_complete
+        );
+        eprintln!("  If the browser didn't open, visit the URL above and enter the code.");
+        eprintln!();
+    }
+
+    // Open browser (non-fatal if it fails)
+    let _ = open::that(verification_uri_complete);
+
+    // Step 3: Poll for completion
+    let spinner = output::Spinner::new("Waiting for browser authentication...");
+    let mut network_retries = 0u8;
+
+    loop {
+        thread::sleep(Duration::from_secs(interval));
+
+        match client.device_token(device_code) {
+            Ok(result) => {
+                spinner.finish();
+                let mut config = load_config();
+                config.api_key = result
+                    .get("api_key")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                config.user_email = result
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                if let Err(e) = save_config(&config) {
+                    output::error(
+                        &format!("Failed to save credentials: {e}"),
+                        "CONFIG_ERROR",
+                        None,
+                    );
+                    process::exit(1);
+                }
+                let display_email = config.user_email.as_deref().unwrap_or("unknown");
+                output::success(
+                    &format!("Logged in as {display_email}"),
+                    Some(serde_json::json!({"email": display_email})),
+                );
+                return;
+            }
+            Err(e) if e.status_code == 202 => {
+                // Still pending — continue polling
+                network_retries = 0;
+                continue;
+            }
+            Err(e) if e.code == "DEVICE_CODE_EXPIRED" => {
+                spinner.finish();
+                output::error(
+                    "Device code expired. Please try again.",
+                    "DEVICE_CODE_EXPIRED",
+                    Some("Run 'floo auth login' to start a new session."),
+                );
+                process::exit(1);
+            }
+            Err(e) if e.code == "DEVICE_AUTH_DENIED" => {
+                spinner.finish();
+                output::error(
+                    "Authorization was denied.",
+                    "DEVICE_AUTH_DENIED",
+                    None,
+                );
+                process::exit(1);
+            }
+            Err(e) if e.status_code == 0 => {
+                // Network error — retry up to 3 times
+                network_retries += 1;
+                if network_retries >= 3 {
+                    spinner.finish();
+                    output::error(&e.message, &e.code, Some("Check your network connection."));
+                    process::exit(1);
+                }
+                continue;
+            }
+            Err(e) => {
+                spinner.finish();
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
+        }
+    }
+}
+
+pub fn register(email: &str) {
+    let password = Password::new()
+        .with_prompt("Password")
+        .with_confirmation("Confirm password", "Passwords do not match.")
+        .interact()
+        .unwrap_or_else(|_| process::exit(1));
+
+    let spinner = output::Spinner::new("Creating account...");
+    let client = super::init_client(None);
+    match client.register(email, &password) {
         Ok(result) => {
             spinner.finish();
             let mut config = load_config();
@@ -42,15 +175,24 @@ pub fn login(email: Option<String>, password: Option<String>) {
                 );
                 process::exit(1);
             }
-            let display_email = config.user_email.as_deref().unwrap_or(&email);
+            let display_email = config.user_email.as_deref().unwrap_or(email);
             output::success(
-                &format!("Logged in as {display_email}"),
+                &format!("Account created! Logged in as {display_email}"),
                 Some(serde_json::json!({"email": display_email})),
             );
         }
+        Err(e) if e.code == "EMAIL_TAKEN" => {
+            spinner.finish();
+            output::error(
+                "This email is already registered.",
+                "EMAIL_TAKEN",
+                Some("Use 'floo auth login' to sign in."),
+            );
+            process::exit(1);
+        }
         Err(e) => {
             spinner.finish();
-            output::error(&e.message, &e.code, Some("Check your email and password."));
+            output::error(&e.message, &e.code, None);
             process::exit(1);
         }
     }
@@ -68,7 +210,7 @@ pub fn whoami() {
             output::error(
                 "Not logged in.",
                 "NOT_AUTHENTICATED",
-                Some("Run 'floo login' to authenticate."),
+                Some("Run 'floo auth login' to authenticate."),
             );
             process::exit(1);
         }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -25,10 +25,7 @@ pub fn login() {
         }
     };
 
-    let user_code = auth
-        .get("user_code")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let user_code = auth.get("user_code").and_then(|v| v.as_str()).unwrap_or("");
     let verification_uri_complete = auth
         .get("verification_uri_complete")
         .and_then(|v| v.as_str())
@@ -37,10 +34,7 @@ pub fn login() {
         .get("device_code")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let interval = auth
-        .get("interval")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(5);
+    let interval = auth.get("interval").and_then(|v| v.as_u64()).unwrap_or(5);
 
     // Step 2: Display code and open browser
     if output::is_json_mode() {
@@ -54,15 +48,9 @@ pub fn login() {
         );
     } else {
         eprintln!();
-        eprintln!(
-            "  Your one-time code is:  {}",
-            user_code.bold()
-        );
+        eprintln!("  Your one-time code is:  {}", user_code.bold());
         eprintln!();
-        eprintln!(
-            "  Opening browser to: {}",
-            verification_uri_complete
-        );
+        eprintln!("  Opening browser to: {}", verification_uri_complete);
         eprintln!("  If the browser didn't open, visit the URL above and enter the code.");
         eprintln!();
     }
@@ -120,11 +108,7 @@ pub fn login() {
             }
             Err(e) if e.code == "DEVICE_AUTH_DENIED" => {
                 spinner.finish();
-                output::error(
-                    "Authorization was denied.",
-                    "DEVICE_AUTH_DENIED",
-                    None,
-                );
+                output::error("Authorization was denied.", "DEVICE_AUTH_DENIED", None);
                 process::exit(1);
             }
             Err(e) if e.status_code == 0 => {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,6 +1,6 @@
 use std::process;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use colored::Colorize;
 use dialoguer::Password;
@@ -57,6 +57,13 @@ pub fn login() {
             output::error("Invalid response: missing interval", "PARSE_ERROR", None);
             process::exit(1);
         });
+    let expires_in = auth
+        .get("expires_in")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| {
+            output::error("Invalid response: missing expires_in", "PARSE_ERROR", None);
+            process::exit(1);
+        });
 
     // Step 2: Display code and open browser
     if !output::is_json_mode() {
@@ -74,22 +81,50 @@ pub fn login() {
     // Step 3: Poll for completion
     let spinner = output::Spinner::new("Waiting for browser authentication...");
     let mut network_retries = 0u8;
+    let deadline = Instant::now() + Duration::from_secs(expires_in);
+    let mut poll_interval = interval;
 
     loop {
-        thread::sleep(Duration::from_secs(interval));
+        thread::sleep(Duration::from_secs(poll_interval));
+
+        if Instant::now() > deadline {
+            spinner.finish();
+            output::error(
+                "Device code expired. Please try again.",
+                "DEVICE_CODE_EXPIRED",
+                Some("Run 'floo auth login' to start a new session."),
+            );
+            process::exit(1);
+        }
 
         match client.device_token(device_code) {
             Ok(result) => {
                 spinner.finish();
-                let mut config = load_config();
-                config.api_key = result
+                let api_key = result
                     .get("api_key")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-                config.user_email = result
+                    .unwrap_or_else(|| {
+                        output::error(
+                            "Server returned success but API key was missing.",
+                            "PARSE_ERROR",
+                            Some("This may be a server bug. Please try again."),
+                        );
+                        process::exit(1);
+                    });
+                let email = result
                     .get("email")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                    .unwrap_or_else(|| {
+                        output::error(
+                            "Server returned success but email was missing.",
+                            "PARSE_ERROR",
+                            Some("This may be a server bug. Please try again."),
+                        );
+                        process::exit(1);
+                    });
+                let mut config = load_config();
+                config.api_key = Some(api_key.to_string());
+                config.user_email = Some(email.to_string());
                 if let Err(e) = save_config(&config) {
                     output::error(
                         &format!("Failed to save credentials: {e}"),
@@ -98,16 +133,19 @@ pub fn login() {
                     );
                     process::exit(1);
                 }
-                let display_email = config.user_email.as_deref().unwrap_or("unknown");
                 output::success(
-                    &format!("Logged in as {display_email}"),
-                    Some(serde_json::json!({"email": display_email})),
+                    &format!("Logged in as {email}"),
+                    Some(serde_json::json!({"email": email})),
                 );
                 return;
             }
             Err(e) if e.status_code == 202 => {
                 // Still pending — continue polling
                 network_retries = 0;
+                if e.code == "DEVICE_SLOW_DOWN" {
+                    // RFC 8628: increase interval by 5 seconds on slow_down
+                    poll_interval = interval + 5;
+                }
                 continue;
             }
             Err(e) if e.code == "DEVICE_CODE_EXPIRED" => {
@@ -155,15 +193,31 @@ pub fn register(email: &str) {
     match client.register(email, &password) {
         Ok(result) => {
             spinner.finish();
-            let mut config = load_config();
-            config.api_key = result
+            let api_key = result
                 .get("api_key")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            config.user_email = result
+                .unwrap_or_else(|| {
+                    output::error(
+                        "Server returned success but API key was missing.",
+                        "PARSE_ERROR",
+                        Some("This may be a server bug. Please try again."),
+                    );
+                    process::exit(1);
+                });
+            let resp_email = result
                 .get("email")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
+                .unwrap_or_else(|| {
+                    output::error(
+                        "Server returned success but email was missing.",
+                        "PARSE_ERROR",
+                        Some("This may be a server bug. Please try again."),
+                    );
+                    process::exit(1);
+                });
+            let mut config = load_config();
+            config.api_key = Some(api_key.to_string());
+            config.user_email = Some(resp_email.to_string());
             if let Err(e) = save_config(&config) {
                 output::error(
                     &format!("Failed to save credentials: {e}"),
@@ -172,10 +226,9 @@ pub fn register(email: &str) {
                 );
                 process::exit(1);
             }
-            let display_email = config.user_email.as_deref().unwrap_or(email);
             output::success(
-                &format!("Account created! Logged in as {display_email}"),
-                Some(serde_json::json!({"email": display_email})),
+                &format!("Account created! Logged in as {resp_email}"),
+                Some(serde_json::json!({"email": resp_email})),
             );
         }
         Err(e) if e.code == "EMAIL_TAKEN" => {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -25,28 +25,41 @@ pub fn login() {
         }
     };
 
-    let user_code = auth.get("user_code").and_then(|v| v.as_str()).unwrap_or("");
+    let user_code = auth
+        .get("user_code")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| {
+            output::error("Invalid response: missing user_code", "PARSE_ERROR", None);
+            process::exit(1);
+        });
     let verification_uri_complete = auth
         .get("verification_uri_complete")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .unwrap_or_else(|| {
+            output::error(
+                "Invalid response: missing verification_uri_complete",
+                "PARSE_ERROR",
+                None,
+            );
+            process::exit(1);
+        });
     let device_code = auth
         .get("device_code")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let interval = auth.get("interval").and_then(|v| v.as_u64()).unwrap_or(5);
+        .unwrap_or_else(|| {
+            output::error("Invalid response: missing device_code", "PARSE_ERROR", None);
+            process::exit(1);
+        });
+    let interval = auth
+        .get("interval")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| {
+            output::error("Invalid response: missing interval", "PARSE_ERROR", None);
+            process::exit(1);
+        });
 
     // Step 2: Display code and open browser
-    if output::is_json_mode() {
-        output::info(
-            "Awaiting browser authentication",
-            Some(serde_json::json!({
-                "status": "awaiting_auth",
-                "user_code": user_code,
-                "verification_uri_complete": verification_uri_complete,
-            })),
-        );
-    } else {
+    if !output::is_json_mode() {
         eprintln!();
         eprintln!("  Your one-time code is:  {}", user_code.bold());
         eprintln!();

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -63,7 +63,9 @@ fn test_auth_help() {
         .args(["auth", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Authenticate and manage your account"));
+        .stdout(predicate::str::contains(
+            "Authenticate and manage your account",
+        ));
 }
 
 #[test]
@@ -139,7 +141,9 @@ fn test_auth_whoami_help() {
         .args(["auth", "whoami", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Show the currently authenticated user"));
+        .stdout(predicate::str::contains(
+            "Show the currently authenticated user",
+        ));
 }
 
 // --- Apps (unauthenticated) ---

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -55,12 +55,48 @@ fn test_no_args_shows_help() {
         .stderr(predicate::str::contains("Usage: floo"));
 }
 
-// --- Auth (unauthenticated) ---
+// --- Auth subcommand ---
 
 #[test]
-fn test_whoami_not_authenticated() {
+fn test_auth_help() {
     floo()
-        .arg("whoami")
+        .args(["auth", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Authenticate and manage your account"));
+}
+
+#[test]
+fn test_auth_login_help() {
+    floo()
+        .args(["auth", "login", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Authenticate with the Floo API"));
+}
+
+#[test]
+fn test_auth_register_help() {
+    floo()
+        .args(["auth", "register", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Create a new Floo account"));
+}
+
+#[test]
+fn test_auth_register_missing_email() {
+    floo()
+        .args(["auth", "register"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_auth_whoami_not_authenticated() {
+    floo()
+        .args(["auth", "whoami"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -68,9 +104,9 @@ fn test_whoami_not_authenticated() {
 }
 
 #[test]
-fn test_whoami_json_not_authenticated() {
+fn test_auth_whoami_json_not_authenticated() {
     floo()
-        .args(["--json", "whoami"])
+        .args(["--json", "auth", "whoami"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -78,9 +114,9 @@ fn test_whoami_json_not_authenticated() {
 }
 
 #[test]
-fn test_logout_succeeds() {
+fn test_auth_logout_succeeds() {
     floo()
-        .arg("logout")
+        .args(["auth", "logout"])
         .env("HOME", "/tmp/floo-test-logout")
         .assert()
         .success()
@@ -88,13 +124,22 @@ fn test_logout_succeeds() {
 }
 
 #[test]
-fn test_logout_json() {
+fn test_auth_logout_json() {
     floo()
-        .args(["--json", "logout"])
+        .args(["--json", "auth", "logout"])
         .env("HOME", "/tmp/floo-test-logout-json")
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""success":true"#));
+}
+
+#[test]
+fn test_auth_whoami_help() {
+    floo()
+        .args(["auth", "whoami", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Show the currently authenticated user"));
 }
 
 // --- Apps (unauthenticated) ---
@@ -395,4 +440,33 @@ fn test_logs_json_not_authenticated() {
         .assert()
         .failure()
         .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
+}
+
+// --- Top-level login/logout/whoami removed ---
+
+#[test]
+fn test_top_level_login_removed() {
+    floo()
+        .arg("login")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn test_top_level_logout_removed() {
+    floo()
+        .arg("logout")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn test_top_level_whoami_removed() {
+    floo()
+        .arg("whoami")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand"));
 }


### PR DESCRIPTION
## Summary
- Move `login`/`logout`/`whoami` under `floo auth` subcommand group
- Add `floo auth register <email>` for quick account creation
- Rewrite `floo auth login` as browser-based device code flow (no email/password)
- Remove top-level `floo login`/`logout`/`whoami` (clean cut)

Closes getfloo/floo-workspace#20

## Changes
- `Cargo.toml` — add `open = "5"` for browser opening
- `src/cli.rs` — replace top-level Login/Logout/Whoami with Auth subcommand group
- `src/commands/auth.rs` — device code login + register + updated whoami hint
- `src/api_client.rs` — add `register()`, `device_authorize()`, `device_token()` methods
- `tests/cli_tests.rs` — update all auth tests to `floo auth` + add new tests

## Test plan
- [x] `cargo test` — 118 tests pass (45 unit + 44 integration + 29 mock API)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Code review: fixed silent unwrap_or fallbacks + JSON double-emit bug

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)