### PR TITLE
chore: simplify duplicated app-resolution patterns

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -589,16 +589,19 @@ impl FlooClient {
 
     // --- GitHub ---
 
+    #[allow(dead_code)]
     pub fn github_setup_begin(&self) -> Result<Value, FlooApiError> {
         let resp = self.post_json("/v1/github/setup/begin", &serde_json::json!({}))?;
         self.handle_response(resp)
     }
 
+    #[allow(dead_code)]
     pub fn github_setup_poll(&self) -> Result<Value, FlooApiError> {
         let resp = self.get("/v1/github/setup/poll")?;
         self.handle_response(resp)
     }
 
+    #[allow(dead_code)]
     pub fn github_installation_repos(&self, installation_id: u64) -> Result<Value, FlooApiError> {
         let resp = self.get(&format!("/v1/github/installations/{installation_id}/repos"))?;
         self.handle_response(resp)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,6 @@ pub enum Commands {
     #[command(subcommand)]
     Billing(BillingCommands),
 
-
     /// Manage your apps.
     #[command(subcommand)]
     Apps(AppsCommands),
@@ -579,7 +578,6 @@ pub fn run() {
                 SpendCapCommands::Set { amount } => commands::billing::spend_cap_set(amount),
             },
         },
-
 
         Commands::Orgs(sub) => match sub {
             OrgsCommands::Members(members_sub) => match members_sub {

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -3,7 +3,6 @@ use std::process;
 use serde_json::Value;
 
 use crate::output;
-use crate::resolve::resolve_app;
 
 pub fn analytics(app: Option<String>, period: &str) {
     super::require_auth();
@@ -69,21 +68,7 @@ fn expect_object<'a>(data: &'a Value, key: &str) -> &'a Value {
 }
 
 fn app_analytics(client: &crate::api_client::FlooClient, app_name: &str, period: &str) {
-    let app_data = match resolve_app(client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
+    let app_data = super::resolve_app_or_exit(client, app_name);
 
     let app_id = super::expect_str_field(&app_data, "id");
     let name = super::expect_str_field(&app_data, "name");

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -5,7 +5,6 @@ use crate::archive::create_archive;
 use crate::detection::detect;
 use crate::output;
 use crate::project_config::{self, AppAccessMode};
-use crate::resolve::resolve_app;
 
 pub fn list(page: u32, per_page: u32) {
     super::require_auth();
@@ -97,21 +96,7 @@ pub fn list(page: u32, per_page: u32) {
 pub fn status(app_name: &str) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
+    let app_data = super::resolve_app_or_exit(&client, app_name);
 
     if output::is_json_mode() {
         let name = app_data
@@ -151,21 +136,7 @@ pub fn status(app_name: &str) {
 pub fn delete(app_name: &str, force: bool) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
+    let app_data = super::resolve_app_or_exit(&client, app_name);
 
     let name = app_data
         .get("name")
@@ -202,21 +173,7 @@ pub fn connect(
 ) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
+    let app_data = super::resolve_app_or_exit(&client, app_name);
 
     let app_id = super::expect_str_field(&app_data, "id").to_string();
     let name = app_data
@@ -234,10 +191,10 @@ pub fn connect(
         );
         process::exit(1);
     });
-    let resolved = match project_config::resolve_app_context(&cwd, Some(app_name)) {
-        Ok(r) => Some(r),
-        Err(_) => None,
-    };
+    // Project config is optional for connect — missing config is fine, all other
+    // errors (LEGACY_CONFIG, INVALID_PROJECT_CONFIG) are also suppressed so the
+    // connect itself still succeeds; users can run `floo env import` separately.
+    let resolved = project_config::resolve_app_context(&cwd, Some(app_name)).ok();
 
     // Step 1: Import env vars from local env_file before connecting
     if let Some(ref r) = resolved {
@@ -413,30 +370,13 @@ fn trigger_initial_deploy(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    output::success(
-        &format!("Deployed to {url}"),
-        Some(deploy_data),
-    );
+    output::success(&format!("Deployed to {url}"), Some(deploy_data));
 }
 
 pub fn disconnect(app_name: &str) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
+    let app_data = super::resolve_app_or_exit(&client, app_name);
 
     let app_id = super::expect_str_field(&app_data, "id");
     let name = app_data

--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -75,7 +75,7 @@ pub fn spend_cap_set(amount: f64) {
     super::require_auth();
     let client = super::init_client(None);
 
-    if !amount.is_finite() || amount < 0.0 || amount > 1_000_000.0 {
+    if !amount.is_finite() || !(0.0..=1_000_000.0).contains(&amount) {
         output::error(
             "Spend cap must be between $0 and $1,000,000.",
             "INVALID_AMOUNT",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -740,16 +740,15 @@ pub(crate) fn stream_deploy_json(
                 "status" => {
                     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&data_buf) {
                         let status = parsed.get("status").and_then(|v| v.as_str()).unwrap_or("");
-                        println!(
-                            "{}",
-                            serde_json::json!({"event": "status", "status": status})
+                        output::print_json(
+                            &serde_json::json!({"event": "status", "status": status}),
                         );
                     }
                 }
                 "log" => {
                     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&data_buf) {
                         if let Some(text) = parsed.get("text").and_then(|v| v.as_str()) {
-                            println!("{}", serde_json::json!({"event": "log", "text": text}));
+                            output::print_json(&serde_json::json!({"event": "log", "text": text}));
                         }
                     }
                 }
@@ -757,9 +756,8 @@ pub(crate) fn stream_deploy_json(
                     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&data_buf) {
                         let status = parsed.get("status").and_then(|v| v.as_str()).unwrap_or("");
                         let url = parsed.get("url").and_then(|v| v.as_str()).unwrap_or("");
-                        println!(
-                            "{}",
-                            serde_json::json!({"event": "done", "status": status, "url": url})
+                        output::print_json(
+                            &serde_json::json!({"event": "done", "status": status, "url": url}),
                         );
                     }
                     break;

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -1,53 +1,7 @@
-use std::env;
 use std::process;
 
 use crate::api_client::FlooClient;
 use crate::output;
-use crate::project_config::resolve_app_context;
-use crate::resolve::resolve_app;
-
-fn resolve(client: &FlooClient, app: Option<&str>) -> (String, String) {
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id").to_string();
-    let app_name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name)
-        .to_string();
-
-    (app_id, app_name)
-}
 
 fn check_services_flag(client: &FlooClient, app_id: &str, services: Option<&str>) {
     let result = match client.list_services(app_id) {
@@ -99,7 +53,7 @@ pub fn add(hostname: &str, app: Option<&str>, services: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let (app_id, app_name) = resolve(&client, app);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
     check_services_flag(&client, &app_id, services);
 
     let result = match client.add_domain(&app_id, hostname) {
@@ -129,7 +83,7 @@ pub fn list(app: Option<&str>, services: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let (app_id, app_name) = resolve(&client, app);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
     check_services_flag(&client, &app_id, services);
 
     let result = match client.list_domains(&app_id) {
@@ -198,7 +152,7 @@ pub fn remove(hostname: &str, app: Option<&str>, services: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let (app_id, app_name) = resolve(&client, app);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
     check_services_flag(&client, &app_id, services);
 
     if let Err(e) = client.delete_domain(&app_id, hostname) {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -4,53 +4,16 @@ use std::process;
 use crate::api_client::FlooClient;
 use crate::output;
 use crate::project_config;
-use crate::resolve::resolve_app;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn resolve_app_id(client: &FlooClient, app_flag: Option<&str>) -> (String, String) {
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "FILE_ERROR",
-            None,
-        );
-        process::exit(1);
-    });
-
-    let resolved = match project_config::resolve_app_context(&cwd, app_flag) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id").to_string();
-    let app_name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name)
-        .to_string();
-    (app_id, app_name)
+fn format_target(app_name: &str, service_name: Option<&str>) -> String {
+    match service_name {
+        Some(sn) => format!("{app_name}/{sn}"),
+        None => app_name.to_string(),
+    }
 }
 
 /// Resolve `--services` names to service IDs.
@@ -259,17 +222,14 @@ pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String], re
     let key = key.to_uppercase();
 
     let client = super::init_client(None);
-    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
 
     let mut last_env_result = serde_json::Value::Null;
     for (service_id, service_name) in &targets {
         match client.set_env_var(&app_id, &key, value, service_id.as_deref()) {
             Ok(result) => {
-                let target = match service_name {
-                    Some(sn) => format!("{app_name}/{sn}"),
-                    None => app_name.clone(),
-                };
+                let target = format_target(&app_name, service_name.as_deref());
                 last_env_result = result.clone();
                 if !restart || !output::is_json_mode() {
                     output::success(&format!("Set {key} on {target}."), Some(result));
@@ -338,7 +298,7 @@ pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String], re
 pub fn list(app_flag: Option<&str>, service_names: &[String]) {
     super::require_auth();
     let client = super::init_client(None);
-    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
 
     for (service_id, service_name) in &targets {
@@ -362,10 +322,7 @@ pub fn list(app_flag: Option<&str>, service_names: &[String]) {
             }
         };
 
-        let target = match service_name {
-            Some(sn) => format!("{app_name}/{sn}"),
-            None => app_name.clone(),
-        };
+        let target = format_target(&app_name, service_name.as_deref());
 
         if env_vars.is_empty() {
             if output::is_json_mode() {
@@ -405,7 +362,7 @@ pub fn remove(key: &str, app_flag: Option<&str>, service_names: &[String]) {
     super::require_auth();
 
     let client = super::init_client(None);
-    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
 
     for (service_id, service_name) in &targets {
@@ -414,10 +371,7 @@ pub fn remove(key: &str, app_flag: Option<&str>, service_names: &[String]) {
             process::exit(1);
         }
 
-        let target = match service_name {
-            Some(sn) => format!("{app_name}/{sn}"),
-            None => app_name.clone(),
-        };
+        let target = format_target(&app_name, service_name.as_deref());
         output::success(
             &format!("Removed {key} from {target}."),
             Some(serde_json::json!({"key": key})),
@@ -430,7 +384,7 @@ pub fn get(key: &str, app_flag: Option<&str>, service_flag: Option<&str>) {
     super::require_auth();
 
     let client = super::init_client(None);
-    let (app_id, app_name) = resolve_app_id(&client, app_flag);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
     let (service_id, _service_name) =
         resolve_single_service(&client, &app_id, &app_name, service_flag);
 
@@ -495,25 +449,11 @@ pub fn import_vars(file_flag: Option<&Path>, app_flag: Option<&str>, service_nam
     let vars = parse_env_file(&env_file_path);
     let count = vars.len();
 
-    // Use resolved app name if available, otherwise resolve_app_id will re-resolve from config.
+    // Use resolved app name if available, otherwise fall back to resolving from config.
     let client = super::init_client(None);
     let (app_id, app_name) = match &resolved {
         Some(r) => {
-            let app_data = match resolve_app(&client, &r.app_name) {
-                Ok(a) => a,
-                Err(e) => {
-                    if e.code == "APP_NOT_FOUND" {
-                        output::error(
-                            &format!("App '{}' not found.", r.app_name),
-                            "APP_NOT_FOUND",
-                            Some("Check the app name or ID and try again."),
-                        );
-                    } else {
-                        output::error(&e.message, &e.code, None);
-                    }
-                    process::exit(1);
-                }
-            };
+            let app_data = super::resolve_app_or_exit(&client, &r.app_name);
             let app_id = super::expect_str_field(&app_data, "id").to_string();
             let app_name = app_data
                 .get("name")
@@ -522,7 +462,7 @@ pub fn import_vars(file_flag: Option<&Path>, app_flag: Option<&str>, service_nam
                 .to_string();
             (app_id, app_name)
         }
-        None => resolve_app_id(&client, app_flag),
+        None => super::resolve_app_from_config(&client, app_flag),
     };
 
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
@@ -530,10 +470,7 @@ pub fn import_vars(file_flag: Option<&Path>, app_flag: Option<&str>, service_nam
     for (service_id, service_name) in &targets {
         match client.import_env_vars(&app_id, &vars, service_id.as_deref()) {
             Ok(result) => {
-                let target = match service_name {
-                    Some(sn) => format!("{app_name}/{sn}"),
-                    None => app_name.clone(),
-                };
+                let target = format_target(&app_name, service_name.as_deref());
                 output::success(
                     &format!("Imported {count} variable(s) to {target}."),
                     Some(result),
@@ -632,21 +569,7 @@ pub fn import_all_services(app_flag: Option<&str>) {
     }
 
     let client = super::init_client(None);
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
+    let app_data = super::resolve_app_or_exit(&client, &resolved.app_name);
     let app_id = super::expect_str_field(&app_data, "id").to_string();
     let app_name = app_data
         .get("name")

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,14 +49,70 @@ pub(crate) fn require_auth() {
 }
 
 pub(crate) fn expect_str_field<'a>(data: &'a serde_json::Value, field: &str) -> &'a str {
-    data.get(field).and_then(|v| v.as_str()).unwrap_or_else(|| {
+    let value = data.get(field).and_then(|v| v.as_str()).unwrap_or_else(|| {
         output::error(
             &format!("Response missing '{field}' field."),
             "PARSE_ERROR",
             Some("This is a bug. Please report it."),
         );
         process::exit(1);
-    })
+    });
+    if value.is_empty() {
+        output::error(
+            &format!("Response field '{field}' is empty."),
+            "PARSE_ERROR",
+            Some("This may indicate a CLI/API version mismatch. Try `floo update`."),
+        );
+        process::exit(1);
+    }
+    value
+}
+
+pub(crate) fn resolve_app_or_exit(client: &FlooClient, app_name: &str) -> serde_json::Value {
+    match crate::resolve::resolve_app(client, app_name) {
+        Ok(a) => a,
+        Err(e) => {
+            if e.code == "APP_NOT_FOUND" {
+                output::error(
+                    &format!("App '{app_name}' not found."),
+                    "APP_NOT_FOUND",
+                    Some("Check the app name or ID and try again."),
+                );
+            } else {
+                output::error(&e.message, &e.code, None);
+            }
+            process::exit(1);
+        }
+    }
+}
+
+pub(crate) fn resolve_app_from_config(
+    client: &FlooClient,
+    app_flag: Option<&str>,
+) -> (String, String) {
+    let cwd = std::env::current_dir().unwrap_or_else(|e| {
+        output::error(
+            &format!("Failed to read current directory: {e}"),
+            "CWD_ERROR",
+            Some("Ensure the current directory exists and you have read permission."),
+        );
+        process::exit(1);
+    });
+    let resolved = match crate::project_config::resolve_app_context(&cwd, app_flag) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
+        }
+    };
+    let app_data = resolve_app_or_exit(client, &resolved.app_name);
+    let app_id = expect_str_field(&app_data, "id").to_string();
+    let app_name = app_data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&resolved.app_name)
+        .to_string();
+    (app_id, app_name)
 }
 
 /// Detect the deploy env file in a directory: prefers .floo.env, falls back to .env.

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -1,51 +1,14 @@
-use std::env;
 use std::process;
 
 use crate::output;
-use crate::project_config::resolve_app_context;
-use crate::resolve::resolve_app;
 
 pub fn promote(app: Option<&str>, tag: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id");
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name);
+    let (app_id, name) = super::resolve_app_from_config(&client, app);
+    let app_id = app_id.as_str();
+    let name = name.as_str();
 
     let _spinner = output::Spinner::new(&format!("Promoting {name} to prod..."));
 
@@ -93,39 +56,8 @@ pub fn list(app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id");
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
+    let app_id = app_id.as_str();
 
     let result = match client.list_releases(app_id, 1, 20) {
         Ok(r) => r,
@@ -199,39 +131,8 @@ pub fn show(release_id: &str, app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id");
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
+    let app_id = app_id.as_str();
 
     let release = match client.get_release(app_id, release_id) {
         Ok(r) => r,

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -1,57 +1,13 @@
-use std::env;
 use std::process;
 
 use crate::output;
-use crate::project_config::resolve_app_context;
-use crate::resolve::resolve_app;
 
 pub fn list(app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = match app_data.get("id").and_then(|v| v.as_str()) {
-        Some(id) if !id.is_empty() => id,
-        _ => {
-            output::error(
-                "Failed to read app ID from API response.",
-                "PARSE_ERROR",
-                Some("This may indicate a CLI/API version mismatch. Try updating the CLI."),
-            );
-            process::exit(1);
-        }
-    };
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
+    let app_id = app_id.as_str();
 
     let result = match client.list_deploys(app_id) {
         Ok(r) => r,
@@ -120,38 +76,12 @@ pub fn rollback(app_name: &str, deploy_id: &str, force: bool) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
+    let app_data = super::resolve_app_or_exit(&client, app_name);
     let name = app_data
         .get("name")
         .and_then(|v| v.as_str())
         .unwrap_or(app_name);
-
-    let app_id = match app_data.get("id").and_then(|v| v.as_str()) {
-        Some(id) if !id.is_empty() => id,
-        _ => {
-            output::error(
-                "Failed to read app ID from API response.",
-                "PARSE_ERROR",
-                Some("This may indicate a CLI/API version mismatch. Try updating the CLI."),
-            );
-            process::exit(1);
-        }
-    };
+    let app_id = super::expect_str_field(&app_data, "id");
 
     if !force
         && !output::confirm(&format!(

--- a/src/commands/service_mgmt.rs
+++ b/src/commands/service_mgmt.rs
@@ -183,15 +183,13 @@ pub fn add(
 
     // Write floo.service.toml in the service's directory
     let svc_dir = cwd.join(path);
-    if !svc_dir.exists() {
-        if let Err(e) = std::fs::create_dir_all(&svc_dir) {
-            output::error(
-                &format!("Failed to create directory '{}': {e}", path),
-                "FILE_ERROR",
-                None,
-            );
-            process::exit(1);
-        }
+    if let Err(e) = std::fs::create_dir_all(&svc_dir) {
+        output::error(
+            &format!("Failed to create directory '{}': {e}", path),
+            "FILE_ERROR",
+            None,
+        );
+        process::exit(1);
     }
 
     let svc_file = ServiceFileConfig {

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -1,51 +1,14 @@
-use std::env;
 use std::process;
 
 use crate::output;
-use crate::project_config::resolve_app_context;
-use crate::resolve::resolve_app;
 
 pub fn list(app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id");
-    let app_name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+    let app_id = app_id.as_str();
+    let app_name = app_name.as_str();
 
     let result = match client.list_services(app_id) {
         Ok(r) => r,
@@ -106,43 +69,9 @@ pub fn info(service_name: &str, app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            "CWD_ERROR",
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
-    let resolved = match resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_data = match resolve_app(&client, &resolved.app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{}' not found.", resolved.app_name),
-                    "APP_NOT_FOUND",
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &e.code, None);
-            }
-            process::exit(1);
-        }
-    };
-
-    let app_id = super::expect_str_field(&app_data, "id");
-    let app_name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+    let app_id = app_id.as_str();
+    let app_name = app_name.as_str();
 
     let services_result = match client.list_services(app_id) {
         Ok(r) => r,


### PR DESCRIPTION
## Summary

- Extract shared `resolve_app_or_exit()` and `resolve_app_from_config()` helpers into `commands/mod.rs`, eliminating a 30-line copy-paste in 5 files
- Consolidate 5+ APP_NOT_FOUND match blocks into the shared helper; add `format_target()` in `env.rs`
- Fix `println!` → `output::print_json()` in deploy stream path, TOCTOU in `service_mgmt.rs`, and 3 pre-existing clippy errors

## Changes

| File | Change |
|------|--------|
| `src/commands/mod.rs` | +`resolve_app_or_exit()`, `resolve_app_from_config()`; strengthen `expect_str_field()` to reject empty strings |
| `src/commands/env.rs` | Delete `resolve_app_id()`, add `format_target()` helper (5 sites replaced) |
| `src/commands/domains.rs` | Delete private `resolve()`, use shared helper |
| `src/commands/rollbacks.rs` | Replace inline resolution blocks with shared helpers |
| `src/commands/releases.rs` | Replace inline resolution blocks with shared helpers |
| `src/commands/services.rs` | Replace inline resolution blocks with shared helpers |
| `src/commands/apps.rs` | Replace 4 APP_NOT_FOUND match blocks with `resolve_app_or_exit()` |
| `src/commands/analytics.rs` | Replace APP_NOT_FOUND match block with `resolve_app_or_exit()` |
| `src/commands/deploy.rs` | Replace 3 bare `println!` with `output::print_json()` in `stream_deploy_json` |
| `src/commands/service_mgmt.rs` | Remove TOCTOU existence check before `create_dir_all` |
| `src/api_client.rs`, `src/commands/billing.rs` | Fix pre-existing clippy errors |

Net: -385 lines of duplicated code.

## Test plan

- [x] `cargo test` — 46 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Code review + silent-failure-hunter agents run; findings addressed (CWD_ERROR code, empty-string ID guard, `.ok()` comment)

## Discovered issues

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)