### PR TITLE
[Feature] [#33] Add service targeting, env get, and env import

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -299,24 +299,91 @@ impl FlooClient {
 
     // --- Env vars ---
 
-    pub fn set_env_var(&self, app_id: &str, key: &str, value: &str) -> Result<Value, FlooApiError> {
-        let body = serde_json::json!({"key": key, "value": value});
+    pub fn set_env_var(
+        &self,
+        app_id: &str,
+        key: &str,
+        value: &str,
+        service_id: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let mut body = serde_json::json!({"key": key, "value": value});
+        if let Some(sid) = service_id {
+            body.as_object_mut()
+                .unwrap()
+                .insert("service_id".to_string(), Value::String(sid.to_string()));
+        }
         let resp = self.post_json(&format!("/v1/apps/{app_id}/env"), &body)?;
         self.handle_response(resp)
     }
 
-    pub fn list_env_vars(&self, app_id: &str) -> Result<Value, FlooApiError> {
-        let resp = self.get(&format!("/v1/apps/{app_id}/env"))?;
+    pub fn list_env_vars(
+        &self,
+        app_id: &str,
+        service_id: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let mut path = format!("/v1/apps/{app_id}/env");
+        if let Some(sid) = service_id {
+            path.push_str(&format!("?service_id={sid}"));
+        }
+        let resp = self.get(&path)?;
         self.handle_response(resp)
     }
 
-    pub fn delete_env_var(&self, app_id: &str, key: &str) -> Result<(), FlooApiError> {
-        let resp = self.delete(&format!("/v1/apps/{app_id}/env/{key}"))?;
+    pub fn delete_env_var(
+        &self,
+        app_id: &str,
+        key: &str,
+        service_id: Option<&str>,
+    ) -> Result<(), FlooApiError> {
+        let mut path = format!("/v1/apps/{app_id}/env/{key}");
+        if let Some(sid) = service_id {
+            path.push_str(&format!("?service_id={sid}"));
+        }
+        let resp = self.delete(&path)?;
         if resp.status().as_u16() == 204 {
             return Ok(());
         }
         self.handle_response(resp)?;
         Ok(())
+    }
+
+    pub fn get_env_var(
+        &self,
+        app_id: &str,
+        key: &str,
+        service_id: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let mut path = format!("/v1/apps/{app_id}/env/{key}");
+        if let Some(sid) = service_id {
+            path.push_str(&format!("?service_id={sid}"));
+        }
+        let resp = self.get(&path)?;
+        self.handle_response(resp)
+    }
+
+    pub fn import_env_vars(
+        &self,
+        app_id: &str,
+        env_vars: &[(String, String)],
+        service_id: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let vars: Vec<Value> = env_vars
+            .iter()
+            .map(|(k, v)| serde_json::json!({"key": k, "value": v}))
+            .collect();
+        let mut body = serde_json::json!({"env_vars": vars});
+        if let Some(sid) = service_id {
+            body.as_object_mut()
+                .unwrap()
+                .insert("service_id".to_string(), Value::String(sid.to_string()));
+        }
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/env/import"), &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn list_services(&self, app_id: &str) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/services?page=1&per_page=100"))?;
+        self.handle_response(resp)
     }
 
     // --- Databases ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -200,16 +200,24 @@ pub enum EnvCommands {
         /// KEY=VALUE pair to set.
         key_value: String,
 
-        /// App name or ID.
+        /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
-        app: String,
+        app: Option<String>,
+
+        /// Target specific services (repeatable).
+        #[arg(long)]
+        services: Vec<String>,
     },
 
     /// List environment variables for an app.
     List {
-        /// App name or ID.
+        /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
-        app: String,
+        app: Option<String>,
+
+        /// Target specific services (repeatable).
+        #[arg(long)]
+        services: Vec<String>,
     },
 
     /// Remove an environment variable from an app.
@@ -217,9 +225,41 @@ pub enum EnvCommands {
         /// Environment variable key to remove.
         key: String,
 
-        /// App name or ID.
+        /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
-        app: String,
+        app: Option<String>,
+
+        /// Target specific services (repeatable).
+        #[arg(long)]
+        services: Vec<String>,
+    },
+
+    /// Get an environment variable's plaintext value.
+    Get {
+        /// Environment variable key.
+        key: String,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Target a specific service.
+        #[arg(long)]
+        service: Option<String>,
+    },
+
+    /// Import environment variables from a .env file.
+    Import {
+        /// Path to .env file (defaults to env_file from config or .env).
+        file: Option<PathBuf>,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Target specific services (repeatable).
+        #[arg(long)]
+        services: Vec<String>,
     },
 }
 
@@ -321,9 +361,23 @@ pub fn run() {
         },
 
         Commands::Env(sub) => match sub {
-            EnvCommands::Set { key_value, app } => commands::env::set(&key_value, &app),
-            EnvCommands::List { app } => commands::env::list(&app),
-            EnvCommands::Remove { key, app } => commands::env::remove(&key, &app),
+            EnvCommands::Set {
+                key_value,
+                app,
+                services,
+            } => commands::env::set(&key_value, app.as_deref(), &services),
+            EnvCommands::List { app, services } => commands::env::list(app.as_deref(), &services),
+            EnvCommands::Remove { key, app, services } => {
+                commands::env::remove(&key, app.as_deref(), &services)
+            }
+            EnvCommands::Get { key, app, service } => {
+                commands::env::get(&key, app.as_deref(), service.as_deref())
+            }
+            EnvCommands::Import {
+                file,
+                app,
+                services,
+            } => commands::env::import_vars(file.as_deref(), app.as_deref(), &services),
         },
 
         Commands::Db(sub) => match sub {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -1,23 +1,250 @@
+use std::path::Path;
 use std::process;
 
-use crate::config::load_config;
+use crate::api_client::FlooClient;
 use crate::output;
+use crate::project_config;
 use crate::resolve::resolve_app;
 
-fn require_auth() {
-    let config = load_config();
-    if config.api_key.is_none() {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn resolve_app_id(client: &FlooClient, app_flag: Option<&str>) -> (String, String) {
+    let cwd = std::env::current_dir().unwrap_or_else(|e| {
         output::error(
-            "Not logged in.",
-            "NOT_AUTHENTICATED",
-            Some("Run 'floo login' to authenticate."),
+            &format!("Failed to read current directory: {e}"),
+            "FILE_ERROR",
+            None,
+        );
+        process::exit(1);
+    });
+
+    let resolved = match project_config::resolve_app_context(&cwd, app_flag) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
+        }
+    };
+
+    let app_data = match resolve_app(client, &resolved.app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{}' not found.", resolved.app_name),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    };
+
+    let app_id = super::expect_str_field(&app_data, "id").to_string();
+    let app_name = app_data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&resolved.app_name)
+        .to_string();
+    (app_id, app_name)
+}
+
+/// Resolve `--services` names to service IDs.
+///
+/// Returns a list of `(Option<service_id>, Option<service_name>)` pairs.
+/// - App with 0 services and no `--services` → `[(None, None)]` (app-level)
+/// - 1 service, no `--services` → auto-select `[(Some(uuid), Some(name))]`
+/// - 2+ services, no `--services` → error
+/// - `--services` provided → resolve each name to UUID
+fn resolve_service_ids(
+    client: &FlooClient,
+    app_id: &str,
+    app_name: &str,
+    service_names: &[String],
+) -> Vec<(Option<String>, Option<String>)> {
+    let result = match client.list_services(app_id) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    };
+
+    let services = match result.get("services").and_then(|v| v.as_array()) {
+        Some(arr) => arr.clone(),
+        None => {
+            output::error(
+                "Response missing 'services' field.",
+                "PARSE_ERROR",
+                Some("This is a bug. Please report it."),
+            );
+            process::exit(1);
+        }
+    };
+
+    if service_names.is_empty() {
+        match services.len() {
+            0 => return vec![(None, None)],
+            1 => {
+                let svc = &services[0];
+                let sid = super::expect_str_field(svc, "id").to_string();
+                let sname = super::expect_str_field(svc, "name").to_string();
+                return vec![(Some(sid), Some(sname))];
+            }
+            _ => {
+                let names: Vec<String> = services
+                    .iter()
+                    .filter_map(|s| s.get("name").and_then(|v| v.as_str()).map(String::from))
+                    .collect();
+                output::error(
+                    &format!(
+                        "App '{app_name}' has multiple services. Specify which with --services."
+                    ),
+                    "MULTIPLE_SERVICES",
+                    Some(&format!("Available services: {}", names.join(", "))),
+                );
+                process::exit(1);
+            }
+        }
+    }
+
+    service_names
+        .iter()
+        .map(|name| {
+            let found = services
+                .iter()
+                .find(|s| s.get("name").and_then(|v| v.as_str()) == Some(name.as_str()));
+            match found {
+                Some(svc) => {
+                    let sid = super::expect_str_field(svc, "id").to_string();
+                    (Some(sid), Some(name.clone()))
+                }
+                None => {
+                    let available: Vec<String> = services
+                        .iter()
+                        .filter_map(|s| s.get("name").and_then(|v| v.as_str()).map(String::from))
+                        .collect();
+                    output::error(
+                        &format!("Service '{name}' not found on app '{app_name}'."),
+                        "SERVICE_NOT_FOUND",
+                        Some(&format!("Available services: {}", available.join(", "))),
+                    );
+                    process::exit(1);
+                }
+            }
+        })
+        .collect()
+}
+
+fn resolve_single_service(
+    client: &FlooClient,
+    app_id: &str,
+    app_name: &str,
+    service_flag: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    let names = match service_flag {
+        Some(name) => vec![name.to_string()],
+        None => vec![],
+    };
+    let ids = resolve_service_ids(client, app_id, app_name, &names);
+    ids.into_iter().next().unwrap_or_else(|| {
+        output::error(
+            "Service resolution returned no results.",
+            "INTERNAL_ERROR",
+            Some("This is a bug. Please report it."),
+        );
+        process::exit(1);
+    })
+}
+
+fn parse_env_file(path: &Path) -> Vec<(String, String)> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            let (code, msg) = match e.kind() {
+                std::io::ErrorKind::NotFound => (
+                    "ENV_FILE_NOT_FOUND",
+                    format!("File not found: {}", path.display()),
+                ),
+                std::io::ErrorKind::PermissionDenied => (
+                    "ENV_FILE_NOT_FOUND",
+                    format!("Permission denied reading: {}", path.display()),
+                ),
+                _ => (
+                    "ENV_FILE_NOT_FOUND",
+                    format!("Failed to read {}: {e}", path.display()),
+                ),
+            };
+            output::error(&msg, code, Some("Check the file path and permissions."));
+            process::exit(1);
+        }
+    };
+
+    let mut vars = Vec::new();
+    let mut bad_lines = Vec::new();
+
+    for (line_num, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let trimmed = trimmed.strip_prefix("export ").unwrap_or(trimmed);
+        match trimmed.split_once('=') {
+            Some((key, value)) => {
+                let key = key.trim().to_uppercase();
+                let mut value = value.trim().to_string();
+                if (value.starts_with('"') && value.ends_with('"'))
+                    || (value.starts_with('\'') && value.ends_with('\''))
+                {
+                    value = value[1..value.len() - 1].to_string();
+                }
+                vars.push((key, value));
+            }
+            None => {
+                bad_lines.push(line_num + 1);
+            }
+        }
+    }
+
+    if !bad_lines.is_empty() {
+        output::error(
+            &format!(
+                "Malformed lines in {}: line(s) {}",
+                path.display(),
+                bad_lines
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            "ENV_PARSE_ERROR",
+            Some("Each non-comment line must be in KEY=VALUE format."),
         );
         process::exit(1);
     }
+
+    if vars.is_empty() {
+        output::error(
+            &format!("No valid KEY=VALUE pairs found in {}.", path.display()),
+            "ENV_PARSE_ERROR",
+            Some("Ensure the file contains lines in KEY=VALUE format."),
+        );
+        process::exit(1);
+    }
+
+    vars
 }
 
-pub fn set(key_value: &str, app_name: &str) {
-    require_auth();
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String]) {
+    super::require_auth();
 
     if !key_value.contains('=') {
         output::error(
@@ -32,65 +259,126 @@ pub fn set(key_value: &str, app_name: &str) {
     let key = key.to_uppercase();
 
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
+    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
+
+    for (service_id, service_name) in &targets {
+        match client.set_env_var(&app_id, &key, value, service_id.as_deref()) {
+            Ok(result) => {
+                let target = match service_name {
+                    Some(sn) => format!("{app_name}/{sn}"),
+                    None => app_name.clone(),
+                };
+                output::success(&format!("Set {key} on {target}."), Some(result));
             }
-            process::exit(1);
-        }
-    };
-
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
-
-    match client.set_env_var(app_id, &key, value) {
-        Ok(result) => {
-            output::success(&format!("Set {key} on {name}."), Some(result));
-        }
-        Err(e) => {
-            output::error(&e.message, &e.code, None);
-            process::exit(1);
+            Err(e) => {
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
         }
     }
 }
 
-pub fn list(app_name: &str) {
-    require_auth();
+pub fn list(app_flag: Option<&str>, service_names: &[String]) {
+    super::require_auth();
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
+    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
+
+    for (service_id, service_name) in &targets {
+        let result = match client.list_env_vars(&app_id, service_id.as_deref()) {
+            Ok(r) => r,
+            Err(e) => {
                 output::error(&e.message, &e.code, None);
+                process::exit(1);
             }
+        };
+
+        let env_vars = match result.get("env_vars").and_then(|v| v.as_array()) {
+            Some(arr) => arr.clone(),
+            None => {
+                output::error(
+                    "Response missing 'env_vars' field.",
+                    "PARSE_ERROR",
+                    Some("This is a bug. Please report it."),
+                );
+                process::exit(1);
+            }
+        };
+
+        let target = match service_name {
+            Some(sn) => format!("{app_name}/{sn}"),
+            None => app_name.clone(),
+        };
+
+        if env_vars.is_empty() {
+            if output::is_json_mode() {
+                output::success("No env vars.", Some(serde_json::json!({"env_vars": []})));
+            } else {
+                output::info(&format!("No environment variables set on {target}."), None);
+            }
+            continue;
+        }
+
+        let rows: Vec<Vec<String>> = env_vars
+            .iter()
+            .map(|ev| {
+                vec![
+                    ev.get("key")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("-")
+                        .to_string(),
+                    ev.get("masked_value")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("-")
+                        .to_string(),
+                ]
+            })
+            .collect();
+
+        output::table(
+            &["Key", "Value"],
+            &rows,
+            Some(serde_json::json!({"env_vars": env_vars})),
+        );
+    }
+}
+
+pub fn remove(key: &str, app_flag: Option<&str>, service_names: &[String]) {
+    let key = key.to_uppercase();
+    super::require_auth();
+
+    let client = super::init_client(None);
+    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
+
+    for (service_id, service_name) in &targets {
+        if let Err(e) = client.delete_env_var(&app_id, &key, service_id.as_deref()) {
+            output::error(&e.message, &e.code, None);
             process::exit(1);
         }
-    };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
+        let target = match service_name {
+            Some(sn) => format!("{app_name}/{sn}"),
+            None => app_name.clone(),
+        };
+        output::success(
+            &format!("Removed {key} from {target}."),
+            Some(serde_json::json!({"key": key})),
+        );
+    }
+}
 
-    let result = match client.list_env_vars(app_id) {
+pub fn get(key: &str, app_flag: Option<&str>, service_flag: Option<&str>) {
+    let key = key.to_uppercase();
+    super::require_auth();
+
+    let client = super::init_client(None);
+    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let (service_id, _service_name) =
+        resolve_single_service(&client, &app_id, &app_name, service_flag);
+
+    let result = match client.get_env_var(&app_id, &key, service_id.as_deref()) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, None);
@@ -98,83 +386,211 @@ pub fn list(app_name: &str) {
         }
     };
 
-    let env_vars = result
-        .get("env_vars")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
+    let value = super::expect_str_field(&result, "value");
 
-    if env_vars.is_empty() {
-        if !output::is_json_mode() {
-            output::info(
-                &format!(
-                    "No environment variables set on {name}. Set one with floo env set KEY=VALUE --app {name}."
-                ),
-                None,
-            );
-        } else {
-            output::success("No env vars.", Some(serde_json::json!({"env_vars": []})));
-        }
-        return;
+    if output::is_json_mode() {
+        output::success(
+            &format!("Got {key}."),
+            Some(serde_json::json!({"key": key, "value": value})),
+        );
+    } else {
+        output::raw_value(value);
     }
-
-    let rows: Vec<Vec<String>> = env_vars
-        .iter()
-        .map(|ev| {
-            vec![
-                ev.get("key")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                ev.get("masked_value")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-            ]
-        })
-        .collect();
-
-    output::table(
-        &["Key", "Value"],
-        &rows,
-        Some(serde_json::json!({"env_vars": env_vars})),
-    );
 }
 
-pub fn remove(key: &str, app_name: &str) {
-    let key = key.to_uppercase();
-    require_auth();
+pub fn import_vars(file_flag: Option<&Path>, app_flag: Option<&str>, service_names: &[String]) {
+    super::require_auth();
 
-    let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
+    let cwd = std::env::current_dir().unwrap_or_else(|e| {
+        output::error(
+            &format!("Failed to read current directory: {e}"),
+            "FILE_ERROR",
+            None,
+        );
+        process::exit(1);
+    });
+
+    // Resolve config once — used for both env_file default and app resolution.
+    // NO_CONFIG_FOUND is acceptable when determining env_file path (fall back to .env),
+    // but all other errors (LEGACY_CONFIG, INVALID_PROJECT_CONFIG) must surface.
+    let resolved = match project_config::resolve_app_context(&cwd, app_flag) {
+        Ok(r) => Some(r),
+        Err(e) if e.code == "NO_CONFIG_FOUND" => None,
         Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
             process::exit(1);
         }
     };
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
+    let env_file_path = match file_flag {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let from_config = resolved
+                .as_ref()
+                .and_then(|r| r.service_config.as_ref())
+                .and_then(|sc| sc.service.env_file.as_deref());
+            match from_config {
+                Some(f) => cwd.join(f),
+                None => cwd.join(".env"),
+            }
+        }
+    };
 
-    if let Err(e) = client.delete_env_var(app_id, &key) {
-        output::error(&e.message, &e.code, None);
-        process::exit(1);
+    let vars = parse_env_file(&env_file_path);
+    let count = vars.len();
+
+    // Use resolved app name if available, otherwise resolve_app_id will re-resolve from config.
+    let client = super::init_client(None);
+    let (app_id, app_name) = match &resolved {
+        Some(r) => {
+            let app_data = match resolve_app(&client, &r.app_name) {
+                Ok(a) => a,
+                Err(e) => {
+                    if e.code == "APP_NOT_FOUND" {
+                        output::error(
+                            &format!("App '{}' not found.", r.app_name),
+                            "APP_NOT_FOUND",
+                            Some("Check the app name or ID and try again."),
+                        );
+                    } else {
+                        output::error(&e.message, &e.code, None);
+                    }
+                    process::exit(1);
+                }
+            };
+            let app_id = super::expect_str_field(&app_data, "id").to_string();
+            let app_name = app_data
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&r.app_name)
+                .to_string();
+            (app_id, app_name)
+        }
+        None => resolve_app_id(&client, app_flag),
+    };
+
+    let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
+
+    for (service_id, service_name) in &targets {
+        match client.import_env_vars(&app_id, &vars, service_id.as_deref()) {
+            Ok(result) => {
+                let target = match service_name {
+                    Some(sn) => format!("{app_name}/{sn}"),
+                    None => app_name.clone(),
+                };
+                output::success(
+                    &format!("Imported {count} variable(s) to {target}."),
+                    Some(result),
+                );
+            }
+            Err(e) => {
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_env_file(dir: &TempDir, name: &str, content: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, content).unwrap();
+        path
     }
 
-    output::success(
-        &format!("Removed {key} from {name}."),
-        Some(serde_json::json!({"key": key})),
-    );
+    #[test]
+    fn test_parse_env_file_basic() {
+        let dir = TempDir::new().unwrap();
+        let path = write_env_file(&dir, ".env", "KEY=value\nOTHER=123\n");
+        let vars = parse_env_file(&path);
+        assert_eq!(
+            vars,
+            vec![
+                ("KEY".to_string(), "value".to_string()),
+                ("OTHER".to_string(), "123".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_file_comments_and_blanks() {
+        let dir = TempDir::new().unwrap();
+        let path = write_env_file(
+            &dir,
+            ".env",
+            "# this is a comment\n\nKEY=value\n\n# another\nFOO=bar\n",
+        );
+        let vars = parse_env_file(&path);
+        assert_eq!(
+            vars,
+            vec![
+                ("KEY".to_string(), "value".to_string()),
+                ("FOO".to_string(), "bar".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_file_quotes() {
+        let dir = TempDir::new().unwrap();
+        let path = write_env_file(
+            &dir,
+            ".env",
+            "DOUBLE=\"hello world\"\nSINGLE='foo bar'\nNONE=plain\n",
+        );
+        let vars = parse_env_file(&path);
+        assert_eq!(
+            vars,
+            vec![
+                ("DOUBLE".to_string(), "hello world".to_string()),
+                ("SINGLE".to_string(), "foo bar".to_string()),
+                ("NONE".to_string(), "plain".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_file_export_prefix() {
+        let dir = TempDir::new().unwrap();
+        let path = write_env_file(&dir, ".env", "export KEY=value\nexport OTHER=123\n");
+        let vars = parse_env_file(&path);
+        assert_eq!(
+            vars,
+            vec![
+                ("KEY".to_string(), "value".to_string()),
+                ("OTHER".to_string(), "123".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_file_uppercase_keys() {
+        let dir = TempDir::new().unwrap();
+        let path = write_env_file(&dir, ".env", "lower_case=value\n");
+        let vars = parse_env_file(&path);
+        assert_eq!(vars[0].0, "LOWER_CASE");
+    }
+
+    #[test]
+    fn test_parse_env_file_value_with_equals() {
+        let dir = TempDir::new().unwrap();
+        let path = write_env_file(
+            &dir,
+            ".env",
+            "DATABASE_URL=postgres://user:pass@host/db?opt=val\n",
+        );
+        let vars = parse_env_file(&path);
+        assert_eq!(vars[0].0, "DATABASE_URL");
+        assert_eq!(vars[0].1, "postgres://user:pass@host/db?opt=val");
+    }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -157,6 +157,13 @@ pub fn prompt_with_default(prompt: &str, default: &str) -> String {
     }
 }
 
+/// Print a raw value to stdout for piping. Used by `env get` in human mode.
+/// In JSON mode, callers should use `success()` instead.
+pub fn raw_value(value: &str) {
+    debug_assert!(!is_json_mode(), "raw_value called in JSON mode");
+    println!("{value}");
+}
+
 pub fn dim_line(line: &str) {
     if !is_json_mode() {
         eprintln!("  {}", line.dimmed());

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -268,6 +268,36 @@ fn test_env_list_not_authenticated() {
         .stderr(predicate::str::contains("Not logged in."));
 }
 
+#[test]
+fn test_env_remove_not_authenticated() {
+    floo()
+        .args(["env", "remove", "MY_KEY", "--app", "test"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
+}
+
+#[test]
+fn test_env_get_not_authenticated() {
+    floo()
+        .args(["env", "get", "MY_KEY", "--app", "test"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
+}
+
+#[test]
+fn test_env_import_not_authenticated() {
+    floo()
+        .args(["env", "import", "--app", "test"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
+}
+
 // --- Domains (unauthenticated) ---
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -203,11 +203,48 @@ fn test_apps_list_api_error() {
 
 // ───────────────────────── Env ─────────────────────────
 
+const TEST_SERVICE_ID: &str = "svc-uuid-1234";
+const TEST_SERVICE_NAME: &str = "web";
+
+fn mock_list_services_one(server: &mut Server) -> Mock {
+    server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/services").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"services":[{{"id":"{TEST_SERVICE_ID}","name":"{TEST_SERVICE_NAME}"}}]}}"#
+        ))
+        .create()
+}
+
+fn mock_list_services_two(server: &mut Server) -> Mock {
+    server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"services":[{{"id":"{TEST_SERVICE_ID}","name":"web"}},{{"id":"svc-uuid-5678","name":"api"}}]}}"#
+        ))
+        .create()
+}
+
 #[test]
 fn test_env_set_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
 
     let _m_set = server
         .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
@@ -237,9 +274,14 @@ fn test_env_list_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
 
     let _m_list = server
         .mock("GET", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .match_query(Matcher::UrlEncoded(
+            "service_id".into(),
+            TEST_SERVICE_ID.into(),
+        ))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"env_vars":[{"key":"DATABASE_URL","masked_value":"post****"}]}"#)
@@ -260,12 +302,17 @@ fn test_env_remove_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
 
     let _m_del = server
         .mock(
             "DELETE",
             format!("/v1/apps/{TEST_APP_ID}/env/MY_KEY").as_str(),
         )
+        .match_query(Matcher::UrlEncoded(
+            "service_id".into(),
+            TEST_SERVICE_ID.into(),
+        ))
         .with_status(204)
         .create();
 
@@ -276,6 +323,114 @@ fn test_env_remove_json() {
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains("MY_KEY"));
+}
+
+#[test]
+fn test_env_get_json() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+
+    let _m_get = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/env/MY_KEY").as_str())
+        .match_query(Matcher::UrlEncoded(
+            "service_id".into(),
+            TEST_SERVICE_ID.into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"MY_KEY","value":"secret123"}"#)
+        .create();
+
+    floo()
+        .args(["--json", "env", "get", "MY_KEY", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("secret123"));
+}
+
+#[test]
+fn test_env_get_human_raw_stdout() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+
+    let _m_get = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/env/MY_KEY").as_str())
+        .match_query(Matcher::UrlEncoded(
+            "service_id".into(),
+            TEST_SERVICE_ID.into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"MY_KEY","value":"secret123"}"#)
+        .create();
+
+    floo()
+        .args(["env", "get", "MY_KEY", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("secret123"));
+}
+
+#[test]
+fn test_env_import_json() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+
+    let _m_import = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/env/import").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"imported":2}"#)
+        .create();
+
+    // Write a temp .env file
+    let env_dir = TempDir::new().unwrap();
+    let env_path = env_dir.path().join(".env");
+    std::fs::write(&env_path, "KEY1=val1\nKEY2=val2\n").unwrap();
+
+    floo()
+        .args([
+            "--json",
+            "env",
+            "import",
+            env_path.to_str().unwrap(),
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("imported"));
+}
+
+#[test]
+fn test_env_multiple_services_error() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_two(&mut server);
+
+    floo()
+        .args(["--json", "env", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("MULTIPLE_SERVICES"))
+        .stdout(predicate::str::contains("web"))
+        .stdout(predicate::str::contains("api"));
 }
 
 // ───────────────────────── Domains ─────────────────────────


### PR DESCRIPTION
## Summary
- Add `--services` flag to `env set/list/remove` for per-service env var targeting
- Add `floo env get KEY` command — prints plaintext value to stdout for piping
- Add `floo env import [FILE]` command — bulk-upserts from `.env` file with comment/quote/export handling
- Make `--app` optional on all env commands (reads from `floo.service.toml` / `floo.app.toml` config)
- Update `api_client.rs` with `service_id` params and new endpoints (`get_env_var`, `import_env_vars`, `list_services`)
- 173 tests passing (86 unit + 51 CLI + 36 mock API)

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 173 tests pass
- [x] Code review: `code-reviewer` + `silent-failure-hunter` — all findings fixed
- [ ] Manual test: `floo env set KEY=VALUE --app <app>` with single-service app
- [ ] Manual test: `floo env get KEY --app <app>` pipes value to stdout
- [ ] Manual test: `floo env import .env --app <app>` bulk imports

Closes getfloo/floo-cli#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)