### PR TITLE
[Feature] Add org member role and profile update commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -115,6 +115,19 @@ impl FlooClient {
             .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
     }
 
+    fn patch_json(
+        &self,
+        path: &str,
+        body: &Value,
+    ) -> Result<reqwest::blocking::Response, FlooApiError> {
+        let mut req = self.client.patch(self.url(path)).json(body);
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        req.send()
+            .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
+    }
+
     fn delete(&self, path: &str) -> Result<reqwest::blocking::Response, FlooApiError> {
         let mut req = self.client.delete(self.url(path));
         if let Some(auth) = self.auth_header() {
@@ -169,6 +182,35 @@ impl FlooClient {
 
     pub fn whoami(&self) -> Result<Value, FlooApiError> {
         let resp = self.get("/v1/auth/whoami")?;
+        self.handle_response(resp)
+    }
+
+    pub fn update_profile(&self, name: &str) -> Result<Value, FlooApiError> {
+        let body = serde_json::json!({"name": name});
+        let resp = self.patch_json("/v1/auth/me", &body)?;
+        self.handle_response(resp)
+    }
+
+    // --- Org ---
+
+    pub fn get_org_me(&self) -> Result<Value, FlooApiError> {
+        let resp = self.get("/v1/orgs/me")?;
+        self.handle_response(resp)
+    }
+
+    pub fn list_members(&self, org_id: &str) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!("/v1/orgs/{org_id}/members"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn update_member_role(
+        &self,
+        org_id: &str,
+        user_id: &str,
+        role: &str,
+    ) -> Result<Value, FlooApiError> {
+        let body = serde_json::json!({"role": role});
+        let resp = self.patch_json(&format!("/v1/orgs/{org_id}/members/{user_id}"), &body)?;
         self.handle_response(resp)
     }
 
@@ -549,13 +591,8 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
-    pub fn github_installation_repos(
-        &self,
-        installation_id: u64,
-    ) -> Result<Value, FlooApiError> {
-        let resp = self.get(&format!(
-            "/v1/github/installations/{installation_id}/repos"
-        ))?;
+    pub fn github_installation_repos(&self, installation_id: u64) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!("/v1/github/installations/{installation_id}/repos"))?;
         self.handle_response(resp)
     }
 
@@ -630,13 +667,11 @@ impl FlooClient {
 
     // --- Analytics ---
 
-    pub fn get_app_analytics(
-        &self,
-        app_id: &str,
-        period: &str,
-    ) -> Result<Value, FlooApiError> {
-        let resp =
-            self.get_with_query(&format!("/v1/apps/{app_id}/analytics"), &[("period", period)])?;
+    pub fn get_app_analytics(&self, app_id: &str, period: &str) -> Result<Value, FlooApiError> {
+        let resp = self.get_with_query(
+            &format!("/v1/apps/{app_id}/analytics"),
+            &[("period", period)],
+        )?;
         self.handle_response(resp)
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,10 @@ pub enum Commands {
     #[command(subcommand)]
     Auth(AuthCommands),
 
+    /// Manage your organization.
+    #[command(subcommand)]
+    Orgs(OrgsCommands),
+
     /// Manage your apps.
     #[command(subcommand)]
     Apps(AppsCommands),
@@ -201,6 +205,32 @@ pub enum AuthCommands {
     Register {
         /// Account email address.
         email: String,
+    },
+    /// Update your display name.
+    UpdateProfile {
+        /// New display name.
+        #[arg(long)]
+        name: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum OrgsCommands {
+    /// Manage org members.
+    #[command(subcommand)]
+    Members(MembersCommands),
+}
+
+#[derive(Subcommand)]
+pub enum MembersCommands {
+    /// List members of the current org.
+    List,
+    /// Change a member's role.
+    SetRole {
+        /// User ID of the member.
+        user_id: String,
+        /// New role (admin, member, or viewer).
+        role: String,
     },
 }
 
@@ -509,6 +539,16 @@ pub fn run() {
             AuthCommands::Whoami => commands::auth::whoami(),
             AuthCommands::Token => commands::auth::token(),
             AuthCommands::Register { email } => commands::auth::register(&email),
+            AuthCommands::UpdateProfile { name } => commands::auth::update_profile(&name),
+        },
+
+        Commands::Orgs(sub) => match sub {
+            OrgsCommands::Members(members_sub) => match members_sub {
+                MembersCommands::List => commands::orgs::list_members(),
+                MembersCommands::SetRole { user_id, role } => {
+                    commands::orgs::set_role(&user_id, &role)
+                }
+            },
         },
 
         Commands::Apps(sub) => match sub {

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -217,11 +217,7 @@ fn render_org_analytics(period: &str, data: &Value) {
                 })
                 .collect();
 
-            output::table(
-                &["App", "Requests", "Errors", "Error Rate"],
-                &rows,
-                None,
-            );
+            output::table(&["App", "Requests", "Errors", "Error Rate"], &rows, None);
         }
     }
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -345,6 +345,25 @@ pub fn register(email: &str) {
     }
 }
 
+pub fn update_profile(name: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    match client.update_profile(name) {
+        Ok(result) => {
+            let updated_name = result.get("name").and_then(|v| v.as_str()).unwrap_or(name);
+            output::success(
+                &format!("Profile updated. Name: {updated_name}"),
+                Some(result),
+            );
+        }
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    }
+}
+
 pub fn logout() {
     clear_config();
     output::success("Logged out.", None);
@@ -367,17 +386,43 @@ pub fn whoami() {
             } else {
                 key.clone()
             };
-            let data = serde_json::json!({
-                "email": config.user_email,
-                "api_key": masked,
-            });
-            output::success(
-                &format!(
-                    "Logged in as {} (key: {masked})",
-                    config.user_email.as_deref().unwrap_or("unknown")
-                ),
-                Some(data),
-            );
+
+            // Fetch live profile data from the API
+            let client = super::init_client(None);
+            match client.whoami() {
+                Ok(result) => {
+                    let email = result
+                        .get("email")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let name = result.get("name").and_then(|v| v.as_str());
+
+                    let mut data = serde_json::json!({
+                        "email": email,
+                        "api_key": masked,
+                    });
+                    if let Some(n) = name {
+                        data.as_object_mut()
+                            .unwrap()
+                            .insert("name".to_string(), serde_json::Value::String(n.to_string()));
+                    }
+
+                    let display = if let Some(n) = name {
+                        format!("{n} ({email}, key: {masked})")
+                    } else {
+                        format!("{email} (key: {masked})")
+                    };
+                    output::success(&format!("Logged in as {display}"), Some(data));
+                }
+                Err(e) => {
+                    output::error(
+                        &e.message,
+                        &e.code,
+                        Some("Your API key may be invalid. Try 'floo auth login'."),
+                    );
+                    process::exit(1);
+                }
+            }
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod domains;
 pub mod env;
 pub mod init;
 pub mod logs;
+pub mod orgs;
 pub mod releases;
 pub mod rollbacks;
 pub mod service_mgmt;

--- a/src/commands/orgs.rs
+++ b/src/commands/orgs.rs
@@ -1,0 +1,106 @@
+use std::process;
+
+use crate::output;
+
+pub fn list_members() {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let org = match client.get_org_me() {
+        Ok(o) => o,
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    };
+    let org_id = super::expect_str_field(&org, "id");
+
+    let result = match client.list_members(org_id) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    };
+
+    let members = result
+        .get("members")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| {
+            output::error(
+                "Failed to parse members from API response.",
+                "PARSE_ERROR",
+                Some("This is a bug. Please report it."),
+            );
+            process::exit(1);
+        });
+
+    if members.is_empty() {
+        output::info("No members found.", None);
+        return;
+    }
+
+    let rows: Vec<Vec<String>> = members
+        .iter()
+        .map(|m| {
+            vec![
+                m.get("user_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
+                m.get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
+                m.get("role")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
+            ]
+        })
+        .collect();
+
+    output::table(&["USER ID", "EMAIL", "ROLE"], &rows, Some(result));
+}
+
+pub fn set_role(user_id: &str, role: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let valid_roles = ["admin", "member", "viewer"];
+    if !valid_roles.contains(&role) {
+        output::error(
+            &format!("Invalid role '{role}'. Must be one of: admin, member, viewer."),
+            "INVALID_ROLE",
+            None,
+        );
+        process::exit(1);
+    }
+
+    let org = match client.get_org_me() {
+        Ok(o) => o,
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    };
+    let org_id = super::expect_str_field(&org, "id");
+
+    match client.update_member_role(org_id, user_id, role) {
+        Ok(result) => {
+            let email = result
+                .get("email")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let new_role = result.get("role").and_then(|v| v.as_str()).unwrap_or(role);
+            output::success(
+                &format!("Updated {email} to role '{new_role}'."),
+                Some(result),
+            );
+        }
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    }
+}

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -23,11 +23,7 @@ pub fn install(path: Option<PathBuf>, print: bool) {
             std::io::stdout()
                 .write_all(SKILL_CONTENT.as_bytes())
                 .unwrap_or_else(|e| {
-                    output::error(
-                        &format!("Failed to write to stdout: {e}"),
-                        "IO_ERROR",
-                        None,
-                    );
+                    output::error(&format!("Failed to write to stdout: {e}"), "IO_ERROR", None);
                     process::exit(1);
                 });
         }
@@ -135,9 +131,7 @@ pub fn refresh_skill_files() -> Vec<String> {
         if !parent_exists {
             // Parent directory gone — prune from tracking
             if !output::is_json_mode() {
-                eprintln!(
-                    "  Removed stale skill path (directory gone): {path_str}"
-                );
+                eprintln!("  Removed stale skill path (directory gone): {path_str}");
             }
             continue;
         }
@@ -151,9 +145,7 @@ pub fn refresh_skill_files() -> Vec<String> {
                 // Write failed but directory exists — keep tracking, report error
                 still_valid.push(path_str.clone());
                 if !output::is_json_mode() {
-                    eprintln!(
-                        "  Warning: failed to refresh skill at {path_str}: {e}"
-                    );
+                    eprintln!("  Warning: failed to refresh skill at {path_str}: {e}");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `floo orgs members list` — list all org members in a table
- `floo orgs members set-role <user_id> <role>` — change a member's role (admin/member/viewer)
- `floo auth update-profile --name <name>` — update display name
- `floo auth whoami` now fetches live profile data and shows name if set
- Adds `patch_json` HTTP method to `FlooClient`

Depends on API changes in getfloo/floo#254.

## Test plan
- [x] `cargo test` — 46 tests pass
- [x] `cargo clippy -- -D warnings` — no new warnings
- [x] `cargo fmt --check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)