### PR TITLE
[Feature] [#32] Rework deploy for multi-service + --services flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,13 +29,13 @@ pub enum Commands {
         #[arg(default_value = ".")]
         path: PathBuf,
 
-        /// App name (generated if omitted).
-        #[arg(short, long)]
-        name: Option<String>,
-
         /// Existing app ID or name to deploy to.
         #[arg(short, long)]
         app: Option<String>,
+
+        /// Deploy only these services (repeatable: --services api --services web).
+        #[arg(short, long = "services")]
+        services: Vec<String>,
     },
 
     /// Authenticate and manage your account.
@@ -348,7 +348,11 @@ pub fn run() {
     }
 
     match cli.command {
-        Commands::Deploy { path, name, app } => commands::deploy::deploy(path, name, app),
+        Commands::Deploy {
+            path,
+            app,
+            services,
+        } => commands::deploy::deploy(path, app, services),
         Commands::Auth(sub) => match sub {
             AuthCommands::Login => commands::auth::login(),
             AuthCommands::Logout => commands::auth::logout(),

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -13,8 +13,8 @@ use crate::errors::FlooApiError;
 use crate::names::generate_name;
 use crate::output;
 use crate::project_config::{
-    self, AppFileAppSection, AppFileConfig, AppSource, ResolvedApp, ServiceConfig,
-    ServiceFileAppSection, ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
+    self, AppFileAppSection, AppFileConfig, AppSource, ServiceConfig, ServiceFileAppSection,
+    ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
 };
 use crate::resolve::resolve_app;
 
@@ -45,7 +45,7 @@ fn required_response_id<'a>(value: &'a serde_json::Value, object_name: &str) -> 
     }
 }
 
-pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
+pub fn deploy(path: PathBuf, app: Option<String>, services_filter: Vec<String>) {
     let config = load_config();
     if config.api_key.is_none() {
         output::error(
@@ -77,37 +77,7 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         process::exit(1);
     }
 
-    // Detect runtime/framework (needed for default_port/default_service_type in first-deploy)
-    let detection = detect(&project_path);
-    if detection.runtime == "unknown" {
-        output::error(
-            "No supported project files found.",
-            "NO_RUNTIME_DETECTED",
-            Some("Add a package.json, requirements.txt, or Dockerfile to your project."),
-        );
-        process::exit(1);
-    }
-
-    if !output::is_json_mode() {
-        let framework_label = detection
-            .framework
-            .as_deref()
-            .map(|f| format!(" ({f})"))
-            .unwrap_or_default();
-        output::info(
-            &format!(
-                "Detected {}{framework_label} \u{2014} {} confidence",
-                detection.runtime, detection.confidence
-            ),
-            None,
-        );
-    }
-
-    if detection.confidence == "low" && !output::confirm("Continue with this detection?") {
-        process::exit(0);
-    }
-
-    // Resolve app context from config files
+    // Resolve app context from config files (before detection, so we know if multi-service)
     let resolved = match project_config::resolve_app_context(&project_path, app.as_deref()) {
         Ok(r) => Some(r),
         Err(e) if e.code == "NO_CONFIG_FOUND" => {
@@ -122,6 +92,40 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
             process::exit(1);
         }
     };
+
+    // Detect runtime/framework (needed for API call metadata and first-deploy prompts)
+    let detection = detect(&project_path);
+    let has_config = resolved.is_some();
+    if detection.runtime == "unknown" && !has_config {
+        output::error(
+            "No supported project files found.",
+            "NO_RUNTIME_DETECTED",
+            Some("Add a package.json, requirements.txt, or Dockerfile to your project."),
+        );
+        process::exit(1);
+    }
+
+    if !output::is_json_mode() && detection.runtime != "unknown" {
+        let framework_label = detection
+            .framework
+            .as_deref()
+            .map(|f| format!(" ({f})"))
+            .unwrap_or_default();
+        output::info(
+            &format!(
+                "Detected {}{framework_label} \u{2014} {} confidence",
+                detection.runtime, detection.confidence
+            ),
+            None,
+        );
+    }
+
+    if detection.confidence == "low"
+        && !has_config
+        && !output::confirm("Continue with this detection?")
+    {
+        process::exit(0);
+    }
 
     // Display config info for resolved apps
     if !output::is_json_mode() {
@@ -184,15 +188,48 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
     // Build the app name and services list
     let (app_name, services, write_configs_on_success) = match resolved {
         Some(ref r) => {
-            let svcs = build_services_from_resolved(r);
-            (r.app_name.clone(), svcs, false)
+            let all_services = match project_config::discover_services(r) {
+                Ok(svcs) => svcs,
+                Err(e) => {
+                    output::error(&e.message, &e.code, e.suggestion.as_deref());
+                    process::exit(1);
+                }
+            };
+            let filtered = match project_config::filter_services(all_services, &services_filter) {
+                Ok(svcs) => svcs,
+                Err(e) => {
+                    output::error(&e.message, &e.code, e.suggestion.as_deref());
+                    process::exit(1);
+                }
+            };
+            (r.app_name.clone(), Some(filtered), false)
         }
         None => {
-            // First-deploy interactive flow
-            let prompted = prompt_first_deploy(&detection, name.as_deref());
+            if !services_filter.is_empty() {
+                output::error(
+                    "--services requires config files.",
+                    "NO_CONFIG_FOUND",
+                    Some("Create floo.app.toml with service entries before using --services."),
+                );
+                process::exit(1);
+            }
+            let prompted = prompt_first_deploy(&detection);
             (prompted.app_name, Some(vec![prompted.service]), true)
         }
     };
+
+    // Display per-service summary for multi-service deploys
+    if !output::is_json_mode() {
+        if let Some(ref svcs) = services {
+            if svcs.len() > 1 {
+                let names: Vec<&str> = svcs.iter().map(|s| s.name.as_str()).collect();
+                output::info(
+                    &format!("Deploying {} services: {}", svcs.len(), names.join(", ")),
+                    None,
+                );
+            }
+        }
+    }
 
     // Create archive
     let spinner = output::Spinner::new("Packaging source...");
@@ -378,12 +415,18 @@ pub fn deploy(path: PathBuf, name: Option<String>, app: Option<String>) {
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    let service_names: Vec<&str> = services
+        .as_ref()
+        .map(|svcs| svcs.iter().map(|s| s.name.as_str()).collect())
+        .unwrap_or_default();
+
     output::success(
         &format!("Deployed to {url}"),
         Some(serde_json::json!({
             "app": app_data,
             "deploy": deploy_data,
             "detection": detection.to_value(),
+            "services": service_names,
         })),
     );
 }
@@ -393,13 +436,8 @@ struct FirstDeployResult {
     service: ServiceConfig,
 }
 
-fn prompt_first_deploy(
-    detection: &crate::detection::DetectionResult,
-    name_flag: Option<&str>,
-) -> FirstDeployResult {
-    let default_name = name_flag
-        .map(|s| s.to_string())
-        .unwrap_or_else(generate_name);
+fn prompt_first_deploy(detection: &crate::detection::DetectionResult) -> FirstDeployResult {
+    let default_name = generate_name();
     let app_name = output::prompt_with_default("App name", &default_name);
 
     let default_port = detection.default_port().to_string();
@@ -429,13 +467,6 @@ fn prompt_first_deploy(
             ingress: ServiceIngress::Public,
         },
     }
-}
-
-fn build_services_from_resolved(resolved: &ResolvedApp) -> Option<Vec<ServiceConfig>> {
-    resolved
-        .service_config
-        .as_ref()
-        .map(|svc_file| vec![svc_file.service.to_api_service_config(".")])
 }
 
 fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &ServiceConfig) {

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -1,0 +1,728 @@
+use std::collections::HashSet;
+
+use crate::errors::FlooError;
+
+use super::app_config::AppServiceType;
+use super::resolve::ResolvedApp;
+use super::service_config::{load_service_config, ServiceConfig};
+
+/// Discover all deployable services from resolved config files.
+///
+/// Three branches:
+/// 1. `floo.app.toml` has user-managed services with `path` entries -> read each sub-service's
+///    `floo.service.toml` and include root service if present
+/// 2. Single `floo.service.toml` only (no app_config path entries) -> single service at "."
+/// 3. `floo.app.toml` only with no deployable services -> error
+pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, FlooError> {
+    let path_entries = user_managed_path_entries(resolved);
+
+    if !path_entries.is_empty() {
+        // Branch 1: app.toml has user-managed services with path fields
+        let mut services = Vec::new();
+        let mut seen_names = HashSet::new();
+
+        // Include root floo.service.toml if present
+        if let Some(ref svc_file) = resolved.service_config {
+            let svc = svc_file.service.to_api_service_config(".");
+            seen_names.insert(svc.name.clone());
+            services.push(svc);
+        }
+
+        for (name, normalized_path) in &path_entries {
+            let sub_dir = resolved.config_dir.join(normalized_path);
+            let svc_file = load_service_config(&sub_dir)?.ok_or_else(|| {
+                FlooError::with_suggestion(
+                    "SERVICE_CONFIG_MISSING",
+                    format!(
+                        "No {} found at '{normalized_path}/' (declared as service '{name}' in {}).",
+                        super::SERVICE_CONFIG_FILE,
+                        super::APP_CONFIG_FILE,
+                    ),
+                    format!(
+                        "Create {normalized_path}/{} with [app] and [service] sections.",
+                        super::SERVICE_CONFIG_FILE,
+                    ),
+                )
+            })?;
+
+            if svc_file.app.name != resolved.app_name {
+                return Err(FlooError::with_suggestion(
+                    "APP_NAME_MISMATCH",
+                    format!(
+                        "Service '{name}' at '{normalized_path}/{}' declares app name '{}', but {} declares '{}'.",
+                        super::SERVICE_CONFIG_FILE,
+                        svc_file.app.name,
+                        super::APP_CONFIG_FILE,
+                        resolved.app_name,
+                    ),
+                    format!(
+                        "Set [app].name = \"{}\" in {normalized_path}/{}.",
+                        resolved.app_name,
+                        super::SERVICE_CONFIG_FILE,
+                    ),
+                ));
+            }
+
+            let svc = svc_file.service.to_api_service_config(normalized_path);
+
+            if !seen_names.insert(svc.name.clone()) {
+                return Err(FlooError::new(
+                    "DUPLICATE_SERVICE_NAMES",
+                    format!(
+                        "Multiple services named '{}'. Service names must be unique.",
+                        svc.name,
+                    ),
+                ));
+            }
+
+            services.push(svc);
+        }
+
+        Ok(services)
+    } else if let Some(ref svc_file) = resolved.service_config {
+        // Branch 2: single floo.service.toml only
+        Ok(vec![svc_file.service.to_api_service_config(".")])
+    } else {
+        // Branch 3: app.toml only with no deployable services
+        Err(FlooError::with_suggestion(
+            "NO_DEPLOYABLE_SERVICES",
+            format!(
+                "{} has no deployable services (only Floo-managed services like postgres/redis).",
+                super::APP_CONFIG_FILE,
+            ),
+            format!(
+                "Add a user-managed service with a 'path' field, or create a {} in your project root.",
+                super::SERVICE_CONFIG_FILE,
+            ),
+        ))
+    }
+}
+
+/// Filter services by name. Empty filter returns all.
+pub fn filter_services(
+    services: Vec<ServiceConfig>,
+    filter: &[String],
+) -> Result<Vec<ServiceConfig>, FlooError> {
+    if filter.is_empty() {
+        return Ok(services);
+    }
+
+    let available: Vec<&str> = services.iter().map(|s| s.name.as_str()).collect();
+
+    for name in filter {
+        if !available.contains(&name.as_str()) {
+            return Err(FlooError::with_suggestion(
+                "UNKNOWN_SERVICE",
+                format!("Unknown service '{name}'."),
+                format!("Available services: {}", available.join(", ")),
+            ));
+        }
+    }
+
+    let filter_set: HashSet<&str> = filter.iter().map(|s| s.as_str()).collect();
+    Ok(services
+        .into_iter()
+        .filter(|s| filter_set.contains(s.name.as_str()))
+        .collect())
+}
+
+/// Extract user-managed service entries with `path` fields from app_config, returning
+/// (service_name, normalized_path) pairs.
+fn user_managed_path_entries(resolved: &ResolvedApp) -> Vec<(String, String)> {
+    let Some(ref app_cfg) = resolved.app_config else {
+        return Vec::new();
+    };
+
+    app_cfg
+        .services
+        .iter()
+        .filter_map(|(name, entry)| {
+            let raw = entry.path.as_deref()?;
+            if !matches!(
+                entry.service_type,
+                AppServiceType::Web | AppServiceType::Api | AppServiceType::Worker
+            ) {
+                return None;
+            }
+            let normalized = normalize_path(raw);
+            if normalized.is_empty() || normalized == "." {
+                return None;
+            }
+            Some((name.clone(), normalized))
+        })
+        .collect()
+}
+
+/// Normalize a relative path: strip leading `./` and trailing `/`.
+fn normalize_path(p: &str) -> String {
+    let s = p.strip_prefix("./").unwrap_or(p);
+    s.strip_suffix('/').unwrap_or(s).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project_config::app_config::{AppFileAppSection, AppFileConfig, AppServiceEntry};
+    use crate::project_config::resolve::AppSource;
+    use crate::project_config::service_config::{
+        ServiceFileAppSection, ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
+    };
+    use std::collections::HashMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_service_toml(name: &str, app_name: &str, svc_type: &str, port: u16) -> String {
+        format!(
+            r#"[app]
+name = "{app_name}"
+
+[service]
+name = "{name}"
+type = "{svc_type}"
+port = {port}
+ingress = "public"
+"#
+        )
+    }
+
+    fn make_resolved(
+        dir: &std::path::Path,
+        app_name: &str,
+        service_config: Option<ServiceFileConfig>,
+        app_config: Option<AppFileConfig>,
+        source: AppSource,
+    ) -> ResolvedApp {
+        ResolvedApp {
+            app_name: app_name.to_string(),
+            source,
+            service_config,
+            app_config,
+            config_dir: dir.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn test_discover_single_service_from_service_file() {
+        let dir = TempDir::new().unwrap();
+        let svc_file = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+            },
+            service: ServiceSection {
+                name: "api".to_string(),
+                service_type: ServiceType::Api,
+                port: 8000,
+                ingress: ServiceIngress::Public,
+                env_file: None,
+            },
+        };
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            Some(svc_file),
+            None,
+            AppSource::ServiceFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "api");
+        assert_eq!(services[0].path, ".");
+        assert_eq!(services[0].port, 8000);
+    }
+
+    #[test]
+    fn test_discover_multi_service_from_app_config_paths() {
+        let dir = TempDir::new().unwrap();
+
+        // Create subdirs with floo.service.toml
+        let backend = dir.path().join("backend");
+        let frontend = dir.path().join("frontend");
+        fs::create_dir(&backend).unwrap();
+        fs::create_dir(&frontend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "my-app", "api", 8000),
+        )
+        .unwrap();
+        fs::write(
+            frontend.join("floo.service.toml"),
+            make_service_toml("web", "my-app", "web", 3000),
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+        services_map.insert(
+            "web".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Web,
+                path: Some("./frontend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 2);
+
+        let names: HashSet<&str> = services.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains("api"));
+        assert!(names.contains("web"));
+
+        let api = services.iter().find(|s| s.name == "api").unwrap();
+        assert_eq!(api.path, "backend");
+        assert_eq!(api.port, 8000);
+
+        let web = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.path, "frontend");
+        assert_eq!(web.port, 3000);
+    }
+
+    #[test]
+    fn test_discover_includes_root_service_with_app_paths() {
+        let dir = TempDir::new().unwrap();
+
+        // Root floo.service.toml
+        let root_svc = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+            },
+            service: ServiceSection {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                port: 3000,
+                ingress: ServiceIngress::Public,
+                env_file: None,
+            },
+        };
+
+        // Sub-service
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "my-app", "api", 8000),
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            Some(root_svc),
+            Some(app_config),
+            AppSource::ServiceFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 2);
+
+        let names: HashSet<&str> = services.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains("web"));
+        assert!(names.contains("api"));
+
+        let root = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(root.path, ".");
+    }
+
+    #[test]
+    fn test_discover_skips_floo_managed_services() {
+        let dir = TempDir::new().unwrap();
+
+        // floo.service.toml at root for the deployable service
+        let root_svc = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+            },
+            service: ServiceSection {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                port: 3000,
+                ingress: ServiceIngress::Public,
+                env_file: None,
+            },
+        };
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "db".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Postgres,
+                path: None,
+                repo: None,
+                version: Some("16".to_string()),
+                plan: None,
+            },
+        );
+        services_map.insert(
+            "cache".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Redis,
+                path: None,
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            Some(root_svc),
+            Some(app_config),
+            AppSource::ServiceFile,
+        );
+
+        // No path entries -> falls to branch 2 (single service)
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "web");
+    }
+
+    #[test]
+    fn test_discover_errors_on_missing_service_toml() {
+        let dir = TempDir::new().unwrap();
+
+        // Create subdir but don't put floo.service.toml in it
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let err = discover_services(&resolved).unwrap_err();
+        assert_eq!(err.code, "SERVICE_CONFIG_MISSING");
+        assert!(err.message.contains("backend"));
+    }
+
+    #[test]
+    fn test_discover_errors_on_app_name_mismatch() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "wrong-app", "api", 8000),
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let err = discover_services(&resolved).unwrap_err();
+        assert_eq!(err.code, "APP_NAME_MISMATCH");
+        assert!(err.message.contains("wrong-app"));
+        assert!(err.message.contains("my-app"));
+    }
+
+    #[test]
+    fn test_discover_errors_on_duplicate_names() {
+        let dir = TempDir::new().unwrap();
+
+        // Root service named "api"
+        let root_svc = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+            },
+            service: ServiceSection {
+                name: "api".to_string(),
+                service_type: ServiceType::Api,
+                port: 8000,
+                ingress: ServiceIngress::Public,
+                env_file: None,
+            },
+        };
+
+        // Sub-service also named "api"
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "my-app", "api", 9000),
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api-svc".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            Some(root_svc),
+            Some(app_config),
+            AppSource::ServiceFile,
+        );
+
+        let err = discover_services(&resolved).unwrap_err();
+        assert_eq!(err.code, "DUPLICATE_SERVICE_NAMES");
+        assert!(err.message.contains("api"));
+    }
+
+    #[test]
+    fn test_discover_errors_no_deployable_services() {
+        let dir = TempDir::new().unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "db".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Postgres,
+                path: None,
+                repo: None,
+                version: Some("16".to_string()),
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let err = discover_services(&resolved).unwrap_err();
+        assert_eq!(err.code, "NO_DEPLOYABLE_SERVICES");
+    }
+
+    #[test]
+    fn test_discover_normalizes_dot_slash_paths() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "my-app", "api", 8000),
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend/".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].path, "backend");
+    }
+
+    #[test]
+    fn test_filter_empty_returns_all() {
+        let services = vec![
+            ServiceConfig {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                path: "frontend".to_string(),
+                port: 3000,
+                ingress: ServiceIngress::Public,
+            },
+            ServiceConfig {
+                name: "api".to_string(),
+                service_type: ServiceType::Api,
+                path: "backend".to_string(),
+                port: 8000,
+                ingress: ServiceIngress::Public,
+            },
+        ];
+
+        let result = filter_services(services, &[]).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_valid_subset() {
+        let services = vec![
+            ServiceConfig {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                path: "frontend".to_string(),
+                port: 3000,
+                ingress: ServiceIngress::Public,
+            },
+            ServiceConfig {
+                name: "api".to_string(),
+                service_type: ServiceType::Api,
+                path: "backend".to_string(),
+                port: 8000,
+                ingress: ServiceIngress::Public,
+            },
+        ];
+
+        let result = filter_services(services, &["api".to_string()]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "api");
+    }
+
+    #[test]
+    fn test_filter_unknown_name_errors() {
+        let services = vec![
+            ServiceConfig {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                path: "frontend".to_string(),
+                port: 3000,
+                ingress: ServiceIngress::Public,
+            },
+            ServiceConfig {
+                name: "api".to_string(),
+                service_type: ServiceType::Api,
+                path: "backend".to_string(),
+                port: 8000,
+                ingress: ServiceIngress::Public,
+            },
+        ];
+
+        let err = filter_services(services, &["nonexistent".to_string()]).unwrap_err();
+        assert_eq!(err.code, "UNKNOWN_SERVICE");
+        assert!(err.message.contains("nonexistent"));
+        assert!(err.suggestion.as_deref().unwrap().contains("web"));
+        assert!(err.suggestion.as_deref().unwrap().contains("api"));
+    }
+}

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -1,4 +1,5 @@
 mod app_config;
+mod discover;
 mod resolve;
 mod service_config;
 
@@ -9,7 +10,8 @@ const SCHEMA_URL: &str = "https://getfloo.com/docs/floo-toml";
 const MAX_WALK_UP_LEVELS: usize = 20;
 
 pub use app_config::{write_app_config, AppFileAppSection, AppFileConfig};
-pub use resolve::{resolve_app_context, AppSource, ResolvedApp};
+pub use discover::{discover_services, filter_services};
+pub use resolve::{resolve_app_context, AppSource};
 pub use service_config::{
     write_service_config, ServiceConfig, ServiceFileAppSection, ServiceFileConfig, ServiceIngress,
     ServiceSection, ServiceType,


### PR DESCRIPTION
## Summary

- Add service discovery from `floo.app.toml` path entries via new `discover_services()` / `filter_services()` in `src/project_config/discover.rs`
- Replace `--name` flag with repeatable `--services` flag (`--services api --services web`) to deploy a subset of services
- Move config resolution before runtime detection so multi-service apps with config files skip the unknown-runtime error
- 12 unit tests for discover/filter covering single-service, multi-service, path normalization, duplicate names, missing toml, and filter edge cases

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — 41 tests pass (12 new discover tests + 29 existing)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual test: `floo deploy` with single `floo.service.toml`
- [ ] Manual test: `floo deploy` with `floo.app.toml` multi-service paths
- [ ] Manual test: `floo deploy --services api` filters correctly

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)