### PR TITLE
[Feature] [#93] Add floo.toml schema and CLI parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "toml",
 ]
 
 [[package]]
@@ -1725,6 +1726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2000,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2534,6 +2585,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = "0.8"
 reqwest = { version = "0.12", features = ["blocking", "multipart", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 sha2 = "0.10"
 tar = "0.4"
 thiserror = "2"

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -11,6 +11,7 @@ use crate::detection::detect;
 use crate::errors::FlooApiError;
 use crate::names::generate_name;
 use crate::output;
+use crate::project_config;
 use crate::resolve::resolve_app;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -70,6 +71,38 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
             Some("Provide a valid project directory."),
         );
         process::exit(1);
+    }
+
+    // Load project config if present
+    let project_config = match project_config::load_project_config(&project_path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
+        }
+    };
+    if !output::is_json_mode() {
+        if let Some(ref cfg) = project_config {
+            let service_list: Vec<String> = cfg
+                .services
+                .iter()
+                .map(|s| {
+                    format!(
+                        "{} ({} at {}, :{}, {})",
+                        s.name, s.service_type, s.path, s.port, s.ingress
+                    )
+                })
+                .collect();
+            output::info(
+                &format!(
+                    "Loaded floo.toml — app '{}', {} service(s): {}",
+                    cfg.app.name,
+                    cfg.services.len(),
+                    service_list.join(", ")
+                ),
+                None,
+            );
+        }
     }
 
     // Detect runtime/framework

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod detection;
 mod errors;
 mod names;
 mod output;
+mod project_config;
 mod resolve;
 mod updater;
 

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -1,0 +1,290 @@
+use std::fmt;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::errors::FlooError;
+
+const SCHEMA_URL: &str = "https://getfloo.com/docs/floo-toml";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectConfig {
+    pub app: AppConfig,
+    #[serde(default)]
+    pub services: Vec<ServiceConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppConfig {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ServiceConfig {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub service_type: ServiceType,
+    pub path: String,
+    pub port: u16,
+    pub ingress: ServiceIngress,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceType {
+    Web,
+    Api,
+    Worker,
+}
+
+impl fmt::Display for ServiceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServiceType::Web => write!(f, "web"),
+            ServiceType::Api => write!(f, "api"),
+            ServiceType::Worker => write!(f, "worker"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceIngress {
+    Public,
+    Internal,
+}
+
+impl fmt::Display for ServiceIngress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServiceIngress::Public => write!(f, "public"),
+            ServiceIngress::Internal => write!(f, "internal"),
+        }
+    }
+}
+
+/// Load and validate `floo.toml` from `dir`.
+///
+/// Returns `Ok(None)` if the file is absent (no-op).
+/// Returns `Err(FlooError { code: "INVALID_PROJECT_CONFIG", ... })` on any parse or
+/// validation error.
+pub fn load_project_config(dir: &Path) -> Result<Option<ProjectConfig>, FlooError> {
+    let config_path = dir.join("floo.toml");
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&config_path).map_err(|e| {
+        FlooError::with_suggestion(
+            "INVALID_PROJECT_CONFIG",
+            format!("Failed to read floo.toml: {e}"),
+            format!("See {SCHEMA_URL} for the schema reference."),
+        )
+    })?;
+
+    let config: ProjectConfig = toml::from_str(&content).map_err(|e| {
+        FlooError::with_suggestion(
+            "INVALID_PROJECT_CONFIG",
+            format!("Invalid floo.toml: {e}"),
+            format!("See {SCHEMA_URL} for the schema reference."),
+        )
+    })?;
+
+    if config.services.is_empty() {
+        return Err(FlooError::with_suggestion(
+            "INVALID_PROJECT_CONFIG",
+            "floo.toml must define at least one [[services]] entry.",
+            format!("See {SCHEMA_URL} for the schema reference."),
+        ));
+    }
+
+    Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_config(dir: &TempDir, content: &str) {
+        fs::write(dir.path().join("floo.toml"), content).unwrap();
+    }
+
+    #[test]
+    fn test_valid_single_service() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+name = "my-app"
+
+[[services]]
+name = "web"
+type = "web"
+path = "."
+port = 3000
+ingress = "public"
+"#,
+        );
+
+        let result = load_project_config(dir.path()).unwrap();
+        let config = result.unwrap();
+        assert_eq!(config.app.name, "my-app");
+        assert_eq!(config.services.len(), 1);
+        assert_eq!(config.services[0].name, "web");
+        assert_eq!(config.services[0].service_type, ServiceType::Web);
+        assert_eq!(config.services[0].port, 3000);
+        assert_eq!(config.services[0].ingress, ServiceIngress::Public);
+    }
+
+    #[test]
+    fn test_valid_multi_service() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+name = "stack"
+
+[[services]]
+name = "frontend"
+type = "web"
+path = "frontend"
+port = 3000
+ingress = "public"
+
+[[services]]
+name = "backend"
+type = "api"
+path = "backend"
+port = 8000
+ingress = "internal"
+"#,
+        );
+
+        let result = load_project_config(dir.path()).unwrap();
+        let config = result.unwrap();
+        assert_eq!(config.services.len(), 2);
+        assert_eq!(config.services[0].service_type, ServiceType::Web);
+        assert_eq!(config.services[1].service_type, ServiceType::Api);
+        assert_eq!(config.services[1].ingress, ServiceIngress::Internal);
+    }
+
+    #[test]
+    fn test_missing_floo_toml_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let result = load_project_config(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_unknown_top_level_field() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+name = "my-app"
+
+[unknown_field]
+foo = "bar"
+
+[[services]]
+name = "web"
+type = "web"
+path = "."
+port = 3000
+ingress = "public"
+"#,
+        );
+
+        let err = load_project_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
+    }
+
+    #[test]
+    fn test_invalid_service_type() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+name = "my-app"
+
+[[services]]
+name = "db"
+type = "database"
+path = "."
+port = 5432
+ingress = "internal"
+"#,
+        );
+
+        let err = load_project_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
+    }
+
+    #[test]
+    fn test_invalid_service_ingress() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+name = "my-app"
+
+[[services]]
+name = "web"
+type = "web"
+path = "."
+port = 3000
+ingress = "private"
+"#,
+        );
+
+        let err = load_project_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
+    }
+
+    #[test]
+    fn test_missing_app_name() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+
+[[services]]
+name = "web"
+type = "web"
+path = "."
+port = 3000
+ingress = "public"
+"#,
+        );
+
+        let err = load_project_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
+    }
+
+    #[test]
+    fn test_empty_services_array() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            &dir,
+            r#"
+[app]
+name = "my-app"
+"#,
+        );
+
+        let err = load_project_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
+        assert!(err.message.contains("at least one"));
+    }
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -446,6 +446,82 @@ fn test_logs_json_not_authenticated() {
         .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
 }
 
+// --- floo.toml validation ---
+
+#[test]
+fn test_deploy_invalid_floo_toml() {
+    let home = tempfile::TempDir::new().unwrap();
+    let config_dir = home.path().join(".floo");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.json"),
+        r#"{"api_key": "floo_test123", "api_url": "https://api.test.local"}"#,
+    )
+    .unwrap();
+
+    // Create a project dir with an invalid floo.toml
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.toml"),
+        r#"[app]
+name = "my-app"
+
+[[services]]
+name = "web"
+type = "database"
+path = "."
+port = 3000
+ingress = "public"
+"#,
+    )
+    .unwrap();
+
+    floo()
+        .args(["deploy", project.path().to_str().unwrap()])
+        .env("HOME", home.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid floo.toml"));
+}
+
+#[test]
+fn test_deploy_invalid_floo_toml_json() {
+    let home = tempfile::TempDir::new().unwrap();
+    let config_dir = home.path().join(".floo");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.json"),
+        r#"{"api_key": "floo_test123", "api_url": "https://api.test.local"}"#,
+    )
+    .unwrap();
+
+    // Create a project dir with an invalid floo.toml
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.toml"),
+        r#"[app]
+name = "my-app"
+
+[[services]]
+name = "web"
+type = "database"
+path = "."
+port = 3000
+ingress = "public"
+"#,
+    )
+    .unwrap();
+
+    floo()
+        .args(["--json", "deploy", project.path().to_str().unwrap()])
+        .env("HOME", home.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"INVALID_PROJECT_CONFIG"#,
+        ));
+}
+
 // --- Top-level login/logout/whoami removed ---
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `src/project_config.rs` — `ProjectConfig`/`AppConfig`/`ServiceConfig` structs with `#[serde(deny_unknown_fields)]`, typed `ServiceType`/`ServiceIngress` enums, and `load_project_config()` that returns `Ok(None)` when absent, `Err(INVALID_PROJECT_CONFIG)` on parse/validation failure
- `floo deploy` loads and validates `floo.toml` immediately after path resolution; invalid configs fail fast with a schema URL suggestion
- 8 unit tests + 2 integration tests (human + JSON mode) covering all error paths

## Test plan

- [x] `cargo test` — all 131 tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] Manual: create a valid `floo.toml` in a project dir and confirm `Loaded floo.toml — app '...', N service(s): ...` appears in human mode
- [ ] Manual: create an invalid `floo.toml` and confirm `Error: Invalid floo.toml:` + schema URL on stderr

Closes getfloo/floo-workspace#93

🤖 Generated with [Claude Code](https://claude.com/claude-code)