### PR TITLE
[Feature] Add access_mode to config structs and send during deploy

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -208,6 +208,7 @@ impl FlooClient {
         runtime: &str,
         framework: Option<&str>,
         services: Option<&[ServiceConfig]>,
+        access_mode: Option<&str>,
     ) -> Result<Value, FlooApiError> {
         let file_bytes = std::fs::read(tarball_path).map_err(|e| {
             FlooApiError::new(0, "FILE_ERROR", format!("Failed to read archive: {e}"))
@@ -237,6 +238,10 @@ impl FlooClient {
                 )
             })?;
             form = form.text("services", json);
+        }
+
+        if let Some(mode) = access_mode {
+            form = form.text("access_mode", mode.to_string());
         }
 
         let mut req = self
@@ -528,6 +533,26 @@ impl FlooClient {
     }
 
     // --- GitHub ---
+
+    pub fn github_setup_begin(&self) -> Result<Value, FlooApiError> {
+        let resp = self.post_json("/v1/github/setup/begin", &serde_json::json!({}))?;
+        self.handle_response(resp)
+    }
+
+    pub fn github_setup_poll(&self) -> Result<Value, FlooApiError> {
+        let resp = self.get("/v1/github/setup/poll")?;
+        self.handle_response(resp)
+    }
+
+    pub fn github_installation_repos(
+        &self,
+        installation_id: u64,
+    ) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!(
+            "/v1/github/installations/{installation_id}/repos"
+        ))?;
+        self.handle_response(resp)
+    }
 
     pub fn github_connect(
         &self,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -13,8 +13,8 @@ use crate::errors::FlooApiError;
 use crate::names::generate_name;
 use crate::output;
 use crate::project_config::{
-    self, AppFileAppSection, AppFileConfig, AppSource, ServiceConfig, ServiceFileAppSection,
-    ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
+    self, AppAccessMode, AppFileAppSection, AppFileConfig, AppSource, ServiceConfig,
+    ServiceFileAppSection, ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
 };
 use crate::resolve::resolve_app;
 
@@ -421,6 +421,14 @@ pub fn deploy(path: PathBuf, app: Option<String>, services_filter: Vec<String>, 
     };
     let app_id = required_response_id(&app_data, "app").to_string();
 
+    // Extract access_mode from config: app_config wins over service_config
+    let access_mode: Option<AppAccessMode> = resolved.as_ref().and_then(|r| {
+        r.app_config
+            .as_ref()
+            .and_then(|c| c.app.access_mode)
+            .or_else(|| r.service_config.as_ref().and_then(|c| c.app.access_mode))
+    });
+
     // Deploy
     let svc_slice = services.as_deref();
     let spinner = output::Spinner::new("Uploading...");
@@ -430,6 +438,7 @@ pub fn deploy(path: PathBuf, app: Option<String>, services_filter: Vec<String>, 
         &detection.runtime,
         detection.framework.as_deref(),
         svc_slice,
+        access_mode.as_ref().map(|m| m.as_str()),
     ) {
         Ok(d) => {
             spinner.finish();
@@ -572,6 +581,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
     let service_file = ServiceFileConfig {
         app: ServiceFileAppSection {
             name: app_name.to_string(),
+            access_mode: None,
         },
         service: ServiceSection {
             name: service.name.clone(),
@@ -585,6 +595,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
     let app_file = AppFileConfig {
         app: AppFileAppSection {
             name: app_name.to_string(),
+            access_mode: None,
         },
         services: HashMap::new(),
     };

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -15,10 +15,30 @@ pub struct AppFileConfig {
     pub services: HashMap<String, AppServiceEntry>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppAccessMode {
+    Public,
+    Password,
+    FlooAccounts,
+}
+
+impl AppAccessMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AppAccessMode::Public => "public",
+            AppAccessMode::Password => "password",
+            AppAccessMode::FlooAccounts => "floo_accounts",
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppFileAppSection {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_mode: Option<AppAccessMode>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -270,6 +290,7 @@ type = "mysql"
         let config = AppFileConfig {
             app: AppFileAppSection {
                 name: "roundtrip-app".to_string(),
+                access_mode: None,
             },
             services: HashMap::new(),
         };
@@ -312,5 +333,89 @@ path = "./backend"
         assert_eq!(config.services["cache"].service_type, AppServiceType::Redis);
         assert_eq!(config.services["web"].service_type, AppServiceType::Web);
         assert_eq!(config.services["api"].service_type, AppServiceType::Api);
+    }
+
+    #[test]
+    fn test_load_app_config_with_access_mode_public() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+access_mode = "public"
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.app.access_mode, Some(AppAccessMode::Public));
+    }
+
+    #[test]
+    fn test_load_app_config_with_access_mode_floo_accounts() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+access_mode = "floo_accounts"
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.app.access_mode, Some(AppAccessMode::FlooAccounts));
+    }
+
+    #[test]
+    fn test_load_app_config_with_access_mode_password() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+access_mode = "password"
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.app.access_mode, Some(AppAccessMode::Password));
+    }
+
+    #[test]
+    fn test_load_app_config_without_access_mode_defaults_none() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert!(config.app.access_mode.is_none());
+    }
+
+    #[test]
+    fn test_load_app_config_invalid_access_mode() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+access_mode = "private"
+"#,
+        )
+        .unwrap();
+
+        let err = load_app_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, "INVALID_PROJECT_CONFIG");
     }
 }

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -207,6 +207,7 @@ ingress = "public"
         let svc_file = ServiceFileConfig {
             app: ServiceFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             service: ServiceSection {
                 name: "api".to_string(),
@@ -276,6 +277,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -312,6 +314,7 @@ ingress = "public"
         let root_svc = ServiceFileConfig {
             app: ServiceFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             service: ServiceSection {
                 name: "web".to_string(),
@@ -346,6 +349,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -377,6 +381,7 @@ ingress = "public"
         let root_svc = ServiceFileConfig {
             app: ServiceFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             service: ServiceSection {
                 name: "web".to_string(),
@@ -412,6 +417,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -453,6 +459,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -497,6 +504,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -523,6 +531,7 @@ ingress = "public"
         let root_svc = ServiceFileConfig {
             app: ServiceFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             service: ServiceSection {
                 name: "api".to_string(),
@@ -557,6 +566,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -593,6 +603,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };
@@ -636,6 +647,7 @@ ingress = "public"
         let app_config = AppFileConfig {
             app: AppFileAppSection {
                 name: "my-app".to_string(),
+                access_mode: None,
             },
             services: services_map,
         };

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -9,7 +9,7 @@ pub const LEGACY_CONFIG_FILE: &str = "floo.toml";
 const SCHEMA_URL: &str = "https://getfloo.com/docs/floo-toml";
 const MAX_WALK_UP_LEVELS: usize = 20;
 
-pub use app_config::{write_app_config, AppFileAppSection, AppFileConfig};
+pub use app_config::{write_app_config, AppAccessMode, AppFileAppSection, AppFileConfig};
 pub use discover::{discover_services, filter_services};
 pub use resolve::{resolve_app_context, AppSource};
 pub use service_config::{

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::FlooError;
 
+use super::app_config::AppAccessMode;
 use super::SCHEMA_URL;
 
 // --- API wire format (sent to the API as JSON) ---
@@ -67,6 +68,8 @@ pub struct ServiceFileConfig {
 #[serde(deny_unknown_fields)]
 pub struct ServiceFileAppSection {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_mode: Option<AppAccessMode>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -249,6 +252,7 @@ ingress = "internal"
         let config = ServiceFileConfig {
             app: ServiceFileAppSection {
                 name: "roundtrip-app".to_string(),
+                access_mode: None,
             },
             service: ServiceSection {
                 name: "web".to_string(),
@@ -300,5 +304,50 @@ ingress = "internal"
         assert_eq!(json["port"], 8000);
         assert_eq!(json["ingress"], "internal");
         assert!(json.get("type").is_none());
+    }
+
+    #[test]
+    fn test_load_service_config_with_access_mode() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+access_mode = "floo_accounts"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+ingress = "public"
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.app.access_mode, Some(AppAccessMode::FlooAccounts));
+    }
+
+    #[test]
+    fn test_load_service_config_without_access_mode() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+ingress = "public"
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert!(config.app.access_mode.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Add `AppAccessMode` enum (`public`, `password`, `floo_accounts`) to `app_config.rs`
- Add `access_mode: Option<AppAccessMode>` to both `AppFileAppSection` and `ServiceFileAppSection`
- Extract `access_mode` from resolved config during deploy (app-level config wins over service-level)
- Send `access_mode` as multipart form field to the API deploy endpoint

**Companion API PR:** https://github.com/getfloo/floo/pull/209

## Test plan
- [x] Tests for parsing `access_mode` from `floo.app.toml` (public, password, floo_accounts, invalid, missing)
- [x] Tests for parsing `access_mode` from `floo.service.toml` (present, missing)
- [x] All 46 CLI tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)