### PR TITLE
[Feature] [F20.4c] [#98] CLI multi-service deploy support

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use crate::config::{load_config, FlooConfig};
 use crate::errors::FlooApiError;
+use crate::project_config::ServiceConfig;
 
 pub struct FlooClient {
     client: Client,
@@ -193,6 +194,7 @@ impl FlooClient {
         tarball_path: &Path,
         runtime: &str,
         framework: Option<&str>,
+        services: Option<&[ServiceConfig]>,
     ) -> Result<Value, FlooApiError> {
         let file_bytes = std::fs::read(tarball_path).map_err(|e| {
             FlooApiError::new(0, "FILE_ERROR", format!("Failed to read archive: {e}"))
@@ -208,10 +210,21 @@ impl FlooClient {
             .mime_str("application/gzip")
             .unwrap();
 
-        let form = multipart::Form::new()
+        let mut form = multipart::Form::new()
             .part("file", file_part)
             .text("runtime", runtime.to_string())
             .text("framework", framework.unwrap_or("").to_string());
+
+        if let Some(svcs) = services {
+            let json = serde_json::to_string(svcs).map_err(|e| {
+                FlooApiError::new(
+                    0,
+                    "SERIALIZATION_ERROR",
+                    format!("Failed to serialize services: {e}"),
+                )
+            })?;
+            form = form.text("services", json);
+        }
 
         let mut req = self
             .client
@@ -417,6 +430,7 @@ impl FlooClient {
         limit: u32,
         since: Option<&str>,
         severity: Option<&str>,
+        service: Option<&str>,
     ) -> Result<Value, FlooApiError> {
         let mut path = format!("/v1/apps/{app_id}/logs?limit={limit}");
         if let Some(s) = since {
@@ -424,6 +438,9 @@ impl FlooClient {
         }
         if let Some(sev) = severity {
             path.push_str(&format!("&severity={sev}"));
+        }
+        if let Some(svc) = service {
+            path.push_str(&format!("&service={svc}"));
         }
         let resp = self.get(&path)?;
         self.handle_response(resp)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,10 @@ pub enum Commands {
         #[arg(long)]
         severity: Option<String>,
 
+        /// Filter logs to a specific service (e.g., "api", "web").
+        #[arg(long)]
+        service: Option<String>,
+
         /// Write logs to a file (JSON or plain text based on --json flag).
         #[arg(short, long)]
         output: Option<PathBuf>,
@@ -281,6 +285,7 @@ pub fn run() {
             since,
             error,
             severity,
+            service,
             output,
         } => {
             let sev = if error {
@@ -288,7 +293,14 @@ pub fn run() {
             } else {
                 severity.as_deref()
             };
-            commands::logs::logs(&app, tail, since.as_deref(), sev, output.as_deref());
+            commands::logs::logs(
+                &app,
+                tail,
+                since.as_deref(),
+                sev,
+                service.as_deref(),
+                output.as_deref(),
+            );
         }
         Commands::Version => commands::update::version(),
         Commands::Update { version } => commands::update::update(version.as_deref()),

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -192,12 +192,14 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
     let app_id = required_response_id(&app_data, "app").to_string();
 
     // Deploy
+    let services = project_config.as_ref().map(|c| c.services.as_slice());
     let spinner = output::Spinner::new("Uploading...");
     let mut deploy_data = match client.create_deploy(
         &app_id,
         &archive_path,
         &detection.runtime,
         detection.framework.as_deref(),
+        services,
     ) {
         Ok(d) => {
             spinner.finish();

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -44,6 +44,7 @@ pub fn logs(
     tail: u32,
     since: Option<&str>,
     severity: Option<&str>,
+    service: Option<&str>,
     output_path: Option<&Path>,
 ) {
     require_auth();
@@ -77,7 +78,7 @@ pub fn logs(
         }
     };
 
-    let result = match client.get_logs(app_id, tail, since, severity) {
+    let result = match client.get_logs(app_id, tail, since, severity, service) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, None);

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::errors::FlooError;
 
@@ -21,18 +21,18 @@ pub struct AppConfig {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ServiceConfig {
     pub name: String,
-    #[serde(rename = "type")]
+    #[serde(rename(deserialize = "type", serialize = "service_type"))]
     pub service_type: ServiceType,
     pub path: String,
     pub port: u16,
     pub ingress: ServiceIngress,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ServiceType {
     Web,
@@ -50,7 +50,7 @@ impl fmt::Display for ServiceType {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ServiceIngress {
     Public,
@@ -270,6 +270,25 @@ ingress = "public"
 
         let err = load_project_config(dir.path()).unwrap_err();
         assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
+    }
+
+    #[test]
+    fn test_service_config_json_serialization() {
+        let config = ServiceConfig {
+            name: "api".to_string(),
+            service_type: ServiceType::Api,
+            path: "backend".to_string(),
+            port: 8000,
+            ingress: ServiceIngress::Internal,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["name"], "api");
+        assert_eq!(json["service_type"], "api");
+        assert_eq!(json["path"], "backend");
+        assert_eq!(json["port"], 8000);
+        assert_eq!(json["ingress"], "internal");
+        // Verify "type" key is NOT present (serialized as "service_type")
+        assert!(json.get("type").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `Serialize` derives to `ServiceConfig`, `ServiceType`, `ServiceIngress` for JSON serialization
- API client sends `services` multipart form field when `floo.toml` defines services
- Deploy command wires project config services through to API
- Add `--service` flag to `logs` command for per-service log filtering
- Serde rename: TOML reads `type`, API gets `service_type`

## Test plan

- [x] 32 CLI tests pass (`cargo test`)
- [x] Clippy clean, fmt clean
- [x] Unit test verifies JSON serialization contract (`service_type` key, not `type`)
- [ ] Manual test: `floo deploy` with multi-service floo.toml
- [ ] Manual test: `floo logs --service api`

Companion PR: getfloo/floo#33 (API side)
Closes getfloo/floo-workspace#98

🤖 Generated with [Claude Code](https://claude.com/claude-code)