### PR TITLE
[Feature] Add api-key login, token command, and login pre-check

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -167,6 +167,11 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn whoami(&self) -> Result<Value, FlooApiError> {
+        let resp = self.get("/v1/auth/whoami")?;
+        self.handle_response(resp)
+    }
+
     // --- Apps ---
 
     pub fn create_app(&self, name: &str, runtime: Option<&str>) -> Result<Value, FlooApiError> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,11 +161,21 @@ pub enum Commands {
 #[derive(Subcommand)]
 pub enum AuthCommands {
     /// Authenticate with the Floo API (opens browser).
-    Login,
+    Login {
+        /// Use an existing API key instead of browser auth.
+        #[arg(long)]
+        api_key: Option<String>,
+
+        /// Skip existing key validation and force re-authentication.
+        #[arg(long)]
+        force: bool,
+    },
     /// Clear stored credentials.
     Logout,
     /// Show the currently authenticated user.
     Whoami,
+    /// Print the current API key to stdout.
+    Token,
     /// Create a new Floo account.
     Register {
         /// Account email address.
@@ -426,9 +436,12 @@ pub fn run() {
             restart,
         } => commands::deploy::deploy(path, app, services, restart),
         Commands::Auth(sub) => match sub {
-            AuthCommands::Login => commands::auth::login(),
+            AuthCommands::Login { api_key, force } => {
+                commands::auth::login(api_key.as_deref(), force)
+            }
             AuthCommands::Logout => commands::auth::logout(),
             AuthCommands::Whoami => commands::auth::whoami(),
+            AuthCommands::Token => commands::auth::token(),
             AuthCommands::Register { email } => commands::auth::register(&email),
         },
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -7,7 +7,71 @@ use colored::Colorize;
 use crate::config::{clear_config, load_config, save_config};
 use crate::output;
 
-pub fn login() {
+pub fn login(api_key: Option<&str>, force: bool) {
+    // Path 1: --api-key flag — save directly and validate
+    if let Some(key) = api_key {
+        let mut config = load_config();
+        config.api_key = Some(key.to_string());
+        if let Err(e) = save_config(&config) {
+            output::error(
+                &format!("Failed to save credentials: {e}"),
+                "CONFIG_ERROR",
+                None,
+            );
+            process::exit(1);
+        }
+
+        let client = super::init_client(Some(config));
+        match client.whoami() {
+            Ok(result) => {
+                let email = result
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                // Save the email too
+                let mut config = load_config();
+                config.user_email = Some(email.to_string());
+                let _ = save_config(&config);
+                output::success(
+                    &format!("Logged in as {email}"),
+                    Some(serde_json::json!({"email": email})),
+                );
+            }
+            Err(e) => {
+                // Key is invalid — clear it
+                clear_config();
+                output::error(&e.message, &e.code, Some("The API key is invalid."));
+                process::exit(1);
+            }
+        }
+        return;
+    }
+
+    // Path 2: Pre-check existing key (unless --force)
+    if !force {
+        let config = load_config();
+        if config.api_key.is_some() {
+            let client = super::init_client(Some(config));
+            match client.whoami() {
+                Ok(result) => {
+                    let email = result
+                        .get("email")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    output::success(
+                        &format!("Already logged in as {email}"),
+                        Some(serde_json::json!({"email": email, "already_authenticated": true})),
+                    );
+                    return;
+                }
+                Err(_) => {
+                    // Key is invalid — proceed to device code flow
+                }
+            }
+        }
+    }
+
+    // Path 3: Device code flow
     let client = super::init_client(None);
 
     // Step 1: Initiate device code flow
@@ -190,6 +254,31 @@ pub fn login() {
                 spinner.finish();
                 output::error(&e.message, &e.code, None);
                 process::exit(1);
+            }
+        }
+    }
+}
+
+pub fn token() {
+    let config = load_config();
+    match &config.api_key {
+        None => {
+            output::error(
+                "Not logged in.",
+                "NOT_AUTHENTICATED",
+                Some("Run 'floo auth login' to authenticate."),
+            );
+            process::exit(1);
+        }
+        Some(key) => {
+            if output::is_json_mode() {
+                output::success(
+                    "API key retrieved",
+                    Some(serde_json::json!({"api_key": key})),
+                );
+            } else {
+                // Print raw key to stdout for piping
+                println!("{key}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- `floo auth login --api-key floo_xxx` for headless authentication (CI/CD, agents)
- `floo auth login` pre-checks existing key validity via `/v1/auth/whoami`, skips browser flow if already authenticated
- `floo auth login --force` bypasses pre-check and forces re-authentication
- `floo auth token` prints raw API key to stdout for piping

Companion to getfloo/floo#230 which adds the multi-key backend and dashboard UI.

## Test plan
- [x] `cargo test` — 46 tests pass
- [x] `cargo build` succeeds
- [x] Pre-existing clippy/fmt issues not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)