### PR TITLE
[Chore] Update issue tracker references for 2-repo structure

### DIFF
--- a/.claude/hooks/evaluate-skills.sh
+++ b/.claude/hooks/evaluate-skills.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# evaluate-skills.sh — UserPromptSubmit hook
+# Forces the coding agent to evaluate all skills and activate relevant ones.
+# Outputs additionalContext before processing the user's prompt.
+
+cat <<'SKILLS_CONTEXT'
+## Skill Evaluation Protocol
+
+Before proceeding with this task, evaluate each skill below. For each one, decide YES or NO based on whether the task involves that domain. Then activate the relevant skills by reading their SKILL.md files.
+
+### Background Skills (auto-activate when relevant)
+
+1. **rust** (`.claude/skills/rust/SKILL.md`)
+   Activate: YES if the task touches Rust code, CLI commands, output module, API client, or any file in `src/`.
+   - Adding new CLI commands → must support `--json` mode, use output contract
+   - Working with errors → use correct error type (FlooError vs FlooApiError vs anyhow)
+   - Adding error codes → add to the Error Code Reference table in the skill
+
+2. **workflow** (`.claude/skills/workflow/SKILL.md`)
+   Activate: YES if the task is any non-trivial implementation (new command, bug fix, or chore). Provides worktree setup, plan structure, execution steps, code review checklist, and PR process. NOT needed for pure questions, exploration, or docs-only changes.
+
+### Protocol
+
+1. **Evaluate:** For each skill, output a one-line `[skill]: YES/NO — reason`.
+2. **Activate:** For each YES skill, read its SKILL.md file. The rules in those files override general conventions for their domain.
+3. **Implement:** Proceed with the task, following all activated skill rules.
+
+If no skills are relevant (e.g., git operations, docs-only changes, general questions), skip activation and proceed normally.
+
+### Worktree Preflight Protocol
+
+Before any mutating action (file edits, git commits, branch changes), include:
+1. `Worktree path: <path>` under `.claude/worktrees/<name>/`
+2. `Main checkout untouched: yes`
+
+If not already in a worktree, create one first with `EnterWorktree "<name>"`. Never implement feature work directly in the main checkout.
+Worktree names use `-` instead of `/` (e.g., `feat/add-rollback` → `.claude/worktrees/feat-add-rollback/`).
+
+### Response Contract (Coding Tasks)
+
+For coding tasks, include a short preflight block at the start of responses:
+- `Skills evaluated: ...`
+- `Skills activated: ...`
+- `Worktree path: ...`
+- `Main checkout untouched: yes/no`
+
+### Post-Implementation Protocol
+
+After completing implementation work, follow the Code Review Checklist and PR process in the `workflow` skill.
+SKILLS_CONTEXT

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/evaluate-skills.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/rust/SKILL.md
+++ b/.claude/skills/rust/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: rust
+description: Detailed coding rules for Floo CLI Rust code.
+user-invocable: false
+---
+
+# Rust / CLI Coding Skill
+
+> Rules for writing Rust code in the Floo CLI (`floo-cli/src/`). These rules are the detailed expansion of `CLAUDE.md`. When this skill is active, follow every rule below.
+
+## Scope
+
+This skill applies to all Rust files in `floo-cli/`. The API is Python — see the `python` skill for API work.
+
+---
+
+## Architecture
+
+```
+main.rs                     <- Entry point, calls cli::run()
+cli.rs                      <- clap App with derive macros, global --json and --version flags
+commands/                   <- One file per command group
+  auth.rs                   <- login, logout, whoami
+  deploy.rs                 <- deploy command
+  apps.rs                   <- list, status, delete
+  env.rs                    <- set, list, remove
+  domains.rs                <- add, list, remove
+  logs.rs                   <- view runtime logs
+output.rs                   <- Dual-mode output (critical)
+api_client.rs               <- FlooClient wrapping reqwest
+config.rs                   <- ~/.floo/config.json management
+detection.rs                <- Runtime/framework auto-detection
+archive.rs                  <- .tar.gz packing with .flooignore
+names.rs                    <- Random app name generation
+resolve.rs                  <- resolve_app() — lookup by UUID or name
+errors.rs                   <- FlooError + FlooApiError
+```
+
+### Global flags
+
+The clap App defines two global flags:
+- `--json` — enables JSON output mode (sets `output::JSON_MODE` atomic bool)
+- `--version` — prints version and exits
+
+Every command must work correctly in both human and JSON output modes.
+
+---
+
+## Output Contract (`output.rs`) — CRITICAL
+
+This is the most important module in the CLI. It enforces the dual-mode output pattern.
+
+### The rule
+
+- **Colored output** (spinners, tables, progress) → **stderr**
+- **JSON output** → **stdout**
+
+This makes `floo deploy --json 2>/dev/null | jq` work for agents.
+
+### Global mode
+
+`JSON_MODE` is an `AtomicBool`. Set once at startup via `set_json_mode()`. Checked by every output function.
+
+### Functions
+
+| Function | Human mode (stderr) | JSON mode (stdout) |
+|----------|--------------------|--------------------|
+| `success(msg, data)` | `"[check] {msg}"` in green | `{"success": true, "data": data}` |
+| `error(msg, code, suggestion)` | `"Error: {msg}\n  -> {suggestion}"` | `{"success": false, "error": {...}}` |
+| `info(msg)` | `"{msg}"` to stderr | `{"success": true, "data": null}` |
+| `table(headers, rows)` | Formatted table to stderr | N/A (use success with data) |
+| `print_json(value)` | N/A | Writes JSON to stdout |
+
+### Spinner
+
+`Spinner` struct with RAII `Drop` trait. Created via `Spinner::new("message")`. Writes to stderr. Auto-clears on drop. In JSON mode, spinners are no-ops.
+
+### CRITICAL: `info()` in JSON mode emits `{"success": true, "data": null}`
+
+If a command calls `info()` then later calls `success()` with real data, stdout has TWO JSON objects — breaking agent parsing.
+
+**Fix:** Guard informational `info()` calls:
+```rust
+if !is_json_mode() {
+    info("Processing...");
+}
+// ... later ...
+success("Done", &data);
+```
+
+---
+
+## Error Handling (`errors.rs`)
+
+### `FlooError`
+
+```rust
+pub struct FlooError {
+    pub code: String,
+    pub message: String,
+    pub suggestion: Option<String>,
+}
+```
+
+Uses `thiserror` derive. Constructors use `impl Into<String>` for ergonomics:
+
+```rust
+impl FlooError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self { ... }
+    pub fn with_suggestion(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        suggestion: impl Into<String>,
+    ) -> Self { ... }
+}
+```
+
+### `FlooApiError`
+
+```rust
+pub struct FlooApiError {
+    pub status_code: u16,
+    pub code: String,
+    pub message: String,
+}
+```
+
+Returned when the API returns an error response. The `FlooClient` converts API error JSON into this type.
+
+### Rules
+
+- Use `?` operator, never `unwrap()` in production paths
+- `unwrap()` is only acceptable in tests and `#[allow(dead_code)]` development stubs
+- Library functions (archive, detection, resolve) return `Result<T, FlooError>`
+- Command functions return `()` and use `output::error()` + `process::exit(1)` on failure
+- Use `FlooError::new("CODE", "message")` or `FlooError::with_suggestion("CODE", "message", "try this")` for user-facing errors in library functions
+
+---
+
+## API Client (`api_client.rs`)
+
+### `FlooClient`
+
+All HTTP calls go through `FlooClient`. Never use `reqwest` directly in commands.
+
+```rust
+pub struct FlooClient {
+    client: reqwest::blocking::Client,
+    base_url: String,
+    api_key: Option<String>,
+}
+```
+
+### Rules
+
+- `handle_response()` converts API error JSON to `FlooApiError`
+- Auth header injected from config automatically
+- Default timeout: 30s. Deploy upload timeout: 300s
+- Base URL from config, overridable via `FLOO_API_URL` env var
+
+### Multipart Uploads
+
+Deploy uses `reqwest::blocking::multipart::Form` with `Part::bytes()`:
+
+```rust
+let file_part = multipart::Part::bytes(file_bytes)
+    .file_name(file_name)
+    .mime_str("application/gzip")
+    .unwrap();
+let form = multipart::Form::new()
+    .part("file", file_part)
+    .text("runtime", runtime.to_string())
+    .text("framework", framework.unwrap_or("").to_string());
+```
+
+Upload requests use a 300s timeout (vs 30s default) to handle large tarballs.
+
+---
+
+## Config (`config.rs`)
+
+Manages `~/.floo/config.json`:
+
+```json
+{
+  "api_key": "floo_...",
+  "user_email": "user@example.com",
+  "api_url": "https://api.getfloo.com"
+}
+```
+
+- File permissions set to `0o600`
+- `FLOO_API_URL` env var overrides stored URL
+- Never hardcode the API URL in commands
+
+---
+
+## Detection (`detection.rs`)
+
+Auto-detects runtime and framework from project files.
+
+Priority order: `Dockerfile` > `package.json` > `pyproject.toml`/`requirements.txt` > `go.mod` > `index.html`
+
+Returns `DetectionResult { runtime, framework, confidence }` where confidence is `"high"`, `"medium"`, or `"low"`.
+
+---
+
+## Archive (`archive.rs`)
+
+Packs source into `.tar.gz`, respects `.flooignore` (fnmatch-style patterns).
+
+Built-in ignores: `.git`, `node_modules`, `__pycache__`, `.venv`, `.env`, `target/`, etc.
+
+500MB size limit. Returns `FlooError` with code `ARCHIVE_TOO_LARGE` if exceeded.
+
+---
+
+## Constants (`constants.rs`)
+
+Shared constants live in `constants.rs`:
+
+```rust
+pub const DEFAULT_API_URL: &str = "https://api.getfloo.com";
+pub const CONFIG_DIR_NAME: &str = ".floo";
+pub const CONFIG_FILE_NAME: &str = "config.json";
+pub const MAX_ARCHIVE_SIZE_MB: u64 = 500;
+pub const VERSION: &str = env!("FLOO_VERSION");  // Set by build.rs
+```
+
+New constants go here. Never hardcode values in command files.
+
+---
+
+## Interactive Prompts
+
+Commands use `dialoguer` for user input:
+
+```rust
+use dialoguer::{Input, Password};
+
+let email: String = Input::new()
+    .with_prompt("Email")
+    .interact_text()
+    .unwrap_or_else(|_| process::exit(1));
+
+let password: String = Password::new()
+    .with_prompt("Password")
+    .interact()
+    .unwrap_or_else(|_| process::exit(1));
+```
+
+Confirmations use `output::confirm()`:
+
+```rust
+if !output::confirm("Delete app? This cannot be undone.") {
+    process::exit(0);
+}
+```
+
+Commands use `process::exit(1)` on errors — they don't return `Result`. The pattern is: display error via `output::error()`, then `process::exit(1)`.
+
+---
+
+## `anyhow` vs `FlooError`
+
+- **`anyhow::Result`** — only in `config.rs` for low-level IO operations (file read/write, JSON parse). These are internal errors not shown to users.
+- **`FlooError`** — for user-facing errors that need a code and suggestion. Used in `archive.rs`, `detection.rs`, and similar modules.
+- **Commands** — return `()` and use `process::exit(1)` after `output::error()`. Commands do NOT return `Result`.
+- **`FlooApiError`** — returned by `FlooClient` methods. Commands match on this to show API error messages.
+
+```rust
+// In a command function:
+match client.list_apps(1, 20) {
+    Ok(data) => output::success("Apps retrieved.", &data),
+    Err(e) => {
+        output::error(&e.message, &e.code, None);
+        process::exit(1);
+    }
+}
+```
+
+---
+
+## Patterns
+
+### Constructor ergonomics
+
+Use `impl Into<String>` for string parameters:
+
+```rust
+pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+    Self {
+        code: code.into(),
+        message: message.into(),
+    }
+}
+```
+
+### Optional parameters
+
+Use `Option<&str>` for optional string params:
+
+```rust
+pub fn create_app(&self, name: Option<&str>) -> Result<Value, FlooApiError> { ... }
+```
+
+### Partial updates
+
+Use `HashMap<String, String>` for update payloads:
+
+```rust
+let mut updates = HashMap::new();
+updates.insert("name".to_string(), new_name.to_string());
+```
+
+### JSON building
+
+Use `serde_json::json!` macro:
+
+```rust
+let body = json!({
+    "name": name,
+    "runtime": runtime,
+});
+```
+
+### Resolve (`resolve.rs`)
+
+`resolve_app()` looks up an app by UUID or name. Used by commands that accept an app identifier.
+
+---
+
+## Testing
+
+### Unit tests
+
+Inline per file with `#[cfg(test)] mod tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = FlooError::new("TEST", "test message");
+        assert_eq!(err.to_string(), "test message");
+    }
+}
+```
+
+### Integration tests
+
+Use `assert_cmd` crate. Tests run the compiled binary as a subprocess.
+
+### JSON mode state leak
+
+The `JSON_MODE` global `AtomicBool` persists across tests run in the same process. Always reset at the start of each test:
+
+```rust
+output::set_json_mode(false);
+```
+
+---
+
+## Style
+
+### Tooling
+
+| Tool | Purpose | Command |
+|------|---------|---------|
+| **clippy** | Lint | `cargo clippy -- -D warnings` |
+| **cargo fmt** | Format | `cargo fmt --check` |
+| **cargo test** | Tests | `cargo test` |
+
+### Installer smoke checks (when installer/update paths change)
+
+If a change touches `install.sh`, updater code, or release-asset wiring, also run:
+
+```bash
+cd /path/to/floo-cli && bash -n install.sh
+cd /path/to/floo-cli && bash tests/install_script_test.sh
+cd /path/to/floo-cli && bash tests/install_script_e2e.sh
+```
+
+This remains required even when CI is manual-only (`workflow_dispatch`).
+
+### No dead code warnings
+
+Use `#[allow(dead_code)]` sparingly and only during development. Remove before merging.
+
+---
+
+## Forbidden
+
+- `println!` — use `output` module functions. The only exception is `output::print_json` which writes JSON to stdout.
+- `unwrap()` in production paths — use `?` operator or explicit error handling
+- `unsafe` without documented justification
+- Direct `reqwest` calls outside `FlooClient`
+- Hardcoded API URLs — use config or `FLOO_API_URL` env var
+- `#[allow(dead_code)]` in merged code (development only)
+
+---
+
+## Known Pitfalls
+
+### `output::info()` emits JSON in `--json` mode
+
+`info(message)` outputs `{"success": true, "data": null}` to stdout in JSON mode. If a command later calls `success()` with real data, stdout has two JSON objects — breaking agents.
+
+**Fix:** Guard with `if !is_json_mode() { info("..."); }` when the command has a final `success()`.
+
+### JSON_MODE global state leaks between tests
+
+The `AtomicBool` persists across test functions. Always call `output::set_json_mode(false)` at the start of every test.
+
+---
+
+## Error Code Reference
+
+All error codes used in the CLI. New error codes must be `UPPER_SNAKE_CASE` and added to this list.
+
+| Code | Source | Meaning |
+|------|--------|---------|
+| `NOT_AUTHENTICATED` | commands | No API key configured (login required) |
+| `INVALID_PATH` | commands/deploy | Deploy path doesn't exist or isn't a directory |
+| `NO_RUNTIME_DETECTED` | commands/deploy | Detection couldn't identify a runtime |
+| `ARCHIVE_TOO_LARGE` | archive.rs | Source archive exceeds `MAX_ARCHIVE_SIZE_MB` |
+| `ARCHIVE_ERROR` | archive.rs | Failed to create/read archive |
+| `INVALID_FORMAT` | commands | Invalid hostname, app name, or other input format |
+| `APP_NOT_FOUND` | commands | App lookup by name/UUID returned nothing |
+| `DEPLOY_NOT_FOUND` | API (404) | Deploy ID not found for app |
+| `INVALID_ROLLBACK_TARGET` | API (400) | Rollback target deploy is not LIVE |
+| `ROLLBACK_IMAGE_MISSING` | API (400) | Rollback target missing stored image URI |
+| `DEPLOY_TIMEOUT` | commands/deploy | Deploy polling exceeded 10-minute timeout |
+| `DEPLOY_FAILED` | commands/deploy | Deploy completed but status is FAILED |
+| `CONFIG_ERROR` | config.rs | Failed to read/write config file |
+| `CONNECTION_ERROR` | api_client.rs | HTTP request failed (network issue) |
+| `FILE_ERROR` | api_client.rs | Failed to read file for upload |
+| `PARSE_ERROR` | api_client.rs | Failed to parse API response JSON |
+| `API_ERROR` | api_client.rs | Generic API error (unrecognized error format) |
+| `LOGS_UNAVAILABLE` | API (503) | GCP project not configured (logs require Cloud Run) |
+| `LOGS_QUERY_ERROR` | API (400) | Logs query validation error (bad severity/since) |
+| `LOGS_SERVICE_ERROR` | API (502) | Cloud Logging backend failure |
+| `SERIALIZATION_ERROR` | api_client.rs | Failed to serialize service definitions to JSON |
+| `UNSUPPORTED_PLATFORM` | updater/install | Host OS/arch is not supported for auto-install/update |
+| `RELEASE_LOOKUP_FAILED` | updater | Release metadata lookup failed or returned non-200 |
+| `RELEASE_PARSE_ERROR` | updater | Failed to parse release metadata JSON |
+| `RELEASE_ASSET_MISSING` | updater | Expected binary asset not present in release |
+| `CHECKSUM_MISSING` | updater/install | Expected checksum asset/file not present |
+| `CHECKSUM_PARSE_ERROR` | updater | Checksum file exists but did not contain a valid hash |
+| `CHECKSUM_MISMATCH` | updater/install | Downloaded binary hash does not match published checksum |
+| `DOWNLOAD_FAILED` | updater/install | Binary or checksum download failed |
+| `UPDATE_HTTP_CLIENT_ERROR` | updater | Failed to initialize HTTP client for update checks |
+| `UPDATE_INSTALL_PATH_UNRESOLVED` | updater | Could not resolve currently installed CLI path |
+| `UPDATE_PERMISSION_DENIED` | updater | No permission to replace installed binary |
+| `UPDATE_INSTALL_FAILED` | updater | Generic failure writing or replacing updated binary |
+| `DEVICE_PENDING` | api_client.rs | Device code flow — authorization still pending (HTTP 202) |
+| `DEVICE_CODE_EXPIRED` | API (410) | Device code flow — device code timed out |
+| `DEVICE_AUTH_DENIED` | API (403) | Device code flow — user denied authorization |
+| `DEVICE_AUTH_FAILED` | API (502) | Device code flow — WorkOS backend failure |
+| `EMAIL_TAKEN` | API (409) | Registration — email already in use |
+| `PERMISSION_DENIED` | API (403) | User has VIEWER role; write action denied |
+| `INVALID_PROJECT_CONFIG` | project_config.rs | Malformed or invalid `floo.toml` |

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: workflow
+description: Full task workflow — issue tracking, worktrees, implementation, verification, PR, and plan structure.
+user-invocable: false
+---
+
+# Workflow Skill
+
+> End-to-end task process for floo-cli development. Activates for any non-trivial implementation task. When this skill is active, follow every rule below.
+
+## When to Activate
+
+- Any implementation task: new command, bug fix, refactor, or chore
+- Any task entering plan mode (3+ steps, architecture decisions, multi-file changes)
+- NOT for pure questions, exploration, or docs-only changes
+
+---
+
+## Plan Structure
+
+Every plan for a non-trivial task MUST start with these sections before technical details.
+
+### Required Worktree Section
+
+Every plan — features AND bug fixes — MUST include this section.
+
+```
+## Worktree
+
+| Branch | Worktree Path |
+|--------|---------------|
+| `fix/20-url-encoding` | `.claude/worktrees/fix-20-url-encoding/` |
+```
+
+Branch naming: `feat/<id>-short-desc` or `fix/<id>-short-desc`. The worktree name uses `-`
+instead of `/` (e.g., `feat/add-rollback` → `feat-add-rollback`); `EnterWorktree` handles
+this naturally via its `name` parameter.
+This section is filled in during planning (before approval), not during execution.
+
+### Required Feature Scope Section (features only)
+
+For any task that adds new functionality, include this section before technical details.
+Skip for pure bug fixes and refactors (but Worktree is still required).
+
+```
+## Feature Scope
+
+### Problem Statement
+[What user problem does this solve? Why now? 2-3 sentences max.]
+
+### What Changes for Users
+[Concrete description — new commands, flags, output changes. Describe the experience.]
+
+### Acceptance Criteria
+- [ ] [Testable criterion — what must be true when done]
+- [ ] ...
+
+### Out of Scope
+[What this does NOT include. Prevents scope creep.]
+```
+
+---
+
+## Issue-Driven Workflow
+
+CLI issues live in `getfloo/floo-cli` (this repo). API/infra issues live in `getfloo/floo`.
+
+Before starting any task:
+
+1. **Find the issue.** The user will provide the issue number, or query:
+   `gh issue list --label "v0" --state open`
+2. **Claim it.** Add the `status:in-progress` label:
+   `gh issue edit <n> --add-label "status:in-progress"`
+3. **Close it via PR.** The PR body must include `Closes #<n>` — GitHub auto-closes on merge.
+   For cross-repo issues, use `Closes getfloo/floo#<n>`.
+
+**Label taxonomy:**
+- **Type:** `type:bug` · `type:feature` · `type:chore` · `type:docs`
+- **Release:** `v0` (launch target) · `v1` (post-launch)
+- **Priority:** `priority:critical` · `priority:high` · `priority:medium` · `priority:low`
+- **Component:** `component:cli`
+- **Status:** `status:in-progress` (agent actively working) · `status:blocked` (waiting on dependency)
+
+---
+
+## Git Worktree Workflow
+
+**ALWAYS use git worktrees for feature development.** Never commit feature work directly on
+`main`. Multiple features may be developed in parallel, so `main` must stay clean. Worktrees
+live under `.claude/worktrees/` (gitignored) — Claude Code's native path.
+
+```bash
+# 0. Preflight: pull latest main
+git checkout main && git pull
+
+# 1. Create worktree — Claude Code creates worktree, switches session CWD
+EnterWorktree "fix-20-url-encoding"
+```
+
+---
+
+## Execution Steps (after plan approval)
+
+**0. Claim the issue.** `gh issue edit <n> --add-label "status:in-progress"`
+
+**1. Create worktree.** Create the branch and worktree exactly as declared in the plan's
+Worktree table. Use `EnterWorktree "<name>"` to create the worktree and switch the session
+CWD. Work exclusively in `.claude/worktrees/<name>/` — never the main checkout.
+
+**2. Implement.** Write code following all CLAUDE.md conventions and activated skill rules.
+Commit incrementally with conventional commits (`feat:`, `fix:`, `test:`, etc.).
+
+**Bug handling:** Small-to-medium bugs → fix directly and note in the commit message. Larger
+bugs (security issues, scope beyond the current task) → file a GitHub issue and reference it
+in the PR body. Do not expand scope mid-implementation; file the issue and keep going.
+
+**3. Verify (MANDATORY — never skip).** Run ALL checks. Every single check must pass.
+No exceptions, no "I'll run them later", no skipping because "the change is small."
+
+```bash
+cargo test && cargo clippy -- -D warnings && cargo fmt --check
+```
+
+When in doubt, run more tests rather than fewer. Skipping tests that should have been run is
+a serious error.
+
+**4. Review (MANDATORY — never skip).** Run `pr-review-toolkit:code-reviewer` and
+`pr-review-toolkit:silent-failure-hunter` in parallel on the diff. Fix ALL findings —
+every single one, regardless of severity. Then re-run Step 3 (all tests must still pass).
+Run the Code Review Checklist below.
+
+**5. PR (MANDATORY).** Push the branch and open a PR — this is required to close the loop on
+every task.
+
+```
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+Closes #<issue-number>
+
+## Changes
+<files changed and why>
+
+## Test plan
+- [ ] <test scenarios run>
+
+## Discovered issues
+<list issue links filed during implementation, or "None">
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**6. Update project memory.** If any corrections, surprises, or new patterns emerged:
+update MEMORY.md or the relevant skill file so the same mistake doesn't recur.
+
+---
+
+## Code Review Checklist
+
+After completing any implementation task, run this checklist before committing. Not optional.
+
+**Correctness (build phase — check every item):**
+- [ ] No fallback values (`unwrap_or_default`, `unwrap_or("")`) on paths that should always succeed
+- [ ] No bare `catch`/`match` arms that eat errors silently — every error must propagate via `?` or return a typed `Err`
+- [ ] Failures propagate to the caller — non-zero exit, `Err(...)` — never silently succeed with wrong data
+
+**Tests & Quality:**
+- [ ] All tests pass (`cargo test`)
+- [ ] Lint is clean (`cargo clippy -- -D warnings`)
+- [ ] Format is clean (`cargo fmt --check`)
+- [ ] New commands have tests covering: happy path, auth errors, not found
+
+**Style & Conventions:**
+- [ ] No `println!` — use `output` module functions
+- [ ] No `unwrap()` in production paths — use `?` operator
+- [ ] `--json` works on any new/modified command
+- [ ] Error codes are UPPER_SNAKE_CASE and added to the reference list
+
+**Security:**
+- [ ] No hardcoded secrets, URLs, or API keys
+- [ ] All HTTP calls via `FlooClient`, never direct `reqwest`
+- [ ] Input validation on all user-facing parameters
+
+**Architecture:**
+- [ ] Changes follow the patterns in the activated skill(s)
+- [ ] No new patterns introduced that conflict with existing conventions
+- [ ] If a convention changed, the relevant skill was updated too
+
+**Before creating a PR:** Run `pr-review-toolkit:code-reviewer` and
+`pr-review-toolkit:silent-failure-hunter` in parallel on the diff. Fix ALL findings.
+Re-run all tests after fixes.
+
+---
+
+## Orchestration Principles
+
+**Plan Mode:** Enter plan mode for any non-trivial task (3+ steps, architecture decisions,
+multi-file changes). If implementation goes sideways, STOP and re-plan — don't keep pushing.
+
+**Subagent Strategy:** Offload research, exploration, and parallel analysis to subagents.
+Use Explore for codebase discovery, Plan for design, pr-review-toolkit agents before every PR.
+One focused task per subagent. Keep the main context window clean.
+
+**Verification Before Done:** Never mark a task complete without proving it works. Run tests,
+check logs, demonstrate correctness. Ask: "Would a staff engineer approve this?"
+
+**Self-Improvement Loop:** After any correction from the user, update MEMORY.md or the
+relevant skill file with the pattern so the same mistake doesn't recur.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,10 @@
 - <1-3 bullet points>
 
 ## Issue Closure (Required)
-Closes getfloo/floo-workspace#<issue-number>
+Closes #<issue-number>
 
 If this PR should not close an issue, write `N/A` and explain why in one sentence.
-Do not use bare references like `Closes #123` in this repo.
+For cross-repo issues, use `Closes getfloo/floo#N`.
 
 ## Changes
 - <files changed and why>

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ Thumbs.db
 .env
 .env.*
 
-# Claude Code local settings
-.claude/
+# Claude Code
+.claude/settings.local.json
+.claude/worktrees/
+.claude/todos/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,10 @@ Packs source into `.tar.gz`, respects `.flooignore`. 500MB size limit.
 - No hardcoded API URLs — use config or `FLOO_API_URL` env var
 - Unit tests inline (`#[cfg(test)] mod tests`), integration tests in `tests/`
 - Reset `output::set_json_mode(false)` at the start of every test (global state leaks)
-- Issue tracker source of truth: `getfloo/floo-workspace` (do not leave active issues in `getfloo/floo-cli`)
+- Issue tracker: CLI issues live in `getfloo/floo-cli` (this repo). API/infra issues live in `getfloo/floo`.
 - PR closure language is mandatory for issue-driven work:
-  - Use fully-qualified references, e.g. `Closes getfloo/floo-workspace#46`
-  - Do not use bare `Closes #46` in this repo
+  - CLI issues: `Closes #N` (same-repo reference)
+  - Cross-repo issues: `Closes getfloo/floo#N`
 
 ## Release Flow
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md and PR template to reflect that CLI issues now live in `getfloo/floo-cli` instead of `getfloo/floo-workspace`
- Part of the workspace consolidation (floo-workspace archived, issues transferred)

## Changes
- `CLAUDE.md`: Issue tracker section now points to `getfloo/floo-cli` for CLI issues, `getfloo/floo` for API/infra
- `.github/PULL_REQUEST_TEMPLATE.md`: `Closes #N` for same-repo, `Closes getfloo/floo#N` for cross-repo

## Test plan
- [x] No code changes — docs only

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)