### PR TITLE
[Feature] Add floo skills install command with embedded agent playbook

### DIFF
--- a/.claude/skills/rust/SKILL.md
+++ b/.claude/skills/rust/SKILL.md
@@ -454,3 +454,5 @@ All error codes used in the CLI. New error codes must be `UPPER_SNAKE_CASE` and 
 | `NO_CONFIG_FOUND` | project_config/resolve.rs | No config files found and no `--app` flag |
 | `LEGACY_CONFIG` | project_config/resolve.rs | Found old `floo.toml`, must migrate to new config files |
 | `CONFIG_WRITE_ERROR` | project_config/ | Failed to serialize or write config file |
+| `MISSING_ARGUMENT` | commands/skills | Required argument not provided (e.g. --path or --print) |
+| `IO_ERROR` | commands/skills | File system operation failed (create dir, write file, resolve path) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,12 @@ Packs source into `.tar.gz`, respects `.flooignore`. 500MB size limit.
   - CLI issues: `Closes #N` (same-repo reference)
   - Cross-repo issues: `Closes getfloo/floo#N`
 
+## Agent Skill Maintenance
+
+The file `skills/floo.md` is the agent playbook embedded in the binary via `include_str!`.
+When adding new commands, changing flags, or modifying error codes, update `skills/floo.md`
+to reflect the changes. The skill is the primary way agents learn to use floo.
+
 ## Release Flow
 
 1. Tag `v*` on main branch

--- a/install.sh
+++ b/install.sh
@@ -176,13 +176,15 @@ main() {
     [[ -n "$version_output" ]] || fail "Installation completed but '${INSTALL_DIR}/${BINARY_NAME} --version' failed."
 
     echo
-    echo "Floo CLI installed successfully."
-    echo "Version: ${version_output}"
+    echo "floo installed successfully (${version_output})"
     echo
     echo "Get started:"
-    echo "  floo login"
-    echo "  floo deploy"
-    echo "  floo update"
+    echo "  floo auth login                        log in or create an account"
+    echo "  floo --help                            see all available commands"
+    echo
+    echo "Agent integration:"
+    echo "  floo skills install --path <dir>       install agent skill to a directory"
+    echo "  floo skills install --print            print skill to stdout"
 }
 
 main "$@"

--- a/skills/floo.md
+++ b/skills/floo.md
@@ -1,0 +1,206 @@
+# Floo — Agent Skill
+
+Floo is a deployment platform. CLI-first — the CLI is the primary interface. Deploy apps with `floo deploy`.
+
+Every command supports `--json` for structured output: JSON goes to stdout, human-readable output goes to stderr. This means `floo deploy --json 2>/dev/null | jq` works for parsing.
+
+## Authentication
+
+```bash
+floo auth login        # opens browser, handles login + account creation (device code flow)
+floo auth logout       # clear stored credentials
+floo auth whoami       # show current user
+```
+
+No auth required for `floo skills install` or `floo --help`.
+
+Credentials are stored at `~/.floo/config.json`.
+
+If signups are closed, you'll get a `SIGNUP_DISABLED` error — join the waitlist at https://getfloo.com.
+
+## Platform Architecture
+
+**Apps** contain **services**. An app is the top-level unit; services are deployable components.
+
+### Service Types
+
+- **User-managed** — your code (web servers, APIs, workers). Deployed from source via `floo deploy`.
+- **Database** — managed Postgres, auto-provisioned. Connection string injected as `DATABASE_URL` env var. Inspect with `floo services info <name>`.
+- **Gateway** — reverse proxy for custom domains and path-prefix routing. Optional, opt-in per app.
+
+### Deploy Flow
+
+1. Detect runtime (Dockerfile > package.json > pyproject.toml > go.mod > index.html)
+2. Archive source (respects `.flooignore`)
+3. Upload to Floo API
+4. Build container image
+5. Deploy to Cloud Run
+6. Return live URL
+
+## Config Files
+
+### `floo.service.toml` — Single-Service Apps
+
+```toml
+[app]
+name = "my-app"
+
+[service]
+port = 8080
+runtime = "python"
+build_command = "pip install -r requirements.txt"
+```
+
+### `floo.app.toml` — Multi-Service Apps
+
+```toml
+[app]
+name = "my-app"
+
+[[services]]
+name = "api"
+path = "./api"
+
+[[services]]
+name = "web"
+path = "./web"
+```
+
+Each service directory has its own `floo.service.toml`.
+
+## Command Reference
+
+### Deploy
+
+```bash
+floo deploy [path] --json
+# --app <name>        deploy to existing app
+# --services <name>   deploy specific services (repeatable)
+# --restart           restart without re-uploading source
+```
+
+JSON output: `data.app`, `data.deploy`, `data.detection`
+
+### Apps
+
+```bash
+floo apps list --json                    # list all apps
+floo apps status <name> --json           # app details + services + deploy status
+floo apps delete <name> --json           # delete an app (--force to skip prompt)
+floo apps connect --repo owner/repo --installation-id <id> --app <name>  # GitHub auto-deploy
+floo apps disconnect --app <name>        # remove GitHub connection
+```
+
+### Environment Variables
+
+```bash
+floo env set KEY=value --app <name> --json          # set env var
+floo env set KEY=value --app <name> --restart --json # set + restart
+floo env list --app <name> --json                    # list env vars
+floo env get KEY --app <name> --json                 # get plaintext value
+floo env remove KEY --app <name> --json              # remove env var
+floo env import .env --app <name> --json             # import from .env file
+# --services <name>   target specific services (repeatable)
+```
+
+### Custom Domains
+
+```bash
+floo domains add <hostname> --app <name> --json      # add domain
+floo domains list --app <name> --json                 # list domains
+floo domains remove <hostname> --app <name> --json    # remove domain
+# --services <name>   target specific service
+```
+
+### Logs
+
+```bash
+floo logs --app <name> --json
+# --tail <n>          number of lines (default: 100)
+# --since <duration>  e.g. 1h, 30m, 2d, or ISO timestamp
+# --severity <level>  DEBUG, INFO, WARNING, ERROR, CRITICAL
+# --error             shorthand for --severity ERROR
+# --services <name>   filter by service (repeatable)
+# --search <text>     filter by text (case-insensitive)
+# --live              stream logs in real-time (poll every 2s)
+# --output <file>     write logs to file
+```
+
+### Services
+
+```bash
+floo services list --app <name> --json               # list all services
+floo services info <service-name> --app <name> --json # service details
+```
+
+### Releases & Rollbacks
+
+```bash
+floo releases list --app <name> --json               # list releases
+floo releases show <release-id> --app <name> --json  # release details
+floo promote --app <name> --json                     # promote to prod (GitHub release)
+floo rollbacks list --app <name> --json              # list deploys for rollback
+floo rollback <app> <deploy-id> --json               # rollback to a previous deploy
+```
+
+### CLI Management
+
+```bash
+floo version --json                      # print installed version
+floo update --json                       # update CLI binary
+floo update --version v0.2.0 --json      # install specific version
+floo skills install --path <dir>         # install agent skill to directory
+floo skills install --print              # print skill content to stdout
+```
+
+## Error Codes
+
+| Code | Meaning | Recovery |
+|------|---------|----------|
+| `NOT_AUTHENTICATED` | No API key found | Run `floo auth login` |
+| `SIGNUP_DISABLED` | Account creation is closed | Join waitlist at https://getfloo.com |
+| `DEPLOY_FAILED` | Build or deploy failed | Check build logs: `floo deploy --json \| jq '.data.deploy.build_logs'` |
+| `DEPLOY_TIMEOUT` | Deploy didn't complete in time | Check status: `floo apps status <name> --json` |
+| `APP_NOT_FOUND` | App name/ID doesn't exist | Verify name: `floo apps list --json` |
+| `ENV_VAR_NOT_FOUND` | Env var key doesn't exist | List vars: `floo env list --app <name> --json` |
+| `DOMAIN_ALREADY_EXISTS` | Domain already assigned | Check domains: `floo domains list --app <name> --json` |
+| `PARSE_ERROR` | Unexpected API response | This is a bug — report it |
+
+All errors in `--json` mode return: `{"success": false, "error": {"code": "...", "message": "...", "suggestion": "..."}}`
+
+## Common Workflows
+
+### Deploy and verify
+
+```bash
+floo deploy . --json
+floo apps status <app-name> --json
+floo logs --app <app-name> --json --since 1m --severity ERROR
+```
+
+### Set env var and restart
+
+```bash
+floo env set DATABASE_URL=postgres://... --app <name> --restart --json
+```
+
+### Check deploy status after failure
+
+```bash
+floo apps status <app-name> --json | jq '.data.services'
+floo logs --app <app-name> --json --since 5m --error
+```
+
+### Rollback a bad deploy
+
+```bash
+floo rollbacks list --app <name> --json          # find the deploy ID
+floo rollback <app-name> <deploy-id> --force --json
+```
+
+### Add a custom domain
+
+```bash
+floo domains add app.example.com --app <name> --json
+# Then configure DNS: CNAME to the URL from floo apps status
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,6 +133,10 @@ pub enum Commands {
         output: Option<PathBuf>,
     },
 
+    /// Install agent skills for AI coding assistants.
+    #[command(subcommand)]
+    Skills(SkillsCommands),
+
     /// Print installed CLI version.
     Version,
 
@@ -381,6 +385,20 @@ pub enum RollbacksCommands {
     },
 }
 
+#[derive(Subcommand)]
+pub enum SkillsCommands {
+    /// Install the floo agent skill file to a directory.
+    Install {
+        /// Directory to write floo.md into (e.g. ~/.claude/commands/).
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// Print skill content to stdout instead of writing a file.
+        #[arg(long)]
+        print: bool,
+    },
+}
+
 pub fn run() {
     let cli = Cli::parse();
 
@@ -479,6 +497,10 @@ pub fn run() {
             deploy_id,
             force,
         } => commands::rollbacks::rollback(&app, &deploy_id, force),
+
+        Commands::Skills(sub) => match sub {
+            SkillsCommands::Install { path, print } => commands::skills::install(path, print),
+        },
 
         Commands::Logs {
             app,

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -136,6 +136,12 @@ pub fn login() {
                     &format!("Logged in as {email}"),
                     Some(serde_json::json!({"email": email})),
                 );
+                if !output::is_json_mode() {
+                    eprintln!();
+                    eprintln!(
+                        "  Tip: Run 'floo skills install --path <dir>' to set up agent integration."
+                    );
+                }
                 return;
             }
             Err(e) if e.status_code == 202 => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod logs;
 pub mod releases;
 pub mod rollbacks;
 pub mod services;
+pub mod skills;
 pub mod update;
 
 pub(crate) fn init_client(config: Option<FlooConfig>) -> FlooClient {

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -1,0 +1,191 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process;
+
+use crate::config::{load_config, save_config};
+use crate::constants::VERSION;
+use crate::output;
+
+const SKILL_CONTENT: &str = include_str!("../../skills/floo.md");
+
+pub fn install(path: Option<PathBuf>, print: bool) {
+    if print {
+        if output::is_json_mode() {
+            output::success(
+                "Skill content",
+                Some(serde_json::json!({
+                    "content": SKILL_CONTENT,
+                    "version": VERSION,
+                })),
+            );
+        } else {
+            std::io::stdout()
+                .write_all(SKILL_CONTENT.as_bytes())
+                .unwrap_or_else(|e| {
+                    output::error(
+                        &format!("Failed to write to stdout: {e}"),
+                        "IO_ERROR",
+                        None,
+                    );
+                    process::exit(1);
+                });
+        }
+        return;
+    }
+
+    let dir = match path {
+        Some(d) => d,
+        None => {
+            output::error(
+                "No target specified.",
+                "MISSING_ARGUMENT",
+                Some("Provide --path <dir> to install or --print to output to stdout."),
+            );
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = fs::create_dir_all(&dir) {
+        output::error(
+            &format!("Failed to create directory '{}': {e}", dir.display()),
+            "IO_ERROR",
+            None,
+        );
+        process::exit(1);
+    }
+
+    let file_path = dir.join("floo.md");
+
+    let abs_path = match file_path.canonicalize().or_else(|_| {
+        // Directory exists but file doesn't yet — canonicalize the parent and append filename
+        dir.canonicalize().map(|d| d.join("floo.md"))
+    }) {
+        Ok(p) => p,
+        Err(e) => {
+            output::error(
+                &format!("Failed to resolve path '{}': {e}", file_path.display()),
+                "IO_ERROR",
+                None,
+            );
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = fs::write(&abs_path, SKILL_CONTENT) {
+        output::error(
+            &format!("Failed to write '{}': {e}", abs_path.display()),
+            "IO_ERROR",
+            None,
+        );
+        process::exit(1);
+    }
+
+    // Track the path in config
+    let abs_str = match abs_path.to_str() {
+        Some(s) => s.to_string(),
+        None => {
+            output::error(
+                &format!(
+                    "Path '{}' contains invalid UTF-8 and cannot be tracked.",
+                    abs_path.display()
+                ),
+                "IO_ERROR",
+                Some("Use a path containing only valid UTF-8 characters."),
+            );
+            process::exit(1);
+        }
+    };
+    let mut config = load_config();
+    config.add_skill_path(&abs_str);
+    if let Err(e) = save_config(&config) {
+        output::error(
+            &format!("Skill installed but failed to save config: {e}"),
+            "CONFIG_ERROR",
+            None,
+        );
+        process::exit(1);
+    }
+
+    output::success(
+        &format!("Installed agent skill to {}", abs_path.display()),
+        Some(serde_json::json!({
+            "path": abs_str,
+            "version": VERSION,
+        })),
+    );
+}
+
+/// Refresh all tracked skill files. Returns the list of paths that were refreshed.
+/// Removes stale paths (directories that no longer exist) from tracking.
+/// Reports errors for write failures without removing those paths.
+pub fn refresh_skill_files() -> Vec<String> {
+    let mut config = load_config();
+    if config.skill_paths.is_empty() {
+        return Vec::new();
+    }
+
+    let mut refreshed = Vec::new();
+    let mut still_valid = Vec::new();
+
+    for path_str in &config.skill_paths {
+        let path = PathBuf::from(path_str);
+        let parent_exists = path.parent().is_some_and(|p| p.exists());
+
+        if !parent_exists {
+            // Parent directory gone — prune from tracking
+            if !output::is_json_mode() {
+                eprintln!(
+                    "  Removed stale skill path (directory gone): {path_str}"
+                );
+            }
+            continue;
+        }
+
+        match fs::write(&path, SKILL_CONTENT) {
+            Ok(()) => {
+                refreshed.push(path_str.clone());
+                still_valid.push(path_str.clone());
+            }
+            Err(e) => {
+                // Write failed but directory exists — keep tracking, report error
+                still_valid.push(path_str.clone());
+                if !output::is_json_mode() {
+                    eprintln!(
+                        "  Warning: failed to refresh skill at {path_str}: {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    if still_valid.len() != config.skill_paths.len() {
+        config.skill_paths = still_valid;
+        if let Err(e) = save_config(&config) {
+            if !output::is_json_mode() {
+                eprintln!("  Warning: failed to update skill tracking in config: {e}");
+            }
+        }
+    }
+
+    refreshed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skill_content_is_embedded() {
+        assert!(!SKILL_CONTENT.is_empty());
+        assert!(SKILL_CONTENT.contains("# Floo"));
+    }
+
+    #[test]
+    fn test_skill_content_has_key_sections() {
+        assert!(SKILL_CONTENT.contains("## Authentication"));
+        assert!(SKILL_CONTENT.contains("## Command Reference"));
+        assert!(SKILL_CONTENT.contains("## Error Codes"));
+        assert!(SKILL_CONTENT.contains("--json"));
+    }
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -19,11 +19,20 @@ pub fn update(version: Option<&str>) {
 
     match updater::run_update(version) {
         Ok(result) => {
+            let refreshed = super::skills::refresh_skill_files();
+
+            if !output::is_json_mode() {
+                for path in &refreshed {
+                    eprintln!("  Refreshed agent skill at {path}");
+                }
+            }
+
             output::success(
                 &format!("Updated Floo to {}.", result.version),
                 Some(serde_json::json!({
                     "version": result.version,
                     "path": result.install_path,
+                    "refreshed_skills": refreshed,
                 })),
             );
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct FlooConfig {
     pub api_url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_email: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skill_paths: Vec<String>,
 }
 
 fn default_api_url() -> String {
@@ -26,7 +28,19 @@ impl Default for FlooConfig {
             api_key: None,
             api_url: DEFAULT_API_URL.to_string(),
             user_email: None,
+            skill_paths: Vec::new(),
         }
+    }
+}
+
+impl FlooConfig {
+    /// Add a skill path if not already tracked. Returns true if added.
+    pub fn add_skill_path(&mut self, path: &str) -> bool {
+        if self.skill_paths.iter().any(|p| p == path) {
+            return false;
+        }
+        self.skill_paths.push(path.to_string());
+        true
     }
 }
 
@@ -120,12 +134,36 @@ mod tests {
             api_key: Some("floo_test123".to_string()),
             api_url: "https://api.test.local".to_string(),
             user_email: Some("test@example.com".to_string()),
+            skill_paths: vec!["/tmp/floo.md".to_string()],
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: FlooConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.api_key.as_deref(), Some("floo_test123"));
         assert_eq!(deserialized.api_url, "https://api.test.local");
         assert_eq!(deserialized.user_email.as_deref(), Some("test@example.com"));
+        assert_eq!(deserialized.skill_paths, vec!["/tmp/floo.md"]);
+    }
+
+    #[test]
+    fn test_config_without_skill_paths_deserializes() {
+        let json = r#"{"api_key":"floo_x","api_url":"https://api.getfloo.com"}"#;
+        let config: FlooConfig = serde_json::from_str(json).unwrap();
+        assert!(config.skill_paths.is_empty());
+    }
+
+    #[test]
+    fn test_add_skill_path_deduplicates() {
+        let mut config = FlooConfig::default();
+        assert!(config.add_skill_path("/tmp/floo.md"));
+        assert!(!config.add_skill_path("/tmp/floo.md"));
+        assert_eq!(config.skill_paths.len(), 1);
+    }
+
+    #[test]
+    fn test_skill_paths_omitted_when_empty() {
+        let config = FlooConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("skill_paths"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `floo skills install` command that embeds an agent playbook (`skills/floo.md`) in the binary via `include_str!`
- `--path <dir>` writes `floo.md` to a directory and tracks the path in `~/.floo/config.json`
- `--print` outputs skill content to stdout (wrapped in JSON envelope when `--json` is used)
- Tracked skill files auto-refresh on `floo update`
- Post-login tip and updated install.sh message hint about agent integration

## Changes

| File | Change |
|------|--------|
| `skills/floo.md` | New — 206-line agent playbook (auth, architecture, commands, errors, workflows) |
| `src/commands/skills.rs` | New — `install` subcommand + `refresh_skill_files()` for update |
| `src/cli.rs` | Add `Skills(SkillsCommands)` variant + dispatch |
| `src/commands/mod.rs` | Add `pub mod skills` |
| `src/config.rs` | Add `skill_paths: Vec<String>` field + `add_skill_path()` helper + 4 tests |
| `src/commands/update.rs` | Call `refresh_skill_files()` after successful update |
| `src/commands/auth.rs` | Post-login tip about `floo skills install` |
| `install.sh` | Updated post-install message with agent integration section |
| `CLAUDE.md` | Agent Skill Maintenance section |
| `.claude/skills/rust/SKILL.md` | New error codes: `MISSING_ARGUMENT`, `IO_ERROR` |

## Test plan

- [x] `cargo build` — compiles with embedded skill
- [x] `cargo test` — 209 tests pass (110 unit + 51 CLI + 46 mock API + 2 new skill tests)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `floo skills install --print` — outputs 206 lines of skill content to stdout
- [x] `floo --json skills install --print` — returns JSON with content and version
- [x] `floo skills install --path /tmp/test` — writes file, tracks in config
- [x] `floo --json skills install --path /tmp/test` — returns `{"success": true, "data": {"path": "...", "version": "0.1.0"}}`
- [x] `floo skills install` (no flags) — errors with usage hint
- [x] `cat ~/.floo/config.json` — `skill_paths` present after install
- [x] `bash -n install.sh` — syntax OK

## Discovered issues

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)