### PR TITLE
[Feature] [F2.2] Add SSE streaming for deploy logs

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -202,6 +202,53 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn stream_deploy_logs(
+        &self,
+        app_id: &str,
+        deploy_id: &str,
+    ) -> Result<reqwest::blocking::Response, FlooApiError> {
+        let streaming_client = Client::builder()
+            .timeout(Duration::from_secs(1200))
+            .build()
+            .map_err(|e| {
+                FlooApiError::new(
+                    0,
+                    "CONNECTION_ERROR",
+                    format!("Failed to create streaming client: {e}"),
+                )
+            })?;
+
+        let url = format!(
+            "{}/v1/apps/{}/deploys/{}/logs/stream",
+            self.base_url, app_id, deploy_id
+        );
+        let mut req = streaming_client
+            .get(&url)
+            .header("Accept", "text/event-stream");
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        let response = req
+            .send()
+            .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))?;
+
+        if response.status().as_u16() == 404 {
+            return Err(FlooApiError::new(
+                404,
+                "NOT_FOUND",
+                "Stream endpoint not available",
+            ));
+        }
+        if !response.status().is_success() {
+            return Err(FlooApiError::new(
+                response.status().as_u16(),
+                "STREAM_ERROR",
+                format!("Stream endpoint returned {}", response.status()),
+            ));
+        }
+        Ok(response)
+    }
+
     // --- Env vars ---
 
     pub fn set_env_var(&self, app_id: &str, key: &str, value: &str) -> Result<Value, FlooApiError> {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,11 +1,14 @@
+use std::io::BufRead;
 use std::path::PathBuf;
 use std::process;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::api_client::FlooClient;
 use crate::archive::create_archive;
 use crate::config::load_config;
 use crate::detection::detect;
+use crate::errors::FlooApiError;
 use crate::names::generate_name;
 use crate::output;
 use crate::resolve::resolve_app;
@@ -178,58 +181,31 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
     // Clean up archive immediately after upload
     cleanup(&archive_path);
 
-    // Poll until terminal status
-    let poll_start = Instant::now();
-    let mut last_log_len: usize = 0;
-    while !TERMINAL_STATUSES.contains(
-        &deploy_data
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or(""),
-    ) {
-        if !output::is_json_mode() {
-            let build_logs = deploy_data
-                .get("build_logs")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            if build_logs.len() > last_log_len {
-                let new_logs = &build_logs[last_log_len..];
-                for line in new_logs.trim().lines() {
-                    output::dim_line(line);
-                }
-                last_log_len = build_logs.len();
-            }
+    // Wait for deploy to complete via SSE streaming or polling
+    let initial_status = deploy_data
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
 
-            let status = deploy_data
-                .get("status")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            output::bold_line(status_label(status));
-        }
-
-        thread::sleep(POLL_INTERVAL);
-
-        if poll_start.elapsed() >= POLL_TIMEOUT {
-            let deploy_id = required_response_id(&deploy_data, "deploy");
-            output::error(
-                "Deploy timed out after 10 minutes",
-                "DEPLOY_TIMEOUT",
-                Some(&format!(
-                    "The deploy may still complete — check status with \
-                     `floo apps status {app_id}` (deploy ID: {deploy_id})"
-                )),
-            );
-            process::exit(1);
-        }
-
+    if TERMINAL_STATUSES.contains(&initial_status) {
+        // Phase 1: deploy already complete synchronously, skip streaming/polling
+    } else if !output::is_json_mode() {
+        // Phase 2 human mode: try SSE streaming, fall back to polling
         let deploy_id = required_response_id(&deploy_data, "deploy").to_string();
-        deploy_data = match client.get_deploy(&app_id, &deploy_id) {
-            Ok(d) => d,
+        match stream_deploy(&client, &app_id, &deploy_id) {
+            Ok(final_data) => deploy_data = final_data,
             Err(e) => {
-                output::error(&e.message, &e.code, None);
-                process::exit(1);
+                // SSE failed — fall back to polling
+                eprintln!(
+                    "Stream unavailable ({}), falling back to polling...",
+                    e.code
+                );
+                deploy_data = poll_deploy(&client, &app_id, &deploy_data);
             }
-        };
+        }
+    } else {
+        // Phase 2 JSON mode: use polling
+        deploy_data = poll_deploy(&client, &app_id, &deploy_data);
     }
 
     let final_status = deploy_data
@@ -238,18 +214,6 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         .unwrap_or("");
 
     if final_status == "failed" {
-        if !output::is_json_mode() {
-            let build_logs = deploy_data
-                .get("build_logs")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            if build_logs.len() > last_log_len {
-                let new_logs = &build_logs[last_log_len..];
-                for line in new_logs.trim().lines() {
-                    output::dim_line(line);
-                }
-            }
-        }
         let build_logs = deploy_data
             .get("build_logs")
             .and_then(|v| v.as_str())
@@ -280,6 +244,157 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
             "detection": detection.to_value(),
         })),
     );
+}
+
+/// Stream deploy logs via SSE and return the final deploy state.
+fn stream_deploy(
+    client: &FlooClient,
+    app_id: &str,
+    deploy_id: &str,
+) -> Result<serde_json::Value, FlooApiError> {
+    let response = client.stream_deploy_logs(app_id, deploy_id)?;
+    let reader = std::io::BufReader::new(response);
+
+    let mut event_type = String::new();
+    let mut data_buf = String::new();
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("SSE connection error: {e}");
+                break;
+            }
+        };
+
+        if let Some(suffix) = line.strip_prefix("event: ") {
+            event_type = suffix.to_string();
+        } else if let Some(suffix) = line.strip_prefix("data: ") {
+            data_buf = suffix.to_string();
+        } else if line.starts_with(':') {
+            continue; // SSE comment (heartbeat)
+        } else if line.is_empty() && !event_type.is_empty() {
+            // Event complete — process it
+            match event_type.as_str() {
+                "status" => match serde_json::from_str::<serde_json::Value>(&data_buf) {
+                    Ok(parsed) => {
+                        let status = parsed.get("status").and_then(|v| v.as_str()).unwrap_or("");
+                        output::bold_line(status_label(status));
+                    }
+                    Err(e) => eprintln!("Malformed SSE status event: {e}"),
+                },
+                "log" => match serde_json::from_str::<serde_json::Value>(&data_buf) {
+                    Ok(parsed) => {
+                        if let Some(text) = parsed.get("text").and_then(|v| v.as_str()) {
+                            for log_line in text.trim().lines() {
+                                output::dim_line(log_line);
+                            }
+                        }
+                    }
+                    Err(e) => eprintln!("Malformed SSE log event: {e}"),
+                },
+                "done" => {
+                    break;
+                }
+                "error" => match serde_json::from_str::<serde_json::Value>(&data_buf) {
+                    Ok(parsed) => {
+                        let msg = parsed
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Stream error");
+                        return Err(FlooApiError::new(0, "STREAM_ERROR", msg));
+                    }
+                    Err(e) => {
+                        eprintln!("Malformed SSE error event: {e}");
+                        break;
+                    }
+                },
+                _ => {}
+            }
+            event_type.clear();
+            data_buf.clear();
+        }
+    }
+
+    // After stream ends, fetch final deploy state for success/error output
+    client.get_deploy(app_id, deploy_id)
+}
+
+/// Poll the deploy endpoint until it reaches a terminal status.
+fn poll_deploy(
+    client: &FlooClient,
+    app_id: &str,
+    initial_data: &serde_json::Value,
+) -> serde_json::Value {
+    let deploy_id = required_response_id(initial_data, "deploy").to_string();
+    let poll_start = Instant::now();
+    let mut last_log_len: usize = 0;
+    let mut deploy_data = initial_data.clone();
+
+    while !TERMINAL_STATUSES.contains(
+        &deploy_data
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or(""),
+    ) {
+        if !output::is_json_mode() {
+            let build_logs = deploy_data
+                .get("build_logs")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if build_logs.len() > last_log_len {
+                let new_logs = &build_logs[last_log_len..];
+                for line in new_logs.trim().lines() {
+                    output::dim_line(line);
+                }
+                last_log_len = build_logs.len();
+            }
+
+            let status = deploy_data
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            output::bold_line(status_label(status));
+        }
+
+        thread::sleep(POLL_INTERVAL);
+
+        if poll_start.elapsed() >= POLL_TIMEOUT {
+            output::error(
+                "Deploy timed out after 10 minutes",
+                "DEPLOY_TIMEOUT",
+                Some(&format!(
+                    "The deploy may still complete — check status with \
+                     `floo apps status {app_id}` (deploy ID: {deploy_id})"
+                )),
+            );
+            process::exit(1);
+        }
+
+        deploy_data = match client.get_deploy(app_id, &deploy_id) {
+            Ok(d) => d,
+            Err(e) => {
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
+        };
+    }
+
+    // Print any remaining build logs for the final state
+    if !output::is_json_mode() {
+        let build_logs = deploy_data
+            .get("build_logs")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if build_logs.len() > last_log_len {
+            let new_logs = &build_logs[last_log_len..];
+            for line in new_logs.trim().lines() {
+                output::dim_line(line);
+            }
+        }
+    }
+
+    deploy_data
 }
 
 fn cleanup(path: &PathBuf) {

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -871,6 +871,205 @@ fn test_apps_status_name_surfaces_list_apps_api_error() {
         .stdout(predicate::str::contains("APP_NOT_FOUND").not());
 }
 
+// ───────────────────────── Deploy SSE streaming ─────────────────────────
+
+#[test]
+fn test_deploy_with_sse_streaming() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let _m_create_app = server
+        .mock("POST", "/v1/apps")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"{TEST_APP_ID}","name":"test-stream","status":"created","runtime":"nodejs"}}"#
+        ))
+        .create();
+
+    // Deploy returns pending (Phase 2 — not terminal)
+    let _m_deploy = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"deploy-001","status":"pending","url":null,"build_logs":""}"#)
+        .create();
+
+    // SSE stream endpoint
+    let sse_body = concat!(
+        "event: status\ndata: {\"status\": \"building\"}\n\n",
+        "event: log\ndata: {\"text\": \"Building image...\\nPushing to registry...\"}\n\n",
+        "event: status\ndata: {\"status\": \"deploying\"}\n\n",
+        "event: done\ndata: {\"status\": \"live\", \"url\": \"https://test-stream.floo.app\"}\n\n",
+    );
+
+    let _m_stream = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/deploys/deploy-001/logs/stream").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create();
+
+    // Final deploy state fetched after stream ends
+    let _m_get_deploy = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/deploys/deploy-001").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"deploy-001","status":"live","url":"https://test-stream.floo.app","build_logs":"Building image...\nPushing to registry..."}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "deploy",
+            project.path().to_str().unwrap(),
+            "--name",
+            "test-stream",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Building"))
+        .stderr(predicate::str::contains("https://test-stream.floo.app"));
+}
+
+#[test]
+fn test_deploy_sse_fallback_to_polling() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let _m_create_app = server
+        .mock("POST", "/v1/apps")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"{TEST_APP_ID}","name":"test-fallback","status":"created","runtime":"nodejs"}}"#
+        ))
+        .create();
+
+    // Deploy returns pending (Phase 2)
+    let _m_deploy = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"deploy-002","status":"pending","url":null,"build_logs":""}"#)
+        .create();
+
+    // SSE endpoint returns 404 — forces fallback to polling
+    let _m_stream = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/deploys/deploy-002/logs/stream").as_str(),
+        )
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"NOT_FOUND","message":"Not found"}}"#)
+        .create();
+
+    // Polling endpoint returns live immediately
+    let _m_get_deploy = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/deploys/deploy-002").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"deploy-002","status":"live","url":"https://test-fallback.floo.app","build_logs":"done"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "deploy",
+            project.path().to_str().unwrap(),
+            "--name",
+            "test-fallback",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("https://test-fallback.floo.app"));
+}
+
+#[test]
+fn test_deploy_json_mode_uses_polling() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let _m_create_app = server
+        .mock("POST", "/v1/apps")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"{TEST_APP_ID}","name":"test-poll","status":"created","runtime":"nodejs"}}"#
+        ))
+        .create();
+
+    // Deploy returns pending
+    let _m_deploy = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"deploy-003","status":"pending","url":null,"build_logs":""}"#)
+        .create();
+
+    // Polling endpoint returns live (SSE is never called in --json mode)
+    let _m_get_deploy = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/deploys/deploy-003").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"deploy-003","status":"live","url":"https://test-poll.floo.app","build_logs":"done"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploy",
+            project.path().to_str().unwrap(),
+            "--name",
+            "test-poll",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("https://test-poll.floo.app"));
+}
+
 // ───────────────────────── Update ─────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- SSE streaming: CLI connects to `/deploys/{id}/logs/stream` in human mode, renders status changes and build logs in real-time
- Polling fallback: if SSE returns 404, CLI falls back to polling via `GET /deploys/{id}`
- JSON mode uses polling exclusively (backward compatible)

Closes getfloo/floo-workspace#24

## Changes
- `src/api_client.rs` — Added `stream_deploy_logs()` with dedicated 20-min timeout client
- `src/commands/deploy.rs` — Added `stream_deploy()` and `poll_deploy()`, refactored post-upload flow (SSE → polling fallback). Log SSE errors and parse failures instead of silent discard.
- `tests/mock_api_tests.rs` — 3 new tests: SSE streaming, SSE fallback to polling, JSON mode polling

## Test plan
- [x] `cargo test` — 32 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] pr-review-toolkit:code-reviewer — all findings addressed
- [x] pr-review-toolkit:silent-failure-hunter — all findings addressed

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)