### PR TITLE
[Feature] [#143] Add --restart flag to deploy and env set

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -568,6 +568,19 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn restart_app(
+        &self,
+        app_id: &str,
+        services: Option<&[String]>,
+    ) -> Result<Value, FlooApiError> {
+        let body = match services {
+            Some(svcs) => serde_json::json!({"services": svcs}),
+            None => serde_json::json!({}),
+        };
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/restart"), &body)?;
+        self.handle_response(resp)
+    }
+
     pub fn list_releases(
         &self,
         app_id: &str,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,10 @@ pub enum Commands {
         /// Deploy only these services (repeatable: --services api --services web).
         #[arg(short, long = "services")]
         services: Vec<String>,
+
+        /// Restart the app without re-uploading source (redeploy existing images with fresh env vars).
+        #[arg(long)]
+        restart: bool,
     },
 
     /// Authenticate and manage your account.
@@ -225,6 +229,10 @@ pub enum EnvCommands {
         /// Target specific services (repeatable).
         #[arg(long)]
         services: Vec<String>,
+
+        /// Restart the app after setting the env var (redeploy with fresh env vars).
+        #[arg(long)]
+        restart: bool,
     },
 
     /// List environment variables for an app.
@@ -385,7 +393,8 @@ pub fn run() {
             path,
             app,
             services,
-        } => commands::deploy::deploy(path, app, services),
+            restart,
+        } => commands::deploy::deploy(path, app, services, restart),
         Commands::Auth(sub) => match sub {
             AuthCommands::Login => commands::auth::login(),
             AuthCommands::Logout => commands::auth::logout(),
@@ -411,7 +420,8 @@ pub fn run() {
                 key_value,
                 app,
                 services,
-            } => commands::env::set(&key_value, app.as_deref(), &services),
+                restart,
+            } => commands::env::set(&key_value, app.as_deref(), &services, restart),
             EnvCommands::List { app, services } => commands::env::list(app.as_deref(), &services),
             EnvCommands::Remove { key, app, services } => {
                 commands::env::remove(&key, app.as_deref(), &services)

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -45,7 +45,7 @@ fn required_response_id<'a>(value: &'a serde_json::Value, object_name: &str) -> 
     }
 }
 
-pub fn deploy(path: PathBuf, app: Option<String>, services_filter: Vec<String>) {
+pub fn deploy(path: PathBuf, app: Option<String>, services_filter: Vec<String>, restart: bool) {
     let config = load_config();
     if config.api_key.is_none() {
         output::error(
@@ -54,6 +54,105 @@ pub fn deploy(path: PathBuf, app: Option<String>, services_filter: Vec<String>) 
             Some("Run 'floo login' to authenticate."),
         );
         process::exit(1);
+    }
+
+    // --- Restart path: skip detection/archive, call restart API ---
+    if restart {
+        let client = super::init_client(Some(config));
+        let app_ident = match app.as_deref() {
+            Some(a) => a.to_string(),
+            None => {
+                let cwd = std::env::current_dir().unwrap_or_else(|e| {
+                    output::error(
+                        &format!("Failed to read current directory: {e}"),
+                        "FILE_ERROR",
+                        None,
+                    );
+                    process::exit(1);
+                });
+                match project_config::resolve_app_context(&cwd, None) {
+                    Ok(r) => r.app_name,
+                    Err(e) => {
+                        output::error(&e.message, &e.code, e.suggestion.as_deref());
+                        process::exit(1);
+                    }
+                }
+            }
+        };
+
+        let app_data = match resolve_app(&client, &app_ident) {
+            Ok(a) => a,
+            Err(e) => {
+                if e.code == "APP_NOT_FOUND" {
+                    output::error(
+                        &format!("App '{app_ident}' not found."),
+                        "APP_NOT_FOUND",
+                        Some("Check the app name or ID and try again."),
+                    );
+                } else {
+                    output::error(&e.message, &e.code, None);
+                }
+                process::exit(1);
+            }
+        };
+        let app_id = required_response_id(&app_data, "app").to_string();
+
+        let svcs = if services_filter.is_empty() {
+            None
+        } else {
+            Some(services_filter.as_slice())
+        };
+
+        let spinner = output::Spinner::new("Restarting...");
+        let deploy_data = match client.restart_app(&app_id, svcs) {
+            Ok(d) => {
+                spinner.finish();
+                d
+            }
+            Err(e) => {
+                spinner.finish();
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
+        };
+
+        let final_status = match deploy_data.get("status").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                output::error(
+                    "API response missing 'status' field.",
+                    "INVALID_RESPONSE",
+                    Some("This may indicate a CLI/API version mismatch. Try `floo update`."),
+                );
+                process::exit(1);
+            }
+        };
+        let url = deploy_data
+            .get("url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(no URL)");
+
+        if final_status == "failed" {
+            output::error_with_data(
+                "Restart failed.",
+                "RESTART_FAILED",
+                Some("Run `floo logs` for details."),
+                Some(serde_json::json!({
+                    "app": app_data,
+                    "deploy": deploy_data,
+                })),
+            );
+            process::exit(1);
+        }
+
+        output::success(
+            &format!("Restarted {url}"),
+            Some(serde_json::json!({
+                "app": app_data,
+                "deploy": deploy_data,
+            })),
+        );
+        return;
     }
 
     let project_path = match path.canonicalize() {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -243,7 +243,7 @@ fn parse_env_file(path: &Path) -> Vec<(String, String)> {
 // Commands
 // ---------------------------------------------------------------------------
 
-pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String]) {
+pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String], restart: bool) {
     super::require_auth();
 
     if !key_value.contains('=') {
@@ -262,6 +262,7 @@ pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String]) {
     let (app_id, app_name) = resolve_app_id(&client, app_flag);
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
 
+    let mut last_env_result = serde_json::Value::Null;
     for (service_id, service_name) in &targets {
         match client.set_env_var(&app_id, &key, value, service_id.as_deref()) {
             Ok(result) => {
@@ -269,13 +270,68 @@ pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String]) {
                     Some(sn) => format!("{app_name}/{sn}"),
                     None => app_name.clone(),
                 };
-                output::success(&format!("Set {key} on {target}."), Some(result));
+                last_env_result = result.clone();
+                if !restart || !output::is_json_mode() {
+                    output::success(&format!("Set {key} on {target}."), Some(result));
+                }
             }
             Err(e) => {
                 output::error(&e.message, &e.code, None);
                 process::exit(1);
             }
         }
+    }
+
+    if restart {
+        let svcs = if service_names.is_empty() {
+            None
+        } else {
+            Some(service_names)
+        };
+
+        let spinner = output::Spinner::new("Restarting...");
+        let deploy_data = match client.restart_app(&app_id, svcs) {
+            Ok(d) => {
+                spinner.finish();
+                d
+            }
+            Err(e) => {
+                spinner.finish();
+                output::error(&e.message, &e.code, None);
+                process::exit(1);
+            }
+        };
+
+        let final_status = match deploy_data.get("status").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => {
+                output::error(
+                    "API response missing 'status' field.",
+                    "INVALID_RESPONSE",
+                    Some("This may indicate a CLI/API version mismatch. Try `floo update`."),
+                );
+                process::exit(1);
+            }
+        };
+        let url = deploy_data
+            .get("url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(no URL)");
+
+        if final_status == "failed" {
+            output::error_with_data(
+                "Restart failed.",
+                "RESTART_FAILED",
+                Some("Run `floo logs` for details."),
+                Some(serde_json::json!({"env": last_env_result, "deploy": deploy_data})),
+            );
+            process::exit(1);
+        }
+
+        output::success(
+            &format!("Restarted {url}"),
+            Some(serde_json::json!({"env": last_env_result, "deploy": deploy_data})),
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `restart_app()` method to `FlooClient` (`POST /v1/apps/{app_id}/restart`)
- Add `--restart` flag to `floo deploy` (skip upload, call restart API)
- Add `--restart` flag to `floo env set` (set env var, then restart)
- Proper JSON mode support: single JSON object on stdout when `--json --restart` used together

Closes getfloo/floo#143

Companion API PR: getfloo/floo#197

## Changes
| File | What |
|------|------|
| `src/api_client.rs` | Add `restart_app()` method |
| `src/cli.rs` | Add `--restart` flag to `Deploy` and `EnvCommands::Set` |
| `src/commands/deploy.rs` | Restart path: resolve app, call restart API, handle status |
| `src/commands/env.rs` | After env set: call restart API, guard JSON output to avoid duplicate objects |

## Test plan
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build` — compiles
- [x] `floo deploy --help` shows `--restart` flag
- [x] `floo env set --help` shows `--restart` flag
- [x] Code review: `code-reviewer` + `silent-failure-hunter` — all findings fixed

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)