### PR TITLE
[Bug] [#20 #21 #22] Fix URL encoding, apps pagination, and config corruption handling

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -89,6 +89,19 @@ impl FlooClient {
             .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
     }
 
+    fn get_with_query(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<reqwest::blocking::Response, FlooApiError> {
+        let mut req = self.client.get(self.url(path)).query(query);
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        req.send()
+            .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
+    }
+
     fn post_json(
         &self,
         path: &str,
@@ -499,17 +512,18 @@ impl FlooClient {
         severity: Option<&str>,
         service: Option<&str>,
     ) -> Result<Value, FlooApiError> {
-        let mut path = format!("/v1/apps/{app_id}/logs?limit={limit}");
+        let limit_str = limit.to_string();
+        let mut params: Vec<(&str, &str)> = vec![("limit", &limit_str)];
         if let Some(s) = since {
-            path.push_str(&format!("&since={s}"));
+            params.push(("since", s));
         }
         if let Some(sev) = severity {
-            path.push_str(&format!("&severity={sev}"));
+            params.push(("severity", sev));
         }
         if let Some(svc) = service {
-            path.push_str(&format!("&service={svc}"));
+            params.push(("service", svc));
         }
-        let resp = self.get(&path)?;
+        let resp = self.get_with_query(&format!("/v1/apps/{app_id}/logs"), &params)?;
         self.handle_response(resp)
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,7 +158,15 @@ pub enum AuthCommands {
 #[derive(Subcommand)]
 pub enum AppsCommands {
     /// List all your apps.
-    List,
+    List {
+        /// Page number.
+        #[arg(long, default_value = "1")]
+        page: u32,
+
+        /// Results per page.
+        #[arg(long, default_value = "50")]
+        per_page: u32,
+    },
 
     /// Show details for an app.
     Status {
@@ -386,7 +394,7 @@ pub fn run() {
         },
 
         Commands::Apps(sub) => match sub {
-            AppsCommands::List => commands::apps::list(),
+            AppsCommands::List { page, per_page } => commands::apps::list(page, per_page),
             AppsCommands::Status { app_name } => commands::apps::status(&app_name),
             AppsCommands::Delete { app_name, force } => commands::apps::delete(&app_name, force),
             AppsCommands::Connect {

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -3,10 +3,10 @@ use std::process;
 use crate::output;
 use crate::resolve::resolve_app;
 
-pub fn list() {
+pub fn list(page: u32, per_page: u32) {
     super::require_auth();
     let client = super::init_client(None);
-    let result = match client.list_apps(1, 20) {
+    let result = match client.list_apps(page, per_page) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, None);
@@ -20,11 +20,19 @@ pub fn list() {
         .cloned()
         .unwrap_or_default();
 
+    let total = result
+        .get("total")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(apps.len() as u64) as u32;
+
     if apps.is_empty() {
         if !output::is_json_mode() {
             output::info("No apps yet. Deploy one with floo deploy.", None);
         } else {
-            output::success("No apps.", Some(serde_json::json!({"apps": []})));
+            output::success(
+                "No apps.",
+                Some(serde_json::json!({"apps": [], "total": total, "page": page, "per_page": per_page})),
+            );
         }
         return;
     }
@@ -60,8 +68,17 @@ pub fn list() {
     output::table(
         &["Name", "Status", "URL", "Runtime", "Created"],
         &rows,
-        Some(serde_json::json!({"apps": apps})),
+        Some(serde_json::json!({"apps": apps, "total": total, "page": page, "per_page": per_page})),
     );
+
+    if !output::is_json_mode() && total > page * per_page {
+        let remaining = total - page * per_page;
+        output::dim_line(&format!(
+            "{remaining} more app{} not shown. Use --page {} to see next page.",
+            if remaining == 1 { "" } else { "s" },
+            page + 1
+        ));
+    }
 }
 
 pub fn status(app_name: &str) {

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -31,7 +31,9 @@ pub fn list(page: u32, per_page: u32) {
         } else {
             output::success(
                 "No apps.",
-                Some(serde_json::json!({"apps": [], "total": total, "page": page, "per_page": per_page})),
+                Some(
+                    serde_json::json!({"apps": [], "total": total, "page": page, "per_page": per_page}),
+                ),
             );
         }
         return;

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -20,10 +20,13 @@ pub fn list(page: u32, per_page: u32) {
         .cloned()
         .unwrap_or_default();
 
-    let total = result
-        .get("total")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(apps.len() as u64) as u32;
+    let total = match result.get("total").and_then(|v| v.as_u64()) {
+        Some(t) => t as u32,
+        None => {
+            eprintln!("Warning: API response missing 'total' field; pagination may be inaccurate.");
+            apps.len() as u32
+        }
+    };
 
     if apps.is_empty() {
         if !output::is_json_mode() {
@@ -73,13 +76,17 @@ pub fn list(page: u32, per_page: u32) {
         Some(serde_json::json!({"apps": apps, "total": total, "page": page, "per_page": per_page})),
     );
 
-    if !output::is_json_mode() && total > page * per_page {
-        let remaining = total - page * per_page;
-        output::dim_line(&format!(
-            "{remaining} more app{} not shown. Use --page {} to see next page.",
-            if remaining == 1 { "" } else { "s" },
-            page + 1
-        ));
+    if !output::is_json_mode() {
+        if let Some(shown) = page.checked_mul(per_page) {
+            if total > shown {
+                let remaining = total - shown;
+                output::dim_line(&format!(
+                    "{remaining} more app{} not shown. Use --page {} to see next page.",
+                    if remaining == 1 { "" } else { "s" },
+                    page + 1
+                ));
+            }
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,8 +48,26 @@ pub fn load_config() -> FlooConfig {
     let path = config_path();
     let mut config = if path.exists() {
         match fs::read_to_string(&path) {
-            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-            Err(_) => FlooConfig::default(),
+            Ok(content) => match serde_json::from_str(&content) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: config file at {} is corrupted ({e}), using defaults.",
+                        path.display()
+                    );
+                    eprintln!(
+                        "  Your API key may have been lost. Run 'floo login' to re-authenticate."
+                    );
+                    FlooConfig::default()
+                }
+            },
+            Err(e) => {
+                eprintln!(
+                    "Warning: could not read config file at {} ({e}), using defaults.",
+                    path.display()
+                );
+                FlooConfig::default()
+            }
         }
     } else {
         FlooConfig::default()
@@ -108,6 +126,14 @@ mod tests {
         assert_eq!(deserialized.api_key.as_deref(), Some("floo_test123"));
         assert_eq!(deserialized.api_url, "https://api.test.local");
         assert_eq!(deserialized.user_email.as_deref(), Some("test@example.com"));
+    }
+
+    #[test]
+    fn test_corrupted_json_returns_default() {
+        let corrupted = "{ not valid json !!!";
+        let result: FlooConfig = serde_json::from_str(corrupted).unwrap_or_default();
+        assert!(result.api_key.is_none());
+        assert_eq!(result.api_url, DEFAULT_API_URL);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,11 +129,16 @@ mod tests {
     }
 
     #[test]
-    fn test_corrupted_json_returns_default() {
-        let corrupted = "{ not valid json !!!";
-        let result: FlooConfig = serde_json::from_str(corrupted).unwrap_or_default();
-        assert!(result.api_key.is_none());
-        assert_eq!(result.api_url, DEFAULT_API_URL);
+    fn test_corrupted_config_file_returns_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(CONFIG_DIR_NAME);
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(config_dir.join(CONFIG_FILE_NAME), "{ not valid json !!!").unwrap();
+
+        env::set_var("HOME", tmp.path());
+        let config = load_config();
+        assert!(config.api_key.is_none());
+        assert_eq!(config.api_url, DEFAULT_API_URL);
     }
 
     #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -131,7 +131,7 @@ fn test_apps_list_json() {
         .mock("GET", "/v1/apps")
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
-            Matcher::UrlEncoded("per_page".into(), "20".into()),
+            Matcher::UrlEncoded("per_page".into(), "50".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -157,7 +157,7 @@ fn test_apps_list_human() {
         .mock("GET", "/v1/apps")
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
-            Matcher::UrlEncoded("per_page".into(), "20".into()),
+            Matcher::UrlEncoded("per_page".into(), "50".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -219,7 +219,7 @@ fn test_apps_list_api_error() {
         .mock("GET", "/v1/apps")
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
-            Matcher::UrlEncoded("per_page".into(), "20".into()),
+            Matcher::UrlEncoded("per_page".into(), "50".into()),
         ]))
         .with_status(500)
         .with_header("content-type", "application/json")
@@ -961,10 +961,7 @@ fn test_services_info_db_uses_db_endpoint() {
 
     // No user-managed services
     let _m_services = server
-        .mock(
-            "GET",
-            format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
-        )
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/services").as_str())
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),
@@ -1000,10 +997,7 @@ fn test_services_info_db_falls_back_to_databases_endpoint() {
     let _resolve = mock_resolve_app(&mut server);
 
     let _m_services = server
-        .mock(
-            "GET",
-            format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
-        )
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/services").as_str())
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),
@@ -1069,10 +1063,7 @@ fn test_services_info_surfaces_api_errors() {
     let _resolve = mock_resolve_app(&mut server);
 
     let _m_services = server
-        .mock(
-            "GET",
-            format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
-        )
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/services").as_str())
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),


### PR DESCRIPTION
## Summary

Fixes three CLI bugs found via codebase audit:

- **#20 — URL-encode query params in logs API call**: ISO timestamps with timezone offsets (e.g. `+05:00`) were concatenated directly into the URL string, causing `+` to be interpreted as a space. Added a `get_with_query()` helper that uses reqwest's `.query()` builder for proper URL encoding.

- **#21 — Apps list hardcoded to 20 results**: `floo apps list` was silently truncating at 20 results. Added `--page` (default 1) and `--per-page` (default 50) flags, with a pagination footer showing remaining count and next page hint. JSON output now includes `total`, `page`, and `per_page` fields.

- **#22 — Config corruption silently resets to default**: `unwrap_or_default()` on corrupted config JSON silently swallowed parse errors, losing the user's API key without any indication. Now prints a warning to stderr with the error details and suggests re-authenticating.

## Test plan

- [x] All 203 tests pass (`cargo test` — 106 unit, 51 CLI integration, 46 mock API)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Code review findings addressed (test rewritten to exercise `load_config()`, `total` fallback warns instead of silent, `page*per_page` overflow prevented)

Closes #20
Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)