### PR TITLE
[Feature] [#48] Add billing spend-cap get/set CLI commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -214,6 +214,14 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    // --- Billing ---
+
+    pub fn set_spend_cap(&self, spend_cap: u64) -> Result<Value, FlooApiError> {
+        let body = serde_json::json!({"spend_cap": spend_cap});
+        let resp = self.post_json("/v1/billing/spend-cap", &body)?;
+        self.handle_response(resp)
+    }
+
     // --- Apps ---
 
     pub fn create_app(&self, name: &str, runtime: Option<&str>) -> Result<Value, FlooApiError> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,10 @@ pub enum Commands {
     #[command(subcommand)]
     Orgs(OrgsCommands),
 
+    /// Manage billing and spend caps.
+    #[command(subcommand)]
+    Billing(BillingCommands),
+
     /// Manage your apps.
     #[command(subcommand)]
     Apps(AppsCommands),
@@ -211,6 +215,24 @@ pub enum AuthCommands {
         /// New display name.
         #[arg(long)]
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum BillingCommands {
+    /// Manage your org's compute spend cap.
+    #[command(subcommand)]
+    SpendCap(SpendCapCommands),
+}
+
+#[derive(Subcommand)]
+pub enum SpendCapCommands {
+    /// Show current spend cap and usage.
+    Get,
+    /// Set the monthly spend cap (in dollars). 0 = no cap.
+    Set {
+        /// Spend cap amount in dollars (e.g., 20.00). Use 0 for no cap.
+        amount: f64,
     },
 }
 
@@ -540,6 +562,13 @@ pub fn run() {
             AuthCommands::Token => commands::auth::token(),
             AuthCommands::Register { email } => commands::auth::register(&email),
             AuthCommands::UpdateProfile { name } => commands::auth::update_profile(&name),
+        },
+
+        Commands::Billing(sub) => match sub {
+            BillingCommands::SpendCap(cap_sub) => match cap_sub {
+                SpendCapCommands::Get => commands::billing::spend_cap_get(),
+                SpendCapCommands::Set { amount } => commands::billing::spend_cap_set(amount),
+            },
         },
 
         Commands::Orgs(sub) => match sub {

--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -1,0 +1,113 @@
+use std::process;
+
+use crate::output;
+
+pub fn spend_cap_get() {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let org = match client.get_org_me() {
+        Ok(o) => o,
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    };
+
+    let spend_cap_value = org.get("spend_cap").unwrap_or_else(|| {
+        output::error(
+            "Response missing 'spend_cap' field.",
+            "PARSE_ERROR",
+            Some("This is a bug. Please report it."),
+        );
+        process::exit(1);
+    });
+    let spend_cap = if spend_cap_value.is_null() {
+        None
+    } else {
+        Some(spend_cap_value.as_u64().unwrap_or_else(|| {
+            output::error(
+                &format!("Unexpected spend_cap value: {spend_cap_value}"),
+                "PARSE_ERROR",
+                Some("This is a bug. Please report it."),
+            );
+            process::exit(1);
+        }))
+    };
+    let current_spend = org
+        .get("current_period_spend_cents")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| {
+            output::error(
+                "Response missing 'current_period_spend_cents' field.",
+                "PARSE_ERROR",
+                Some("This is a bug. Please report it."),
+            );
+            process::exit(1);
+        });
+    let exceeded = org
+        .get("spend_cap_exceeded")
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| {
+            output::error(
+                "Response missing 'spend_cap_exceeded' field.",
+                "PARSE_ERROR",
+                Some("This is a bug. Please report it."),
+            );
+            process::exit(1);
+        });
+
+    let data = serde_json::json!({
+        "spend_cap": spend_cap,
+        "current_period_spend_cents": current_spend,
+        "spend_cap_exceeded": exceeded,
+    });
+
+    if output::is_json_mode() {
+        output::success("", Some(data));
+        return;
+    }
+
+    match spend_cap {
+        Some(0) => eprintln!("  Spend cap: none (unlimited)"),
+        Some(cents) => eprintln!("  Spend cap: ${:.2}/month", cents as f64 / 100.0),
+        None => eprintln!("  Spend cap: none (unlimited)"),
+    }
+    eprintln!("  Current spend: ${:.2}", current_spend as f64 / 100.0);
+    if exceeded {
+        output::warn("Spend cap exceeded — deploys are blocked.");
+    }
+}
+
+pub fn spend_cap_set(amount: f64) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    if !amount.is_finite() || amount < 0.0 {
+        output::error(
+            "Spend cap amount must be a finite, non-negative number.",
+            "INVALID_AMOUNT",
+            Some("Use a positive dollar amount, or 0 for no cap."),
+        );
+        process::exit(1);
+    }
+
+    let cents = (amount * 100.0).round() as u64;
+
+    match client.set_spend_cap(cents) {
+        Ok(result) => {
+            if cents == 0 {
+                output::success("Spend cap removed (unlimited).", Some(result));
+            } else {
+                output::success(
+                    &format!("Spend cap set to ${:.2}/month.", cents as f64 / 100.0),
+                    Some(result),
+                );
+            }
+        }
+        Err(e) => {
+            output::error(&e.message, &e.code, None);
+            process::exit(1);
+        }
+    }
+}

--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -14,25 +14,16 @@ pub fn spend_cap_get() {
         }
     };
 
-    let spend_cap_value = org.get("spend_cap").unwrap_or_else(|| {
-        output::error(
-            "Response missing 'spend_cap' field.",
-            "PARSE_ERROR",
-            Some("This is a bug. Please report it."),
-        );
-        process::exit(1);
-    });
-    let spend_cap = if spend_cap_value.is_null() {
-        None
-    } else {
-        Some(spend_cap_value.as_u64().unwrap_or_else(|| {
+    let spend_cap = match org.get("spend_cap") {
+        Some(v) => v.as_u64(),
+        None => {
             output::error(
-                &format!("Unexpected spend_cap value: {spend_cap_value}"),
+                "Response missing 'spend_cap' field.",
                 "PARSE_ERROR",
                 Some("This is a bug. Please report it."),
             );
             process::exit(1);
-        }))
+        }
     };
     let current_spend = org
         .get("current_period_spend_cents")
@@ -69,9 +60,10 @@ pub fn spend_cap_get() {
     }
 
     match spend_cap {
-        Some(0) => eprintln!("  Spend cap: none (unlimited)"),
-        Some(cents) => eprintln!("  Spend cap: ${:.2}/month", cents as f64 / 100.0),
-        None => eprintln!("  Spend cap: none (unlimited)"),
+        Some(cents) if cents > 0 => {
+            eprintln!("  Spend cap: ${:.2}/month", cents as f64 / 100.0)
+        }
+        _ => eprintln!("  Spend cap: none (unlimited)"),
     }
     eprintln!("  Current spend: ${:.2}", current_spend as f64 / 100.0);
     if exceeded {
@@ -83,9 +75,9 @@ pub fn spend_cap_set(amount: f64) {
     super::require_auth();
     let client = super::init_client(None);
 
-    if !amount.is_finite() || amount < 0.0 {
+    if !amount.is_finite() || amount < 0.0 || amount > 1_000_000.0 {
         output::error(
-            "Spend cap amount must be a finite, non-negative number.",
+            "Spend cap must be between $0 and $1,000,000.",
             "INVALID_AMOUNT",
             Some("Use a positive dollar amount, or 0 for no cap."),
         );
@@ -100,7 +92,7 @@ pub fn spend_cap_set(amount: f64) {
                 output::success("Spend cap removed (unlimited).", Some(result));
             } else {
                 output::success(
-                    &format!("Spend cap set to ${:.2}/month.", cents as f64 / 100.0),
+                    &format!("Spend cap set to ${amount:.2}/month."),
                     Some(result),
                 );
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ use crate::output;
 pub mod analytics;
 pub mod apps;
 pub mod auth;
+pub mod billing;
 pub mod check;
 pub mod deploy;
 pub mod domains;


### PR DESCRIPTION
## Summary
- Adds `floo billing spend-cap get` — shows current spend cap, period spend, and exceeded status from org
- Adds `floo billing spend-cap set <amount>` — sets monthly spend cap in dollars (0 = no cap)
- Adds `set_spend_cap()` API client method for `POST /v1/billing/spend-cap`
- Both commands support `--json` mode for programmatic/agent use

## Test plan
- [x] `cargo build` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 251 tests pass
- [x] `floo billing spend-cap --help` shows correct usage
- [x] `floo billing --help` shows correct usage
- [x] Code reviewed by `code-reviewer` agent — all findings addressed
- [x] Reviewed by `silent-failure-hunter` agent — all findings addressed
- [ ] Manual test: `floo billing spend-cap get` against live API
- [ ] Manual test: `floo billing spend-cap set 20` against live API
- [ ] Manual test: `floo --json billing spend-cap get` returns structured JSON

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)