### PR TITLE
[Feature] [F21.4] CLI commands for GitHub integration

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -462,7 +462,7 @@ impl FlooClient {
         if let Some(b) = branch {
             body.as_object_mut()
                 .unwrap()
-                .insert("branch".to_string(), Value::String(b.to_string()));
+                .insert("default_branch".to_string(), Value::String(b.to_string()));
         }
         let resp = self.post_json(&format!("/v1/apps/{app_id}/github/connect"), &body)?;
         self.handle_response(resp)
@@ -470,10 +470,6 @@ impl FlooClient {
 
     pub fn github_disconnect(&self, app_id: &str) -> Result<(), FlooApiError> {
         let resp = self.delete(&format!("/v1/apps/{app_id}/github/disconnect"))?;
-        if resp.status().as_u16() == 200 {
-            let _ = self.handle_response(resp)?;
-            return Ok(());
-        }
         self.handle_response(resp)?;
         Ok(())
     }

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -445,4 +445,66 @@ impl FlooClient {
         let resp = self.get(&path)?;
         self.handle_response(resp)
     }
+
+    // --- GitHub ---
+
+    pub fn github_connect(
+        &self,
+        app_id: &str,
+        repo_full_name: &str,
+        installation_id: u64,
+        branch: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let mut body = serde_json::json!({
+            "repo_full_name": repo_full_name,
+            "installation_id": installation_id,
+        });
+        if let Some(b) = branch {
+            body.as_object_mut()
+                .unwrap()
+                .insert("branch".to_string(), Value::String(b.to_string()));
+        }
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/github/connect"), &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn github_disconnect(&self, app_id: &str) -> Result<(), FlooApiError> {
+        let resp = self.delete(&format!("/v1/apps/{app_id}/github/disconnect"))?;
+        if resp.status().as_u16() == 200 {
+            let _ = self.handle_response(resp)?;
+            return Ok(());
+        }
+        self.handle_response(resp)?;
+        Ok(())
+    }
+
+    // --- Releases ---
+
+    pub fn promote_app(&self, app_id: &str, tag: Option<&str>) -> Result<Value, FlooApiError> {
+        let mut body = serde_json::json!({});
+        if let Some(t) = tag {
+            body.as_object_mut()
+                .unwrap()
+                .insert("tag".to_string(), Value::String(t.to_string()));
+        }
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/promote"), &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn list_releases(
+        &self,
+        app_id: &str,
+        page: u32,
+        per_page: u32,
+    ) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!(
+            "/v1/apps/{app_id}/releases?page={page}&per_page={per_page}"
+        ))?;
+        self.handle_response(resp)
+    }
+
+    pub fn get_release(&self, app_id: &str, release_id: &str) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/releases/{release_id}"))?;
+        self.handle_response(resp)
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,20 @@ pub enum Commands {
     #[command(subcommand)]
     Domains(DomainsCommands),
 
+    /// Manage releases.
+    #[command(subcommand)]
+    Releases(ReleasesCommands),
+
+    /// Promote an app to prod by creating a GitHub release.
+    Promote {
+        /// App name or ID.
+        app: String,
+
+        /// Release tag (auto-generated if omitted).
+        #[arg(short, long)]
+        tag: Option<String>,
+    },
+
     /// View deploy history for rollback.
     #[command(subcommand)]
     Rollbacks(RollbacksCommands),
@@ -151,6 +165,32 @@ pub enum AppsCommands {
         #[arg(short, long)]
         force: bool,
     },
+
+    /// Connect a GitHub repo to an app for auto-deploy.
+    Connect {
+        /// GitHub repo (owner/repo).
+        #[arg(long)]
+        repo: String,
+
+        /// GitHub App installation ID.
+        #[arg(long)]
+        installation_id: u64,
+
+        /// App name or ID.
+        #[arg(short, long)]
+        app: String,
+
+        /// Default branch (defaults to "main").
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+
+    /// Disconnect a GitHub repo from an app.
+    Disconnect {
+        /// App name or ID.
+        #[arg(short, long)]
+        app: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -223,6 +263,26 @@ pub enum DbCommands {
 }
 
 #[derive(Subcommand)]
+pub enum ReleasesCommands {
+    /// List releases for an app.
+    List {
+        /// App name or ID.
+        #[arg(short, long)]
+        app: String,
+    },
+
+    /// Show details for a release.
+    Show {
+        /// Release ID.
+        release_id: String,
+
+        /// App name or ID.
+        #[arg(short, long)]
+        app: String,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum RollbacksCommands {
     /// List deploys available for rollback.
     List {
@@ -251,6 +311,13 @@ pub fn run() {
             AppsCommands::List => commands::apps::list(),
             AppsCommands::Status { app_name } => commands::apps::status(&app_name),
             AppsCommands::Delete { app_name, force } => commands::apps::delete(&app_name, force),
+            AppsCommands::Connect {
+                repo,
+                installation_id,
+                app,
+                branch,
+            } => commands::apps::connect(&repo, installation_id, &app, branch.as_deref()),
+            AppsCommands::Disconnect { app } => commands::apps::disconnect(&app),
         },
 
         Commands::Env(sub) => match sub {
@@ -268,6 +335,15 @@ pub fn run() {
             DomainsCommands::List { app } => commands::domains::list(&app),
             DomainsCommands::Remove { hostname, app } => commands::domains::remove(&hostname, &app),
         },
+
+        Commands::Releases(sub) => match sub {
+            ReleasesCommands::List { app } => commands::releases::list(&app),
+            ReleasesCommands::Show { release_id, app } => {
+                commands::releases::show(&release_id, &app)
+            }
+        },
+
+        Commands::Promote { app, tag } => commands::releases::promote(&app, tag.as_deref()),
 
         Commands::Rollbacks(sub) => match sub {
             RollbacksCommands::List { app } => commands::rollbacks::list(&app),

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -1,23 +1,10 @@
 use std::process;
 
-use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
 
-fn require_auth() {
-    let config = load_config();
-    if config.api_key.is_none() {
-        output::error(
-            "Not logged in.",
-            "NOT_AUTHENTICATED",
-            Some("Run 'floo login' to authenticate."),
-        );
-        process::exit(1);
-    }
-}
-
 pub fn list() {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let result = match client.list_apps(1, 20) {
         Ok(r) => r,
@@ -78,7 +65,7 @@ pub fn list() {
 }
 
 pub fn status(app_name: &str) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -132,7 +119,7 @@ pub fn status(app_name: &str) {
 }
 
 pub fn delete(app_name: &str, force: bool) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -176,7 +163,7 @@ pub fn delete(app_name: &str, force: bool) {
 }
 
 pub fn connect(repo: &str, installation_id: u64, app_name: &str, branch: Option<&str>) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -194,7 +181,7 @@ pub fn connect(repo: &str, installation_id: u64, app_name: &str, branch: Option<
         }
     };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let app_id = super::expect_str_field(&app_data, "id");
     let name = app_data
         .get("name")
         .and_then(|v| v.as_str())
@@ -207,7 +194,7 @@ pub fn connect(repo: &str, installation_id: u64, app_name: &str, branch: Option<
                 "GITHUB_ALREADY_CONNECTED" => {
                     Some("Disconnect first: floo apps disconnect --app <name>")
                 }
-                "REPO_NOT_ACCESSIBLE" => {
+                "GITHUB_REPO_NOT_ACCESSIBLE" => {
                     Some("Ensure the GitHub App is installed on the repo's organization.")
                 }
                 _ => None,
@@ -217,10 +204,7 @@ pub fn connect(repo: &str, installation_id: u64, app_name: &str, branch: Option<
         }
     };
 
-    let connected_branch = result
-        .get("default_branch")
-        .and_then(|v| v.as_str())
-        .unwrap_or("main");
+    let connected_branch = super::expect_str_field(&result, "default_branch");
 
     output::success(
         &format!("Connected {name} to {repo} (branch: {connected_branch})"),
@@ -229,7 +213,7 @@ pub fn connect(repo: &str, installation_id: u64, app_name: &str, branch: Option<
 }
 
 pub fn disconnect(app_name: &str) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -247,7 +231,7 @@ pub fn disconnect(app_name: &str) {
         }
     };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let app_id = super::expect_str_field(&app_data, "id");
     let name = app_data
         .get("name")
         .and_then(|v| v.as_str())

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -174,3 +174,92 @@ pub fn delete(app_name: &str, force: bool) {
         Some(serde_json::json!({"id": app_id})),
     );
 }
+
+pub fn connect(repo: &str, installation_id: u64, app_name: &str, branch: Option<&str>) {
+    require_auth();
+    let client = super::init_client(None);
+    let app_data = match resolve_app(&client, app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let name = app_data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(app_name);
+
+    let result = match client.github_connect(app_id, repo, installation_id, branch) {
+        Ok(r) => r,
+        Err(e) => {
+            let suggestion = match e.code.as_str() {
+                "GITHUB_ALREADY_CONNECTED" => {
+                    Some("Disconnect first: floo apps disconnect --app <name>")
+                }
+                "REPO_NOT_ACCESSIBLE" => {
+                    Some("Ensure the GitHub App is installed on the repo's organization.")
+                }
+                _ => None,
+            };
+            output::error(&e.message, &e.code, suggestion);
+            process::exit(1);
+        }
+    };
+
+    let connected_branch = result
+        .get("default_branch")
+        .and_then(|v| v.as_str())
+        .unwrap_or("main");
+
+    output::success(
+        &format!("Connected {name} to {repo} (branch: {connected_branch})"),
+        Some(result),
+    );
+}
+
+pub fn disconnect(app_name: &str) {
+    require_auth();
+    let client = super::init_client(None);
+    let app_data = match resolve_app(&client, app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let name = app_data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(app_name);
+
+    if let Err(e) = client.github_disconnect(app_id) {
+        output::error(&e.message, &e.code, None);
+        process::exit(1);
+    }
+
+    output::success(
+        &format!("Disconnected {name} from GitHub."),
+        Some(serde_json::json!({"app": name})),
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
 use std::process;
 
 use crate::api_client::FlooClient;
-use crate::config::FlooConfig;
+use crate::config::{load_config, FlooConfig};
 use crate::output;
 
 pub mod apps;
@@ -27,4 +27,27 @@ pub(crate) fn init_client(config: Option<FlooConfig>) -> FlooClient {
             process::exit(1);
         }
     }
+}
+
+pub(crate) fn require_auth() {
+    let config = load_config();
+    if config.api_key.is_none() {
+        output::error(
+            "Not logged in.",
+            "NOT_AUTHENTICATED",
+            Some("Run 'floo login' to authenticate."),
+        );
+        process::exit(1);
+    }
+}
+
+pub(crate) fn expect_str_field<'a>(data: &'a serde_json::Value, field: &str) -> &'a str {
+    data.get(field).and_then(|v| v.as_str()).unwrap_or_else(|| {
+        output::error(
+            &format!("Response missing '{field}' field."),
+            "PARSE_ERROR",
+            Some("This is a bug. Please report it."),
+        );
+        process::exit(1);
+    })
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod deploy;
 pub mod domains;
 pub mod env;
 pub mod logs;
+pub mod releases;
 pub mod rollbacks;
 pub mod update;
 

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -1,0 +1,249 @@
+use std::process;
+
+use crate::config::load_config;
+use crate::output;
+use crate::resolve::resolve_app;
+
+fn require_auth() {
+    let config = load_config();
+    if config.api_key.is_none() {
+        output::error(
+            "Not logged in.",
+            "NOT_AUTHENTICATED",
+            Some("Run 'floo login' to authenticate."),
+        );
+        process::exit(1);
+    }
+}
+
+pub fn promote(app_name: &str, tag: Option<&str>) {
+    require_auth();
+    let client = super::init_client(None);
+    let app_data = match resolve_app(&client, app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let name = app_data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(app_name);
+
+    let _spinner = output::Spinner::new(&format!("Promoting {name} to prod..."));
+
+    let result = match client.promote_app(app_id, tag) {
+        Ok(r) => r,
+        Err(e) => {
+            let suggestion = match e.code.as_str() {
+                "GITHUB_NOT_CONNECTED" => {
+                    Some("Connect a GitHub repo first: floo apps connect --repo org/repo --installation-id <id> --app <name>")
+                }
+                "NO_DEV_DEPLOY" => Some("Deploy to dev first: floo deploy --app <name>"),
+                "RELEASE_TAG_EXISTS" => Some("Use a different tag with --tag <tag>"),
+                _ => None,
+            };
+            output::error(&e.message, &e.code, suggestion);
+            process::exit(1);
+        }
+    };
+
+    let result_tag = result
+        .get("tag")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let release_url = result
+        .get("release_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if output::is_json_mode() {
+        output::success(
+            &format!("Promoted {name} → prod ({result_tag})"),
+            Some(result),
+        );
+    } else {
+        output::success(
+            &format!("Promoted {name} → prod ({result_tag})"),
+            Some(serde_json::json!({
+                "app": name,
+                "tag": result_tag,
+                "release_url": release_url,
+            })),
+        );
+        if !release_url.is_empty() {
+            output::dim_line(&format!("Release: {release_url}"));
+        }
+        output::dim_line("Deployment in progress via GitHub webhook.");
+    }
+}
+
+pub fn list(app_name: &str) {
+    require_auth();
+    let client = super::init_client(None);
+    let app_data = match resolve_app(&client, app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+
+    let result = match client.list_releases(app_id, 1, 20) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    };
+
+    let releases = result
+        .get("releases")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    if releases.is_empty() {
+        if output::is_json_mode() {
+            output::success("No releases.", Some(serde_json::json!({"releases": []})));
+        } else {
+            output::info("No releases yet. Promote with: floo promote <app>", None);
+        }
+        return;
+    }
+
+    let rows: Vec<Vec<String>> = releases
+        .iter()
+        .map(|r| {
+            let sha = r.get("commit_sha").and_then(|v| v.as_str()).unwrap_or("-");
+            let short_sha = if sha.len() > 7 { &sha[..7] } else { sha };
+            vec![
+                r.get("release_number")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| format!("#{n}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                r.get("tag")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
+                short_sha.to_string(),
+                r.get("promoted_by")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
+                r.get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
+            ]
+        })
+        .collect();
+
+    output::table(
+        &["#", "Tag", "Commit", "Promoted By", "Created"],
+        &rows,
+        Some(result),
+    );
+}
+
+pub fn show(release_id: &str, app_name: &str) {
+    require_auth();
+    let client = super::init_client(None);
+    let app_data = match resolve_app(&client, app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+
+    let release = match client.get_release(app_id, release_id) {
+        Ok(r) => r,
+        Err(e) => {
+            if e.code == "RELEASE_NOT_FOUND" {
+                output::error(
+                    &format!("Release '{release_id}' not found."),
+                    "RELEASE_NOT_FOUND",
+                    Some("Check the release ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        let tag = release
+            .get("tag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        output::success(&format!("Release {tag}"), Some(release));
+    } else {
+        let tag = release.get("tag").and_then(|v| v.as_str()).unwrap_or("-");
+        let number = release
+            .get("release_number")
+            .and_then(|v| v.as_u64())
+            .map(|n| format!("#{n}"))
+            .unwrap_or_else(|| "-".to_string());
+        let sha = release
+            .get("commit_sha")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        let promoted_by = release
+            .get("promoted_by")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        let created = release
+            .get("created_at")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        let deploy_id = release
+            .get("deploy_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        let image = release
+            .get("image_digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+
+        output::info(&format!("Release {tag} ({number})"), None);
+        output::info(&format!("  Tag:         {tag}"), None);
+        output::info(&format!("  Commit:      {sha}"), None);
+        output::info(&format!("  Promoted by: {promoted_by}"), None);
+        output::info(&format!("  Deploy ID:   {deploy_id}"), None);
+        output::info(&format!("  Image:       {image}"), None);
+        output::info(&format!("  Created:     {created}"), None);
+    }
+}

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -1,23 +1,10 @@
 use std::process;
 
-use crate::config::load_config;
 use crate::output;
 use crate::resolve::resolve_app;
 
-fn require_auth() {
-    let config = load_config();
-    if config.api_key.is_none() {
-        output::error(
-            "Not logged in.",
-            "NOT_AUTHENTICATED",
-            Some("Run 'floo login' to authenticate."),
-        );
-        process::exit(1);
-    }
-}
-
 pub fn promote(app_name: &str, tag: Option<&str>) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -35,7 +22,7 @@ pub fn promote(app_name: &str, tag: Option<&str>) {
         }
     };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let app_id = super::expect_str_field(&app_data, "id");
     let name = app_data
         .get("name")
         .and_then(|v| v.as_str())
@@ -59,23 +46,17 @@ pub fn promote(app_name: &str, tag: Option<&str>) {
         }
     };
 
-    let result_tag = result
-        .get("tag")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
-    let release_url = result
-        .get("release_url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let result_tag = super::expect_str_field(&result, "tag");
+    let release_url = super::expect_str_field(&result, "release_url");
 
     if output::is_json_mode() {
         output::success(
-            &format!("Promoted {name} → prod ({result_tag})"),
+            &format!("Promoted {name} \u{2192} prod ({result_tag})"),
             Some(result),
         );
     } else {
         output::success(
-            &format!("Promoted {name} → prod ({result_tag})"),
+            &format!("Promoted {name} \u{2192} prod ({result_tag})"),
             Some(serde_json::json!({
                 "app": name,
                 "tag": result_tag,
@@ -90,7 +71,7 @@ pub fn promote(app_name: &str, tag: Option<&str>) {
 }
 
 pub fn list(app_name: &str) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -108,7 +89,7 @@ pub fn list(app_name: &str) {
         }
     };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let app_id = super::expect_str_field(&app_data, "id");
 
     let result = match client.list_releases(app_id, 1, 20) {
         Ok(r) => r,
@@ -121,8 +102,15 @@ pub fn list(app_name: &str) {
     let releases = result
         .get("releases")
         .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
+        .unwrap_or_else(|| {
+            output::error(
+                "Failed to parse releases from API response.",
+                "PARSE_ERROR",
+                Some("This is a bug. Please report it."),
+            );
+            process::exit(1);
+        })
+        .clone();
 
     if releases.is_empty() {
         if output::is_json_mode() {
@@ -137,7 +125,11 @@ pub fn list(app_name: &str) {
         .iter()
         .map(|r| {
             let sha = r.get("commit_sha").and_then(|v| v.as_str()).unwrap_or("-");
-            let short_sha = if sha.len() > 7 { &sha[..7] } else { sha };
+            let short_sha = if sha.len() > 7 && sha.is_ascii() {
+                &sha[..7]
+            } else {
+                sha
+            };
             vec![
                 r.get("release_number")
                     .and_then(|v| v.as_u64())
@@ -168,7 +160,7 @@ pub fn list(app_name: &str) {
 }
 
 pub fn show(release_id: &str, app_name: &str) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -186,7 +178,7 @@ pub fn show(release_id: &str, app_name: &str) {
         }
     };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let app_id = super::expect_str_field(&app_data, "id");
 
     let release = match client.get_release(app_id, release_id) {
         Ok(r) => r,


### PR DESCRIPTION
## Summary

Implements F21.4 — CLI commands for GitHub integration:

- `floo apps connect --repo org/repo --installation-id <id> --app <name> [--branch develop]` — link app to GitHub repo
- `floo apps disconnect --app <name>` — unlink GitHub repo
- `floo promote <app> [--tag v1.0.0]` — promote app to prod via GitHub release
- `floo releases list --app <app>` — list releases (paginated table)
- `floo releases show <id> --app <app>` — release detail view

All commands support `--json` mode. Error handling includes specific suggestions for common errors (GITHUB_NOT_CONNECTED, NO_DEV_DEPLOY, RELEASE_TAG_EXISTS, etc.).

Depends on API PR: https://github.com/getfloo/floo/pull/41

Closes getfloo/floo-workspace#127

## Changes

- `api_client.rs`: 5 new methods (github_connect, github_disconnect, promote_app, list_releases, get_release)
- `cli.rs`: New subcommands (Connect, Disconnect under Apps; Releases; Promote top-level)
- `commands/releases.rs`: New module with promote, list, show
- `commands/apps.rs`: New connect/disconnect functions
- `commands/mod.rs`: Shared `require_auth()` and `expect_str_field()` helpers

Code review fixes applied:
- Fixed critical field name bug (`"default_branch"` not `"branch"`) in github_connect
- Fixed error code mismatch (`GITHUB_REPO_NOT_ACCESSIBLE`)
- Extracted shared helpers to eliminate duplication
- Replaced silent fallbacks with explicit parse errors (fail loudly)
- Added ASCII guard on SHA slicing

## Test plan

- [x] 32 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Code review: all findings from code-reviewer and silent-failure-hunter addressed
- [ ] Manual test: `floo apps connect/disconnect` with real GitHub App
- [ ] Manual test: `floo promote` → verify release created → deploy triggered


🤖 Generated with [Claude Code](https://claude.com/claude-code)