### PR TITLE
[Feature] [#34] Rework logs command with multi-service, live, and search

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,8 +91,9 @@ pub enum Commands {
 
     /// View runtime logs for an app.
     Logs {
-        /// App name or ID.
-        app: String,
+        /// App name or ID (overrides config file).
+        #[arg(short, long)]
+        app: Option<String>,
 
         /// Number of log lines to show.
         #[arg(short, long, default_value = "100")]
@@ -110,9 +111,17 @@ pub enum Commands {
         #[arg(long)]
         severity: Option<String>,
 
-        /// Filter logs to a specific service (e.g., "api", "web").
+        /// Filter logs to specific services (repeatable).
         #[arg(long)]
-        service: Option<String>,
+        services: Vec<String>,
+
+        /// Filter log messages by text (case-insensitive).
+        #[arg(long)]
+        search: Option<String>,
+
+        /// Stream logs in real-time (poll every 2s).
+        #[arg(short = 'f', long, conflicts_with = "output")]
+        live: bool,
 
         /// Write logs to a file (JSON or plain text based on --json flag).
         #[arg(short, long)]
@@ -361,7 +370,9 @@ pub fn run() {
             since,
             error,
             severity,
-            service,
+            services,
+            search,
+            live,
             output,
         } => {
             let sev = if error {
@@ -370,11 +381,13 @@ pub fn run() {
                 severity.as_deref()
             };
             commands::logs::logs(
-                &app,
+                app.as_deref(),
                 tail,
                 since.as_deref(),
                 sev,
-                service.as_deref(),
+                &services,
+                search.as_deref(),
+                live,
                 output.as_deref(),
             );
         }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -1,34 +1,32 @@
 use std::path::Path;
 use std::process;
+use std::thread;
+use std::time::Duration;
 
 use colored::Colorize;
 
-use crate::config::load_config;
 use crate::output;
+use crate::project_config::{self, AppSource};
 use crate::resolve::resolve_app;
 
-fn require_auth() {
-    let config = load_config();
-    if config.api_key.is_none() {
-        output::error(
-            "Not logged in.",
-            "NOT_AUTHENTICATED",
-            Some("Run 'floo login' to authenticate."),
-        );
-        process::exit(1);
-    }
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+const MAX_TRANSIENT_RETRIES: u32 = 3;
+
+struct LogsFilter<'a> {
+    since: Option<&'a str>,
+    severity: Option<&'a str>,
+    services: &'a [String],
+    search: Option<&'a str>,
 }
 
-fn format_log_line(entry: &serde_json::Value) -> String {
-    let ts = entry
-        .get("timestamp")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let sev = entry
-        .get("severity")
-        .and_then(|v| v.as_str())
-        .unwrap_or("DEFAULT");
-    let msg = entry.get("message").and_then(|v| v.as_str()).unwrap_or("");
+fn extract_field<'a>(entry: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    entry.get(key).and_then(|v| v.as_str())
+}
+
+fn format_log_line(entry: &serde_json::Value, show_service_prefix: bool) -> String {
+    let ts = extract_field(entry, "timestamp").unwrap_or("");
+    let sev = extract_field(entry, "severity").unwrap_or("DEFAULT");
+    let msg = extract_field(entry, "message").unwrap_or("");
     let colored_sev = match sev {
         "ERROR" | "CRITICAL" => sev.red().bold().to_string(),
         "WARNING" => sev.yellow().to_string(),
@@ -36,19 +34,205 @@ fn format_log_line(entry: &serde_json::Value) -> String {
         "DEBUG" => sev.dimmed().to_string(),
         _ => sev.to_string(),
     };
-    format!("{ts} [{colored_sev}] {msg}")
+
+    if show_service_prefix {
+        let service = extract_field(entry, "service_name").unwrap_or("unknown");
+        let colored_service = format!("[{}]", service).blue().bold().to_string();
+        format!("{colored_service} {ts} [{colored_sev}] {msg}")
+    } else {
+        format!("{ts} [{colored_sev}] {msg}")
+    }
 }
 
+fn format_log_line_plain(entry: &serde_json::Value, show_service_prefix: bool) -> String {
+    let ts = extract_field(entry, "timestamp").unwrap_or("");
+    let sev = extract_field(entry, "severity").unwrap_or("DEFAULT");
+    let msg = extract_field(entry, "message").unwrap_or("");
+
+    if show_service_prefix {
+        let svc = extract_field(entry, "service_name").unwrap_or("unknown");
+        format!("[{svc}] {ts} [{sev}] {msg}")
+    } else {
+        format!("{ts} [{sev}] {msg}")
+    }
+}
+
+fn apply_search_filter(entries: Vec<serde_json::Value>, search: &str) -> Vec<serde_json::Value> {
+    let needle = search.to_lowercase();
+    entries
+        .into_iter()
+        .filter(|entry| {
+            extract_field(entry, "message")
+                .map(|msg| msg.to_lowercase().contains(&needle))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+fn fetch_logs(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    tail: u32,
+    filter: &LogsFilter,
+) -> Vec<serde_json::Value> {
+    if filter.services.len() <= 1 {
+        let service = filter.services.first().map(|s| s.as_str());
+        let result = match client.get_logs(app_id, tail, filter.since, filter.severity, service) {
+            Ok(r) => r,
+            Err(e) => {
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
+        };
+        parse_logs_array(&result)
+    } else {
+        let mut all_logs = Vec::new();
+        for svc in filter.services {
+            let result =
+                match client.get_logs(app_id, tail, filter.since, filter.severity, Some(svc)) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        output::error(
+                            &format!("Failed to fetch logs for service '{}': {}", svc, e.message),
+                            &e.code,
+                            None,
+                        );
+                        process::exit(1);
+                    }
+                };
+            all_logs.extend(parse_logs_array(&result));
+        }
+        all_logs.sort_by(|a, b| {
+            let ts_a = extract_field(a, "timestamp").unwrap_or("");
+            let ts_b = extract_field(b, "timestamp").unwrap_or("");
+            ts_a.cmp(ts_b)
+        });
+        all_logs
+    }
+}
+
+fn try_fetch_logs(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    tail: u32,
+    filter: &LogsFilter,
+) -> Result<Vec<serde_json::Value>, crate::errors::FlooApiError> {
+    if filter.services.len() <= 1 {
+        let service = filter.services.first().map(|s| s.as_str());
+        let result = client.get_logs(app_id, tail, filter.since, filter.severity, service)?;
+        Ok(parse_logs_array(&result))
+    } else {
+        let mut all_logs = Vec::new();
+        for svc in filter.services {
+            let result = client.get_logs(app_id, tail, filter.since, filter.severity, Some(svc))?;
+            all_logs.extend(parse_logs_array(&result));
+        }
+        all_logs.sort_by(|a, b| {
+            let ts_a = extract_field(a, "timestamp").unwrap_or("");
+            let ts_b = extract_field(b, "timestamp").unwrap_or("");
+            ts_a.cmp(ts_b)
+        });
+        Ok(all_logs)
+    }
+}
+
+fn parse_logs_array(result: &serde_json::Value) -> Vec<serde_json::Value> {
+    match result.get("logs").and_then(|v| v.as_array()) {
+        Some(arr) => arr.clone(),
+        None => {
+            output::error(
+                "Unexpected response format from the API.",
+                "PARSE_ERROR",
+                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | bash"),
+            );
+            process::exit(1);
+        }
+    }
+}
+
+fn print_context_header(app_name: &str, source_label: &str, filter: &LogsFilter) {
+    eprintln!();
+    eprintln!("  {} {} (from {})", "App:".bold(), app_name, source_label);
+    if filter.services.is_empty() {
+        eprintln!("  {} all", "Services:".bold());
+    } else {
+        eprintln!("  {} {}", "Services:".bold(), filter.services.join(", "));
+    }
+    if let Some(s) = filter.since {
+        eprintln!("  {} {}", "Since:".bold(), s);
+    }
+    if let Some(q) = filter.search {
+        eprintln!("  {} \"{}\"", "Search:".bold(), q);
+    }
+    eprintln!("  {}", "\u{2500}".repeat(40).dimmed());
+    eprintln!();
+}
+
+fn source_label(source: &AppSource, config_dir: &Path) -> String {
+    match source {
+        AppSource::Flag => "--app flag".to_string(),
+        AppSource::ServiceFile => {
+            format!(
+                "{} in {}",
+                project_config::SERVICE_CONFIG_FILE,
+                config_dir.display()
+            )
+        }
+        AppSource::AppFile => {
+            format!(
+                "{} in {}",
+                project_config::APP_CONFIG_FILE,
+                config_dir.display()
+            )
+        }
+    }
+}
+
+fn update_last_timestamp(last: &mut Option<String>, entry: &serde_json::Value) {
+    if let Some(ts) = extract_field(entry, "timestamp") {
+        let is_newer = match last.as_deref() {
+            Some(prev) => ts > prev,
+            None => true,
+        };
+        if is_newer {
+            *last = Some(ts.to_string());
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn logs(
-    app_name: &str,
+    app_flag: Option<&str>,
     tail: u32,
     since: Option<&str>,
     severity: Option<&str>,
-    service: Option<&str>,
+    services: &[String],
+    search: Option<&str>,
+    live: bool,
     output_path: Option<&Path>,
 ) {
-    require_auth();
+    super::require_auth();
     let client = super::init_client(None);
+
+    let cwd = std::env::current_dir().unwrap_or_else(|e| {
+        output::error(
+            &format!("Failed to read current directory: {e}"),
+            "FILE_ERROR",
+            None,
+        );
+        process::exit(1);
+    });
+
+    let resolved = match project_config::resolve_app_context(&cwd, app_flag) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
+        }
+    };
+
+    let app_name = &resolved.app_name;
+    let src_label = source_label(&resolved.source, &resolved.config_dir);
 
     let app_data = match resolve_app(&client, app_name) {
         Ok(a) => a,
@@ -66,41 +250,61 @@ pub fn logs(
         }
     };
 
-    let app_id = match app_data.get("id").and_then(|v| v.as_str()) {
-        Some(id) if !id.is_empty() => id,
-        _ => {
-            output::error(
-                "Failed to read app ID from API response.",
-                "PARSE_ERROR",
-                Some("This may indicate a CLI/API version mismatch. Try updating the CLI."),
-            );
-            process::exit(1);
-        }
+    let app_id = super::expect_str_field(&app_data, "id");
+    let show_service_prefix = services.len() != 1;
+
+    let filter = LogsFilter {
+        since,
+        severity,
+        services,
+        search,
     };
 
-    let result = match client.get_logs(app_id, tail, since, severity, service) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, None);
-            process::exit(1);
-        }
-    };
+    if !output::is_json_mode() {
+        print_context_header(app_name, &src_label, &filter);
+    }
 
-    let logs = match result.get("logs").and_then(|v| v.as_array()) {
-        Some(arr) => arr.clone(),
-        None => {
-            output::error(
-                "Unexpected response format from the API.",
-                "PARSE_ERROR",
-                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | bash"),
-            );
-            process::exit(1);
-        }
-    };
+    if live {
+        live_logs(&client, app_id, tail, &filter, show_service_prefix);
+    } else {
+        batch_logs(
+            &client,
+            app_id,
+            app_name,
+            tail,
+            &filter,
+            show_service_prefix,
+            output_path,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn batch_logs(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    app_name: &str,
+    tail: u32,
+    filter: &LogsFilter,
+    show_service_prefix: bool,
+    output_path: Option<&Path>,
+) {
+    let mut logs = fetch_logs(client, app_id, tail, filter);
+
+    if let Some(q) = filter.search {
+        logs = apply_search_filter(logs, q);
+    }
 
     if logs.is_empty() {
         if output::is_json_mode() {
-            output::success("No logs found.", Some(result));
+            output::success(
+                "No logs found.",
+                Some(serde_json::json!({
+                    "logs": [],
+                    "total": 0,
+                    "app_name": app_name,
+                })),
+            );
         } else {
             output::info(
                 "No logs found. The app may not have produced any output yet.",
@@ -111,72 +315,273 @@ pub fn logs(
     }
 
     if let Some(path) = output_path {
-        let content = if output::is_json_mode() {
-            match serde_json::to_string_pretty(&result) {
-                Ok(s) => s,
-                Err(e) => {
-                    output::error(
-                        &format!("Failed to serialize logs to JSON: {e}"),
-                        "PARSE_ERROR",
-                        None,
-                    );
-                    process::exit(1);
-                }
-            }
-        } else {
-            logs.iter()
-                .map(|entry| {
-                    let ts = entry
-                        .get("timestamp")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let sev = entry
-                        .get("severity")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("DEFAULT");
-                    let msg = entry.get("message").and_then(|v| v.as_str()).unwrap_or("");
-                    format!("{ts} [{sev}] {msg}")
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
-
-        if let Err(e) = std::fs::write(path, &content) {
-            output::error(
-                &format!("Failed to write logs to {}: {e}", path.display()),
-                "FILE_ERROR",
-                None,
-            );
-            process::exit(1);
-        }
-
-        let count = logs.len();
-        if output::is_json_mode() {
-            output::success(
-                &format!("Wrote {count} log entries to {}", path.display()),
-                Some(result),
-            );
-        } else {
-            output::success(
-                &format!("Wrote {count} log entries to {}", path.display()),
-                None,
-            );
-        }
+        write_logs_to_file(path, &logs, app_name, show_service_prefix);
         return;
     }
 
     if output::is_json_mode() {
-        output::success("Logs retrieved.", Some(result));
+        let total = logs.len();
+        output::success(
+            "Logs retrieved.",
+            Some(serde_json::json!({
+                "logs": logs,
+                "total": total,
+                "app_name": app_name,
+            })),
+        );
         return;
     }
 
-    let app_display = result
-        .get("app_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
-    output::info(&format!("Logs for {app_display}:"), None);
+    for entry in &logs {
+        output::dim_line(&format_log_line(entry, show_service_prefix));
+    }
+}
+
+fn write_logs_to_file(
+    path: &Path,
+    logs: &[serde_json::Value],
+    app_name: &str,
+    show_service_prefix: bool,
+) {
+    let content = if output::is_json_mode() {
+        let payload = serde_json::json!({
+            "logs": logs,
+            "total": logs.len(),
+            "app_name": app_name,
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => s,
+            Err(e) => {
+                output::error(
+                    &format!("Failed to serialize logs to JSON: {e}"),
+                    "PARSE_ERROR",
+                    None,
+                );
+                process::exit(1);
+            }
+        }
+    } else {
+        logs.iter()
+            .map(|entry| format_log_line_plain(entry, show_service_prefix))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    if let Err(e) = std::fs::write(path, &content) {
+        output::error(
+            &format!("Failed to write logs to {}: {e}", path.display()),
+            "FILE_ERROR",
+            None,
+        );
+        process::exit(1);
+    }
+
+    let count = logs.len();
+    if output::is_json_mode() {
+        output::success(
+            &format!("Wrote {count} log entries to {}", path.display()),
+            Some(serde_json::json!({
+                "logs": logs,
+                "total": count,
+                "app_name": app_name,
+            })),
+        );
+    } else {
+        output::success(
+            &format!("Wrote {count} log entries to {}", path.display()),
+            None,
+        );
+    }
+}
+
+fn live_logs(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    tail: u32,
+    filter: &LogsFilter,
+    show_service_prefix: bool,
+) {
+    let is_json = output::is_json_mode();
+
+    let mut logs = fetch_logs(client, app_id, tail, filter);
+    if let Some(q) = filter.search {
+        logs = apply_search_filter(logs, q);
+    }
+
+    let mut last_timestamp: Option<String> = None;
 
     for entry in &logs {
-        output::dim_line(&format_log_line(entry));
+        if is_json {
+            output::print_json(entry);
+        } else {
+            output::dim_line(&format_log_line(entry, show_service_prefix));
+        }
+        update_last_timestamp(&mut last_timestamp, entry);
+    }
+
+    if !is_json && logs.is_empty() {
+        output::info("Waiting for new logs...", None);
+    }
+
+    let mut consecutive_errors: u32 = 0;
+
+    loop {
+        thread::sleep(POLL_INTERVAL);
+
+        let since_filter = last_timestamp.as_deref().or(filter.since);
+
+        let poll_filter = LogsFilter {
+            since: since_filter,
+            severity: filter.severity,
+            services: filter.services,
+            search: None,
+        };
+
+        let poll_result = try_fetch_logs(client, app_id, tail, &poll_filter);
+        let mut new_logs = match poll_result {
+            Ok(logs) => {
+                consecutive_errors = 0;
+                logs
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_TRANSIENT_RETRIES {
+                    output::error(
+                        &format!(
+                            "Live polling failed after {} consecutive errors: {}",
+                            MAX_TRANSIENT_RETRIES, e.message
+                        ),
+                        &e.code,
+                        Some("Check your network connection and try again."),
+                    );
+                    process::exit(1);
+                }
+                if !is_json {
+                    eprintln!(
+                        "  {} transient error (retry {}/{}): {}",
+                        "!".yellow().bold(),
+                        consecutive_errors,
+                        MAX_TRANSIENT_RETRIES,
+                        e.message
+                    );
+                }
+                continue;
+            }
+        };
+
+        if let Some(q) = filter.search {
+            new_logs = apply_search_filter(new_logs, q);
+        }
+
+        let new_entries: Vec<_> = match &last_timestamp {
+            None => new_logs,
+            Some(last_ts) => new_logs
+                .into_iter()
+                .filter(|entry| {
+                    extract_field(entry, "timestamp")
+                        .map(|ts| ts > last_ts.as_str())
+                        .unwrap_or(false)
+                })
+                .collect(),
+        };
+
+        for entry in &new_entries {
+            if is_json {
+                output::print_json(entry);
+            } else {
+                output::dim_line(&format_log_line(entry, show_service_prefix));
+            }
+            update_last_timestamp(&mut last_timestamp, entry);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_apply_search_filter_matches_case_insensitive() {
+        let entries = vec![
+            json!({"message": "Server started", "timestamp": "t1", "severity": "INFO"}),
+            json!({"message": "Error: connection failed", "timestamp": "t2", "severity": "ERROR"}),
+            json!({"message": "Request handled", "timestamp": "t3", "severity": "INFO"}),
+        ];
+
+        let result = apply_search_filter(entries, "error");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].get("message").unwrap().as_str().unwrap(),
+            "Error: connection failed"
+        );
+    }
+
+    #[test]
+    fn test_apply_search_filter_empty_query_matches_all() {
+        let entries = vec![json!({"message": "Hello", "timestamp": "t1", "severity": "INFO"})];
+
+        let result = apply_search_filter(entries, "");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_apply_search_filter_no_match() {
+        let entries =
+            vec![json!({"message": "Hello world", "timestamp": "t1", "severity": "INFO"})];
+
+        let result = apply_search_filter(entries, "zzz_nonexistent");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_apply_search_filter_missing_message_field() {
+        let entries = vec![json!({"timestamp": "t1", "severity": "INFO"})];
+
+        let result = apply_search_filter(entries, "anything");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_format_log_line_without_prefix() {
+        let entry = json!({
+            "timestamp": "2024-01-01T00:00:00Z",
+            "severity": "INFO",
+            "message": "Server started",
+            "service_name": "api"
+        });
+
+        let line = format_log_line(&entry, false);
+        assert!(line.contains("2024-01-01T00:00:00Z"));
+        assert!(line.contains("Server started"));
+        assert!(!line.contains("[api]"));
+    }
+
+    #[test]
+    fn test_format_log_line_with_prefix() {
+        let entry = json!({
+            "timestamp": "2024-01-01T00:00:00Z",
+            "severity": "INFO",
+            "message": "Server started",
+            "service_name": "api"
+        });
+
+        let line = format_log_line(&entry, true);
+        assert!(line.contains("2024-01-01T00:00:00Z"));
+        assert!(line.contains("Server started"));
+        assert!(line.contains("[api]"));
+    }
+
+    #[test]
+    fn test_format_log_line_with_prefix_missing_service_name() {
+        let entry = json!({
+            "timestamp": "2024-01-01T00:00:00Z",
+            "severity": "ERROR",
+            "message": "something broke"
+        });
+
+        let line = format_log_line(&entry, true);
+        assert!(line.contains("[unknown]"));
+        assert!(line.contains("something broke"));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -18,7 +18,7 @@ pub fn is_json_mode() -> bool {
     JSON_MODE.load(Ordering::SeqCst)
 }
 
-fn print_json(data: &Value) {
+pub fn print_json(data: &Value) {
     println!("{}", serde_json::to_string(data).unwrap_or_default());
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -429,7 +429,7 @@ fn test_logs_help() {
 #[test]
 fn test_logs_not_authenticated() {
     floo()
-        .args(["logs", "my-app"])
+        .args(["logs", "--app", "my-app"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -439,7 +439,7 @@ fn test_logs_not_authenticated() {
 #[test]
 fn test_logs_json_not_authenticated() {
     floo()
-        .args(["--json", "logs", "my-app"])
+        .args(["--json", "logs", "--app", "my-app"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -447,12 +447,12 @@ fn test_logs_json() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Server started"}],"app_name":"my-app"}"#,
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Server started","service_name":"web"}],"app_name":"my-app"}"#,
         )
         .create();
 
     floo()
-        .args(["--json", "logs", TEST_APP_NAME])
+        .args(["--json", "logs", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -476,17 +476,204 @@ fn test_logs_human() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Server started"}],"app_name":"my-app"}"#,
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Server started","service_name":"web"}],"app_name":"my-app"}"#,
         )
         .create();
 
     floo()
-        .args(["logs", TEST_APP_NAME])
+        .args(["logs", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
-        .stderr(predicate::str::contains("Logs for"))
+        .stderr(predicate::str::contains("App:"))
+        .stderr(predicate::str::contains(TEST_APP_NAME))
         .stderr(predicate::str::contains("Server started"));
+}
+
+#[test]
+fn test_logs_from_config_file() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.service.toml"),
+        format!(
+            r#"[app]
+name = "{TEST_APP_NAME}"
+
+[service]
+name = "web"
+type = "web"
+port = 3000
+ingress = "public"
+"#
+        ),
+    )
+    .unwrap();
+
+    let _m_logs = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::UrlEncoded("limit".into(), "100".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Config resolved","service_name":"web"}],"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "logs"])
+        .env("HOME", home.path())
+        .current_dir(project.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("Config resolved"));
+}
+
+#[test]
+fn test_logs_no_config_no_app_errors() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let project = TempDir::new().unwrap();
+
+    floo()
+        .args(["--json", "logs"])
+        .env("HOME", home.path())
+        .current_dir(project.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"NO_CONFIG_FOUND"#));
+}
+
+#[test]
+fn test_logs_multi_services() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_logs_api = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("service".into(), "api".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:01Z","severity":"INFO","message":"API log","service_name":"api"}],"app_name":"my-app"}"#,
+        )
+        .create();
+
+    let _m_logs_web = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("service".into(), "web".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Web log","service_name":"web"}],"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "logs",
+            "--app",
+            TEST_APP_NAME,
+            "--services",
+            "api",
+            "--services",
+            "web",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("API log"))
+        .stdout(predicate::str::contains("Web log"));
+}
+
+#[test]
+fn test_logs_search_filter() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_logs = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::UrlEncoded("limit".into(), "100".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Server started","service_name":"web"},{"timestamp":"2024-01-01T00:00:01Z","severity":"ERROR","message":"Connection error occurred","service_name":"web"}],"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "logs",
+            "--app",
+            TEST_APP_NAME,
+            "--search",
+            "error",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("Connection error occurred"))
+        .stdout(predicate::str::contains("Server started").not());
+}
+
+#[test]
+fn test_logs_single_service_no_prefix() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_logs = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("service".into(), "api".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Single service log","service_name":"api"}],"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["logs", "--app", TEST_APP_NAME, "--services", "api"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Single service log"))
+        .stderr(predicate::str::contains("[api]").not());
 }
 
 // ───────────────────────── Databases ─────────────────────────
@@ -680,13 +867,14 @@ fn test_deploy_existing_app_by_name_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
 
-    // Create a temp project with package.json for detection
+    // Create a temp project with package.json for detection + service config
     let project = TempDir::new().unwrap();
     std::fs::write(
         project.path().join("package.json"),
         r#"{"name":"test-project","version":"1.0.0"}"#,
     )
     .unwrap();
+    write_service_config(&project, TEST_APP_NAME);
 
     let _m_list = server
         .mock("GET", "/v1/apps")
@@ -781,6 +969,7 @@ fn test_deploy_failed_json_includes_logs_and_suggestion() {
         r#"{"name":"test-project","version":"1.0.0"}"#,
     )
     .unwrap();
+    write_service_config(&project, TEST_APP_NAME);
 
     let _m_list = server
         .mock("GET", "/v1/apps")
@@ -918,6 +1107,19 @@ fn test_deploy_with_sse_streaming() {
         r#"{"name":"test-project","version":"1.0.0"}"#,
     )
     .unwrap();
+    write_service_config(&project, "test-stream");
+
+    // resolve_app: name lookup returns empty, so app gets created
+    let _m_list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"apps":[]}"#)
+        .create();
 
     let _m_create_app = server
         .mock("POST", "/v1/apps")
@@ -968,12 +1170,7 @@ fn test_deploy_with_sse_streaming() {
         .create();
 
     floo()
-        .args([
-            "deploy",
-            project.path().to_str().unwrap(),
-            "--name",
-            "test-stream",
-        ])
+        .args(["deploy", project.path().to_str().unwrap()])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -992,6 +1189,19 @@ fn test_deploy_sse_fallback_to_polling() {
         r#"{"name":"test-project","version":"1.0.0"}"#,
     )
     .unwrap();
+    write_service_config(&project, "test-fallback");
+
+    // resolve_app: name lookup returns empty, so app gets created
+    let _m_list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"apps":[]}"#)
+        .create();
 
     let _m_create_app = server
         .mock("POST", "/v1/apps")
@@ -1035,12 +1245,7 @@ fn test_deploy_sse_fallback_to_polling() {
         .create();
 
     floo()
-        .args([
-            "deploy",
-            project.path().to_str().unwrap(),
-            "--name",
-            "test-fallback",
-        ])
+        .args(["deploy", project.path().to_str().unwrap()])
         .env("HOME", home.path())
         .assert()
         .success()


### PR DESCRIPTION
## Summary

- Reworks `floo logs` per the CLI UX design spec (§ Logs)
- Changes positional `app` arg to `--app/-a` flag with config-file resolution via `floo.service.toml` / `floo.app.toml`
- Adds repeatable `--services` flag for multi-service filtering (N services → N API calls, merged and sorted by timestamp)
- Adds `--search` for client-side case-insensitive text filtering on the `message` field
- Adds `--live/-f` for real-time log polling (2s interval) with transient error retry logic (3 retries before exit)
- Shows context header (app name, source, services, filters) before log output in human mode
- Shows `[service_name]` prefix when viewing all or multiple services; hidden for single service
- NDJSON output for `--json --live` mode via `pub print_json`
- `--live` conflicts with `--output` (enforced at CLI level)

## Test plan

- [x] `cargo test` — 184 tests pass (99 unit + 48 CLI + 37 mock API)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Unit tests: 7 tests for `apply_search_filter` and `format_log_line`
- [x] Integration tests: `test_logs_json`, `test_logs_human`, `test_logs_from_config_file`, `test_logs_no_config_no_app_errors`, `test_logs_multi_services`, `test_logs_search_filter`, `test_logs_single_service_no_prefix`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)