### PR TITLE
refactor: replace untyped Value API responses with typed structs

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use reqwest::blocking::{multipart, Client};
 use serde_json::Value;
 
+use crate::api_types::*;
 use crate::config::{load_config, FlooConfig};
 use crate::errors::FlooApiError;
 use crate::project_config::ServiceConfig;
@@ -43,41 +44,52 @@ impl FlooClient {
         self.api_key.as_ref().map(|k| format!("Bearer {k}"))
     }
 
-    fn handle_response(
+    fn handle_error(&self, response: reqwest::blocking::Response) -> FlooApiError {
+        let status = response.status().as_u16();
+        let text = response.text().unwrap_or_default();
+        let (code, message) = if let Ok(body) = serde_json::from_str::<Value>(&text) {
+            let detail = body.get("detail").unwrap_or(&body);
+            if let Some(obj) = detail.as_object() {
+                (
+                    obj.get("code")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("API_ERROR")
+                        .to_string(),
+                    obj.get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&text)
+                        .to_string(),
+                )
+            } else {
+                (
+                    "API_ERROR".to_string(),
+                    detail.to_string().trim_matches('"').to_string(),
+                )
+            }
+        } else {
+            ("API_ERROR".to_string(), text)
+        };
+        FlooApiError::new(status, code, message)
+    }
+
+    fn handle_response<T: serde::de::DeserializeOwned>(
+        &self,
+        response: reqwest::blocking::Response,
+    ) -> Result<T, FlooApiError> {
+        let status = response.status().as_u16();
+        if status >= 400 {
+            return Err(self.handle_error(response));
+        }
+        response.json::<T>().map_err(|e| {
+            FlooApiError::new(500, "PARSE_ERROR", format!("Failed to parse response: {e}"))
+        })
+    }
+
+    fn handle_response_value(
         &self,
         response: reqwest::blocking::Response,
     ) -> Result<Value, FlooApiError> {
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().unwrap_or_default();
-            let (code, message) = if let Ok(body) = serde_json::from_str::<Value>(&text) {
-                let detail = body.get("detail").unwrap_or(&body);
-                if let Some(obj) = detail.as_object() {
-                    (
-                        obj.get("code")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("API_ERROR")
-                            .to_string(),
-                        obj.get("message")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(&text)
-                            .to_string(),
-                    )
-                } else {
-                    (
-                        "API_ERROR".to_string(),
-                        detail.to_string().trim_matches('"').to_string(),
-                    )
-                }
-            } else {
-                ("API_ERROR".to_string(), text)
-            };
-            return Err(FlooApiError::new(status, code, message));
-        }
-        let body: Value = response.json().map_err(|e| {
-            FlooApiError::new(500, "PARSE_ERROR", format!("Failed to parse response: {e}"))
-        })?;
-        Ok(body)
+        self.handle_response(response)
     }
 
     fn get(&self, path: &str) -> Result<reqwest::blocking::Response, FlooApiError> {
@@ -139,18 +151,18 @@ impl FlooClient {
 
     // --- Auth ---
 
-    pub fn register(&self, email: &str) -> Result<Value, FlooApiError> {
+    pub fn register(&self, email: &str) -> Result<AuthTokenResponse, FlooApiError> {
         let body = serde_json::json!({"email": email});
         let resp = self.post_json("/v1/auth/register", &body)?;
         self.handle_response(resp)
     }
 
-    pub fn device_authorize(&self) -> Result<Value, FlooApiError> {
+    pub fn device_authorize(&self) -> Result<DeviceAuthorizeResponse, FlooApiError> {
         let resp = self.post_json("/v1/auth/device", &serde_json::json!({}))?;
         self.handle_response(resp)
     }
 
-    pub fn device_token(&self, device_code: &str) -> Result<Value, FlooApiError> {
+    pub fn device_token(&self, device_code: &str) -> Result<AuthTokenResponse, FlooApiError> {
         let body = serde_json::json!({"device_code": device_code});
         let resp = self.post_json("/v1/auth/device/token", &body)?;
         let status = resp.status().as_u16();
@@ -180,12 +192,12 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
-    pub fn whoami(&self) -> Result<Value, FlooApiError> {
+    pub fn whoami(&self) -> Result<WhoamiResponse, FlooApiError> {
         let resp = self.get("/v1/auth/whoami")?;
         self.handle_response(resp)
     }
 
-    pub fn update_profile(&self, name: &str) -> Result<Value, FlooApiError> {
+    pub fn update_profile(&self, name: &str) -> Result<ProfileResponse, FlooApiError> {
         let body = serde_json::json!({"name": name});
         let resp = self.patch_json("/v1/auth/me", &body)?;
         self.handle_response(resp)
@@ -193,12 +205,12 @@ impl FlooClient {
 
     // --- Org ---
 
-    pub fn get_org_me(&self) -> Result<Value, FlooApiError> {
+    pub fn get_org_me(&self) -> Result<OrgResponse, FlooApiError> {
         let resp = self.get("/v1/orgs/me")?;
         self.handle_response(resp)
     }
 
-    pub fn list_members(&self, org_id: &str) -> Result<Value, FlooApiError> {
+    pub fn list_members(&self, org_id: &str) -> Result<ListMembersResponse, FlooApiError> {
         let resp = self.get(&format!("/v1/orgs/{org_id}/members"))?;
         self.handle_response(resp)
     }
@@ -208,7 +220,7 @@ impl FlooClient {
         org_id: &str,
         user_id: &str,
         role: &str,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<MemberRoleResponse, FlooApiError> {
         let body = serde_json::json!({"role": role});
         let resp = self.patch_json(&format!("/v1/orgs/{org_id}/members/{user_id}"), &body)?;
         self.handle_response(resp)
@@ -224,7 +236,7 @@ impl FlooClient {
 
     // --- Apps ---
 
-    pub fn create_app(&self, name: &str, runtime: Option<&str>) -> Result<Value, FlooApiError> {
+    pub fn create_app(&self, name: &str, runtime: Option<&str>) -> Result<App, FlooApiError> {
         let mut body = serde_json::json!({"name": name});
         if let Some(rt) = runtime {
             body.as_object_mut()
@@ -235,12 +247,12 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
-    pub fn list_apps(&self, page: u32, per_page: u32) -> Result<Value, FlooApiError> {
+    pub fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError> {
         let resp = self.get(&format!("/v1/apps?page={page}&per_page={per_page}"))?;
         self.handle_response(resp)
     }
 
-    pub fn get_app(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    pub fn get_app(&self, app_id: &str) -> Result<App, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}"))?;
         self.handle_response(resp)
     }
@@ -250,7 +262,7 @@ impl FlooClient {
         if resp.status().as_u16() == 204 {
             return Ok(());
         }
-        self.handle_response(resp)?;
+        self.handle_response_value(resp)?;
         Ok(())
     }
 
@@ -264,7 +276,7 @@ impl FlooClient {
         framework: Option<&str>,
         services: Option<&[ServiceConfig]>,
         access_mode: Option<&str>,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<Deploy, FlooApiError> {
         let file_bytes = std::fs::read(tarball_path).map_err(|e| {
             FlooApiError::new(0, "FILE_ERROR", format!("Failed to read archive: {e}"))
         })?;
@@ -313,12 +325,12 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
-    pub fn list_deploys(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    pub fn list_deploys(&self, app_id: &str) -> Result<ListDeploysResponse, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}/deploys"))?;
         self.handle_response(resp)
     }
 
-    pub fn get_deploy(&self, app_id: &str, deploy_id: &str) -> Result<Value, FlooApiError> {
+    pub fn get_deploy(&self, app_id: &str, deploy_id: &str) -> Result<Deploy, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}/deploys/{deploy_id}"))?;
         self.handle_response(resp)
     }
@@ -378,7 +390,7 @@ impl FlooClient {
         key: &str,
         value: &str,
         service_id: Option<&str>,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<SetEnvVarResponse, FlooApiError> {
         let mut body = serde_json::json!({"key": key, "value": value});
         if let Some(sid) = service_id {
             body.as_object_mut()
@@ -393,7 +405,7 @@ impl FlooClient {
         &self,
         app_id: &str,
         service_id: Option<&str>,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<ListEnvVarsResponse, FlooApiError> {
         let mut path = format!("/v1/apps/{app_id}/env");
         if let Some(sid) = service_id {
             path.push_str(&format!("?service_id={sid}"));
@@ -416,7 +428,7 @@ impl FlooClient {
         if resp.status().as_u16() == 204 {
             return Ok(());
         }
-        self.handle_response(resp)?;
+        self.handle_response_value(resp)?;
         Ok(())
     }
 
@@ -425,7 +437,7 @@ impl FlooClient {
         app_id: &str,
         key: &str,
         service_id: Option<&str>,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<EnvVar, FlooApiError> {
         let mut path = format!("/v1/apps/{app_id}/env/{key}");
         if let Some(sid) = service_id {
             path.push_str(&format!("?service_id={sid}"));
@@ -454,35 +466,50 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
-    pub fn list_services(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    pub fn list_services(&self, app_id: &str) -> Result<ListServicesResponse, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}/services?page=1&per_page=100"))?;
         self.handle_response(resp)
     }
 
     // --- Databases ---
 
-    fn parse_database_response(&self, response: &Value) -> Result<Value, FlooApiError> {
-        if response.get("host").is_some()
+    fn parse_database_response(&self, response: &Value) -> Result<DatabaseInfo, FlooApiError> {
+        let target = if response.get("host").is_some()
             && response.get("port").is_some()
             && response.get("database").is_some()
         {
-            return Ok(response.clone());
-        }
-
-        if let Some(database) = response.get("database") {
+            response.clone()
+        } else if let Some(database) = response.get("database") {
             if database.is_object() {
-                return Ok(database.clone());
+                database.clone()
+            } else {
+                return Err(FlooApiError::new(
+                    500,
+                    "PARSE_ERROR",
+                    "Failed to parse database info response from API.",
+                ));
             }
-        }
+        } else {
+            return Err(FlooApiError::new(
+                500,
+                "PARSE_ERROR",
+                "Failed to parse database info response from API.",
+            ));
+        };
 
-        Err(FlooApiError::new(
-            500,
-            "PARSE_ERROR",
-            "Failed to parse database info response from API.",
-        ))
+        serde_json::from_value(target).map_err(|e| {
+            FlooApiError::new(
+                500,
+                "PARSE_ERROR",
+                format!("Failed to parse database info: {e}"),
+            )
+        })
     }
 
-    fn parse_database_from_list_response(&self, response: &Value) -> Result<Value, FlooApiError> {
+    fn parse_database_from_list_response(
+        &self,
+        response: &Value,
+    ) -> Result<DatabaseInfo, FlooApiError> {
         let databases = response
             .get("databases")
             .and_then(|value| value.as_array())
@@ -506,16 +533,22 @@ impl FlooClient {
                 )
             })?;
 
-        Ok(database.clone())
+        serde_json::from_value(database.clone()).map_err(|e| {
+            FlooApiError::new(
+                500,
+                "PARSE_ERROR",
+                format!("Failed to parse database info: {e}"),
+            )
+        })
     }
 
-    pub fn get_database_info(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    pub fn get_database_info(&self, app_id: &str) -> Result<DatabaseInfo, FlooApiError> {
         let db_info_response = self.get(&format!("/v1/apps/{app_id}/db"))?;
-        match self.handle_response(db_info_response) {
+        match self.handle_response_value(db_info_response) {
             Ok(response) => self.parse_database_response(&response),
             Err(error) if error.status_code == 404 => {
                 let list_response = self.get(&format!("/v1/apps/{app_id}/databases"))?;
-                let list_body = self.handle_response(list_response)?;
+                let list_body = self.handle_response_value(list_response)?;
                 self.parse_database_from_list_response(&list_body)
             }
             Err(error) => Err(error),
@@ -524,13 +557,17 @@ impl FlooClient {
 
     // --- Domains ---
 
-    pub fn add_domain(&self, app_id: &str, hostname: &str) -> Result<Value, FlooApiError> {
+    pub fn add_domain(
+        &self,
+        app_id: &str,
+        hostname: &str,
+    ) -> Result<AddDomainResponse, FlooApiError> {
         let body = serde_json::json!({"hostname": hostname});
         let resp = self.post_json(&format!("/v1/apps/{app_id}/domains"), &body)?;
         self.handle_response(resp)
     }
 
-    pub fn list_domains(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    pub fn list_domains(&self, app_id: &str) -> Result<ListDomainsResponse, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}/domains"))?;
         self.handle_response(resp)
     }
@@ -540,13 +577,13 @@ impl FlooClient {
         if resp.status().as_u16() == 204 {
             return Ok(());
         }
-        self.handle_response(resp)?;
+        self.handle_response_value(resp)?;
         Ok(())
     }
 
     // --- Rollbacks ---
 
-    pub fn rollback_deploy(&self, app_id: &str, deploy_id: &str) -> Result<Value, FlooApiError> {
+    pub fn rollback_deploy(&self, app_id: &str, deploy_id: &str) -> Result<Deploy, FlooApiError> {
         let body = serde_json::json!({"deploy_id": deploy_id});
         let mut req = self
             .client
@@ -571,7 +608,7 @@ impl FlooClient {
         since: Option<&str>,
         severity: Option<&str>,
         service: Option<&str>,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<LogsResponse, FlooApiError> {
         let limit_str = limit.to_string();
         let mut params: Vec<(&str, &str)> = vec![("limit", &limit_str)];
         if let Some(s) = since {
@@ -614,7 +651,7 @@ impl FlooClient {
         installation_id: u64,
         branch: Option<&str>,
         skip_env_var_check: bool,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<GitHubConnectResponse, FlooApiError> {
         let mut body = serde_json::json!({
             "repo_full_name": repo_full_name,
             "installation_id": installation_id,
@@ -635,13 +672,17 @@ impl FlooClient {
 
     pub fn github_disconnect(&self, app_id: &str) -> Result<(), FlooApiError> {
         let resp = self.delete(&format!("/v1/apps/{app_id}/github/disconnect"))?;
-        self.handle_response(resp)?;
+        self.handle_response_value(resp)?;
         Ok(())
     }
 
     // --- Releases ---
 
-    pub fn promote_app(&self, app_id: &str, tag: Option<&str>) -> Result<Value, FlooApiError> {
+    pub fn promote_app(
+        &self,
+        app_id: &str,
+        tag: Option<&str>,
+    ) -> Result<PromoteResponse, FlooApiError> {
         let mut body = serde_json::json!({});
         if let Some(t) = tag {
             body.as_object_mut()
@@ -670,21 +711,25 @@ impl FlooClient {
         app_id: &str,
         page: u32,
         per_page: u32,
-    ) -> Result<Value, FlooApiError> {
+    ) -> Result<ListReleasesResponse, FlooApiError> {
         let resp = self.get(&format!(
             "/v1/apps/{app_id}/releases?page={page}&per_page={per_page}"
         ))?;
         self.handle_response(resp)
     }
 
-    pub fn get_release(&self, app_id: &str, release_id: &str) -> Result<Value, FlooApiError> {
+    pub fn get_release(&self, app_id: &str, release_id: &str) -> Result<Release, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}/releases/{release_id}"))?;
         self.handle_response(resp)
     }
 
     // --- Analytics ---
 
-    pub fn get_app_analytics(&self, app_id: &str, period: &str) -> Result<Value, FlooApiError> {
+    pub fn get_app_analytics(
+        &self,
+        app_id: &str,
+        period: &str,
+    ) -> Result<AppAnalyticsResponse, FlooApiError> {
         let resp = self.get_with_query(
             &format!("/v1/apps/{app_id}/analytics"),
             &[("period", period)],
@@ -692,7 +737,7 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
-    pub fn get_org_analytics(&self, period: &str) -> Result<Value, FlooApiError> {
+    pub fn get_org_analytics(&self, period: &str) -> Result<AppAnalyticsResponse, FlooApiError> {
         let resp = self.get_with_query("/v1/orgs/analytics", &[("period", period)])?;
         self.handle_response(resp)
     }

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -1,0 +1,250 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// --- Auth ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WhoamiResponse {
+    pub email: String,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceAuthorizeResponse {
+    pub user_code: String,
+    pub verification_uri_complete: String,
+    pub device_code: String,
+    pub interval: u64,
+    pub expires_in: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthTokenResponse {
+    pub api_key: String,
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileResponse {
+    pub name: String,
+}
+
+// --- Org ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgResponse {
+    pub id: String,
+    pub name: Option<String>,
+    pub spend_cap: Option<u64>,
+    pub current_period_spend_cents: Option<u64>,
+    pub spend_cap_exceeded: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListMembersResponse {
+    pub members: Vec<OrgMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgMember {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemberRoleResponse {
+    pub email: String,
+    pub role: String,
+}
+
+// --- App ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct App {
+    pub id: String,
+    pub name: String,
+    pub status: Option<String>,
+    pub url: Option<String>,
+    pub runtime: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListAppsResponse {
+    pub apps: Vec<App>,
+    pub total: Option<u64>,
+}
+
+// --- Deploy ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Deploy {
+    pub id: String,
+    pub status: Option<String>,
+    pub url: Option<String>,
+    pub build_logs: Option<String>,
+    pub runtime: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListDeploysResponse {
+    pub deploys: Vec<Deploy>,
+}
+
+// --- Env Var ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvVar {
+    pub key: String,
+    pub value: Option<String>,
+    pub masked_value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListEnvVarsResponse {
+    pub env_vars: Vec<EnvVar>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetEnvVarResponse {
+    pub key: Option<String>,
+    pub masked_value: Option<String>,
+    pub status: Option<String>,
+}
+
+// --- Service ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiService {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub service_type: Option<String>,
+    pub status: Option<String>,
+    pub cloud_run_url: Option<String>,
+    pub port: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListServicesResponse {
+    pub services: Vec<ApiService>,
+}
+
+// --- Domain ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Domain {
+    pub hostname: String,
+    pub status: Option<String>,
+    pub dns_instructions: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListDomainsResponse {
+    pub domains: Vec<Domain>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddDomainResponse {
+    pub hostname: Option<String>,
+    pub status: Option<String>,
+    pub dns_instructions: Option<String>,
+}
+
+// --- Logs ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEntry {
+    pub timestamp: Option<String>,
+    pub severity: Option<String>,
+    pub message: Option<String>,
+    pub service_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogsResponse {
+    pub logs: Vec<LogEntry>,
+}
+
+// --- Release ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+    pub release_number: Option<u64>,
+    pub tag: Option<String>,
+    pub commit_sha: Option<String>,
+    pub promoted_by: Option<String>,
+    pub created_at: Option<String>,
+    pub deploy_id: Option<String>,
+    pub image_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListReleasesResponse {
+    pub releases: Vec<Release>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromoteResponse {
+    pub tag: String,
+    pub release_url: String,
+}
+
+// --- GitHub ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubConnectResponse {
+    pub default_branch: Option<String>,
+}
+
+// --- Database ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseInfo {
+    pub host: String,
+    pub port: u64,
+    pub database: String,
+    pub name: Option<String>,
+    pub status: Option<String>,
+    pub username: Option<String>,
+    pub schema_name: Option<String>,
+}
+
+// --- Analytics ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalyticsSummary {
+    pub total_requests: i64,
+    pub total_errors: i64,
+    pub error_rate: f64,
+    pub avg_latency_ms: Option<i64>,
+    pub p95_latency_ms: Option<i64>,
+    pub unique_users: Option<i64>,
+    pub status_code_breakdown: Option<HashMap<String, i64>>,
+    pub total_apps_with_traffic: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppAnalyticsResponse {
+    pub summary: AnalyticsSummary,
+    pub time_series: Option<Vec<TimeSeriesPoint>>,
+    pub apps: Option<Vec<AppAnalyticsEntry>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeSeriesPoint {
+    pub request_count: i64,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppAnalyticsEntry {
+    pub app_name: String,
+    pub total_requests: i64,
+    pub total_errors: i64,
+    pub error_rate: f64,
+}

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -1,7 +1,7 @@
+use std::collections::HashMap;
 use std::process;
 
-use serde_json::Value;
-
+use crate::api_types::{AppAnalyticsResponse, TimeSeriesPoint};
 use crate::output;
 
 pub fn analytics(app: Option<String>, period: &str) {
@@ -14,64 +14,11 @@ pub fn analytics(app: Option<String>, period: &str) {
     }
 }
 
-fn expect_i64(value: &Value, path: &str) -> i64 {
-    value.as_i64().unwrap_or_else(|| {
-        output::error(
-            &format!("Analytics response missing or invalid field: '{path}'."),
-            "PARSE_ERROR",
-            Some("The API response format may have changed. Try 'floo update'."),
-        );
-        process::exit(1);
-    })
-}
-
-fn expect_f64(value: &Value, path: &str) -> f64 {
-    value.as_f64().unwrap_or_else(|| {
-        output::error(
-            &format!("Analytics response missing or invalid field: '{path}'."),
-            "PARSE_ERROR",
-            Some("The API response format may have changed. Try 'floo update'."),
-        );
-        process::exit(1);
-    })
-}
-
-fn expect_str<'a>(value: &'a Value, path: &str) -> &'a str {
-    value.as_str().unwrap_or_else(|| {
-        output::error(
-            &format!("Analytics response missing or invalid field: '{path}'."),
-            "PARSE_ERROR",
-            Some("The API response format may have changed. Try 'floo update'."),
-        );
-        process::exit(1);
-    })
-}
-
-fn expect_object<'a>(data: &'a Value, key: &str) -> &'a Value {
-    let val = data.get(key).unwrap_or_else(|| {
-        output::error(
-            &format!("Analytics response missing '{key}' object."),
-            "PARSE_ERROR",
-            Some("The API response format may have changed. Try 'floo update'."),
-        );
-        process::exit(1);
-    });
-    if !val.is_object() {
-        output::error(
-            &format!("Analytics response '{key}' is not an object."),
-            "PARSE_ERROR",
-            Some("The API response format may have changed. Try 'floo update'."),
-        );
-        process::exit(1);
-    }
-    val
-}
-
 fn app_analytics(client: &crate::api_client::FlooClient, app_name: &str, period: &str) {
     let app_data = super::resolve_app_or_exit(client, app_name);
 
-    let app_id = super::expect_str_field(&app_data, "id");
-    let name = super::expect_str_field(&app_data, "name");
+    let app_id = &app_data.id;
+    let name = &app_data.name;
 
     let data = match client.get_app_analytics(app_id, period) {
         Ok(d) => d,
@@ -82,7 +29,10 @@ fn app_analytics(client: &crate::api_client::FlooClient, app_name: &str, period:
     };
 
     if output::is_json_mode() {
-        output::success(&format!("Analytics for {name}"), Some(data));
+        output::success(
+            &format!("Analytics for {name}"),
+            Some(output::to_value(&data)),
+        );
         return;
     }
 
@@ -99,18 +49,18 @@ fn org_analytics(client: &crate::api_client::FlooClient, period: &str) {
     };
 
     if output::is_json_mode() {
-        output::success("Organization analytics", Some(data));
+        output::success("Organization analytics", Some(output::to_value(&data)));
         return;
     }
 
     render_org_analytics(period, &data);
 }
 
-fn render_app_analytics(name: &str, period: &str, data: &Value) {
-    let summary = expect_object(data, "summary");
-    let total_requests = expect_i64(&summary["total_requests"], "summary.total_requests");
-    let total_errors = expect_i64(&summary["total_errors"], "summary.total_errors");
-    let error_rate = expect_f64(&summary["error_rate"], "summary.error_rate");
+fn render_app_analytics(name: &str, period: &str, data: &AppAnalyticsResponse) {
+    let summary = &data.summary;
+    let total_requests = summary.total_requests;
+    let total_errors = summary.total_errors;
+    let error_rate = summary.error_rate;
 
     eprintln!();
     eprintln!("Analytics for {} (last {})", name, format_period(period));
@@ -123,17 +73,17 @@ fn render_app_analytics(name: &str, period: &str, data: &Value) {
         error_rate * 100.0
     );
 
-    if let Some(avg) = summary["avg_latency_ms"].as_i64() {
+    if let Some(avg) = summary.avg_latency_ms {
         eprintln!("  {:14}{:>10}", "Avg Latency", format!("{}ms", avg));
     }
-    if let Some(p95) = summary["p95_latency_ms"].as_i64() {
+    if let Some(p95) = summary.p95_latency_ms {
         eprintln!("  {:14}{:>10}", "P95 Latency", format!("{}ms", p95));
     }
-    if let Some(unique) = summary["unique_users"].as_i64() {
+    if let Some(unique) = summary.unique_users {
         eprintln!("  {:14}{:>10}", "Unique Users", format_number(unique));
     }
 
-    if let Some(breakdown) = summary["status_code_breakdown"].as_object() {
+    if let Some(breakdown) = &summary.status_code_breakdown {
         if !breakdown.is_empty() {
             eprintln!();
             eprintln!("Status Codes");
@@ -141,7 +91,7 @@ fn render_app_analytics(name: &str, period: &str, data: &Value) {
         }
     }
 
-    if let Some(time_series) = data["time_series"].as_array() {
+    if let Some(time_series) = &data.time_series {
         if !time_series.is_empty() {
             eprintln!();
             eprintln!("Traffic");
@@ -152,15 +102,12 @@ fn render_app_analytics(name: &str, period: &str, data: &Value) {
     eprintln!();
 }
 
-fn render_org_analytics(period: &str, data: &Value) {
-    let summary = expect_object(data, "summary");
-    let total_requests = expect_i64(&summary["total_requests"], "summary.total_requests");
-    let total_errors = expect_i64(&summary["total_errors"], "summary.total_errors");
-    let error_rate = expect_f64(&summary["error_rate"], "summary.error_rate");
-    let apps_with_traffic = expect_i64(
-        &summary["total_apps_with_traffic"],
-        "summary.total_apps_with_traffic",
-    );
+fn render_org_analytics(period: &str, data: &AppAnalyticsResponse) {
+    let summary = &data.summary;
+    let total_requests = summary.total_requests;
+    let total_errors = summary.total_errors;
+    let error_rate = summary.error_rate;
+    let apps_with_traffic = summary.total_apps_with_traffic.unwrap_or(0);
 
     eprintln!();
     eprintln!("Organization Analytics (last {})", format_period(period));
@@ -182,22 +129,18 @@ fn render_org_analytics(period: &str, data: &Value) {
         format_number(apps_with_traffic)
     );
 
-    if let Some(apps) = data["apps"].as_array() {
+    if let Some(apps) = &data.apps {
         if !apps.is_empty() {
             eprintln!();
 
             let rows: Vec<Vec<String>> = apps
                 .iter()
                 .map(|a| {
-                    let name = expect_str(&a["app_name"], "apps[].app_name");
-                    let reqs = expect_i64(&a["total_requests"], "apps[].total_requests");
-                    let errs = expect_i64(&a["total_errors"], "apps[].total_errors");
-                    let erate = expect_f64(&a["error_rate"], "apps[].error_rate");
                     vec![
-                        name.to_string(),
-                        format_number(reqs),
-                        format_number(errs),
-                        format!("{:.2}%", erate * 100.0),
+                        a.app_name.clone(),
+                        format_number(a.total_requests),
+                        format_number(a.total_errors),
+                        format!("{:.2}%", a.error_rate * 100.0),
                     ]
                 })
                 .collect();
@@ -206,7 +149,7 @@ fn render_org_analytics(period: &str, data: &Value) {
         }
     }
 
-    if let Some(time_series) = data["time_series"].as_array() {
+    if let Some(time_series) = &data.time_series {
         if !time_series.is_empty() {
             eprintln!();
             eprintln!("Traffic");
@@ -217,15 +160,12 @@ fn render_org_analytics(period: &str, data: &Value) {
     eprintln!();
 }
 
-fn render_status_code_chart(breakdown: &serde_json::Map<String, Value>, total: i64) {
+fn render_status_code_chart(breakdown: &HashMap<String, i64>, total: i64) {
     let max_bar_width: usize = 20;
 
     let mut entries: Vec<(&str, i64)> = breakdown
         .iter()
-        .map(|(k, v)| {
-            let count = expect_i64(v, &format!("status_code_breakdown.{k}"));
-            (k.as_str(), count)
-        })
+        .map(|(k, &count)| (k.as_str(), count))
         .collect();
     entries.sort_by_key(|(k, _)| k.to_string());
 
@@ -258,16 +198,13 @@ fn render_status_code_chart(breakdown: &serde_json::Map<String, Value>, total: i
     }
 }
 
-fn render_sparkline(time_series: &[Value]) {
+fn render_sparkline(time_series: &[TimeSeriesPoint]) {
     let blocks = [
         '\u{2581}', '\u{2582}', '\u{2583}', '\u{2584}', '\u{2585}', '\u{2586}', '\u{2587}',
         '\u{2588}',
     ];
 
-    let counts: Vec<i64> = time_series
-        .iter()
-        .map(|p| expect_i64(&p["request_count"], "time_series[].request_count"))
-        .collect();
+    let counts: Vec<i64> = time_series.iter().map(|p| p.request_count).collect();
 
     let max = counts
         .iter()

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -17,21 +17,12 @@ pub fn list(page: u32, per_page: u32) {
         }
     };
 
-    let apps = result
-        .get("apps")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
+    let total = result.total.unwrap_or_else(|| {
+        eprintln!("Warning: API response missing 'total' field; pagination may be inaccurate.");
+        result.apps.len() as u64
+    }) as u32;
 
-    let total = match result.get("total").and_then(|v| v.as_u64()) {
-        Some(t) => t as u32,
-        None => {
-            eprintln!("Warning: API response missing 'total' field; pagination may be inaccurate.");
-            apps.len() as u32
-        }
-    };
-
-    if apps.is_empty() {
+    if result.apps.is_empty() {
         if !output::is_json_mode() {
             output::info("No apps yet. Deploy one with floo deploy.", None);
         } else {
@@ -45,30 +36,16 @@ pub fn list(page: u32, per_page: u32) {
         return;
     }
 
-    let rows: Vec<Vec<String>> = apps
+    let rows: Vec<Vec<String>> = result
+        .apps
         .iter()
         .map(|a| {
             vec![
-                a.get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                a.get("status")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                a.get("url")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("\u{2014}")
-                    .to_string(),
-                a.get("runtime")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("\u{2014}")
-                    .to_string(),
-                a.get("created_at")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
+                a.name.clone(),
+                a.status.as_deref().unwrap_or("-").to_string(),
+                a.url.as_deref().unwrap_or("\u{2014}").to_string(),
+                a.runtime.as_deref().unwrap_or("\u{2014}").to_string(),
+                a.created_at.as_deref().unwrap_or("-").to_string(),
             ]
         })
         .collect();
@@ -76,7 +53,9 @@ pub fn list(page: u32, per_page: u32) {
     output::table(
         &["Name", "Status", "URL", "Runtime", "Created"],
         &rows,
-        Some(serde_json::json!({"apps": apps, "total": total, "page": page, "per_page": per_page})),
+        Some(
+            serde_json::json!({"apps": output::to_value(&result.apps), "total": total, "page": page, "per_page": per_page}),
+        ),
     );
 
     if !output::is_json_mode() {
@@ -96,70 +75,60 @@ pub fn list(page: u32, per_page: u32) {
 pub fn status(app_name: &str) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = super::resolve_app_or_exit(&client, app_name);
+    let app = super::resolve_app_or_exit(&client, app_name);
 
     if output::is_json_mode() {
-        let name = app_data
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or(app_name);
-        output::success(&format!("App {name}"), Some(app_data));
+        output::success(&format!("App {}", app.name), Some(output::to_value(&app)));
     } else {
-        let name = app_data.get("name").and_then(|v| v.as_str()).unwrap_or("-");
-        let st = app_data
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let url = app_data
-            .get("url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("\u{2014}");
-        let runtime = app_data
-            .get("runtime")
-            .and_then(|v| v.as_str())
-            .unwrap_or("\u{2014}");
-        let id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("-");
-        let created = app_data
-            .get("created_at")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-
-        output::info(name, None);
-        output::info(&format!("  Status:   {st}"), None);
-        output::info(&format!("  URL:      {url}"), None);
-        output::info(&format!("  Runtime:  {runtime}"), None);
-        output::info(&format!("  ID:       {id}"), None);
-        output::info(&format!("  Created:  {created}"), None);
+        output::info(&app.name, None);
+        output::info(
+            &format!("  Status:   {}", app.status.as_deref().unwrap_or("-")),
+            None,
+        );
+        output::info(
+            &format!("  URL:      {}", app.url.as_deref().unwrap_or("\u{2014}")),
+            None,
+        );
+        output::info(
+            &format!(
+                "  Runtime:  {}",
+                app.runtime.as_deref().unwrap_or("\u{2014}")
+            ),
+            None,
+        );
+        output::info(&format!("  ID:       {}", app.id), None);
+        output::info(
+            &format!("  Created:  {}", app.created_at.as_deref().unwrap_or("-")),
+            None,
+        );
     }
 }
 
 pub fn delete(app_name: &str, force: bool) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = super::resolve_app_or_exit(&client, app_name);
+    let app = super::resolve_app_or_exit(&client, app_name);
 
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
-
-    if !force && !output::confirm(&format!("Delete app '{name}'? This cannot be undone.")) {
+    if !force
+        && !output::confirm(&format!(
+            "Delete app '{}'? This cannot be undone.",
+            app.name
+        ))
+    {
         if !output::is_json_mode() {
             output::info("Cancelled.", None);
         }
         process::exit(0);
     }
 
-    let app_id = app_data.get("id").and_then(|v| v.as_str()).unwrap_or("");
-
-    if let Err(e) = client.delete_app(app_id) {
+    if let Err(e) = client.delete_app(&app.id) {
         output::error(&e.message, &e.code, None);
         process::exit(1);
     }
 
     output::success(
-        &format!("Deleted app '{name}'."),
-        Some(serde_json::json!({"id": app_id})),
+        &format!("Deleted app '{}'.", app.name),
+        Some(serde_json::json!({"id": app.id})),
     );
 }
 
@@ -173,14 +142,10 @@ pub fn connect(
 ) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = super::resolve_app_or_exit(&client, app_name);
+    let app = super::resolve_app_or_exit(&client, app_name);
 
-    let app_id = super::expect_str_field(&app_data, "id").to_string();
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name)
-        .to_string();
+    let app_id = app.id.clone();
+    let name = app.name.clone();
 
     // Try to load project config from cwd to import env vars and trigger deploy
     let cwd = std::env::current_dir().unwrap_or_else(|e| {
@@ -220,15 +185,11 @@ pub fn connect(
         }
     };
 
-    let connected_branch = result
-        .get("default_branch")
-        .and_then(|v| v.as_str())
-        .unwrap_or("main")
-        .to_string();
+    let connected_branch = result.default_branch.as_deref().unwrap_or("main");
 
     output::success(
         &format!("Connected {name} to {repo} (branch: {connected_branch})"),
-        Some(result),
+        Some(output::to_value(&result)),
     );
 
     // Step 3: Trigger initial deploy unless --no-deploy
@@ -319,23 +280,18 @@ fn trigger_initial_deploy(
 
     super::deploy::cleanup(&archive_path);
 
-    let initial_status = deploy_data
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let initial_status = deploy_data.status.as_deref().unwrap_or("");
 
     if !super::deploy::TERMINAL_STATUSES.contains(&initial_status) {
-        let deploy_id = match deploy_data.get("id").and_then(|v| v.as_str()) {
-            Some(id) => id.to_string(),
-            None => {
-                output::error(
-                    "Unexpected API response: deploy is missing required 'id'.",
-                    "INVALID_RESPONSE",
-                    Some("This may indicate a CLI/API mismatch. Check for updates with `floo update`."),
-                );
-                process::exit(1);
-            }
-        };
+        if deploy_data.id.is_empty() {
+            output::error(
+                "Unexpected API response: deploy is missing required 'id'.",
+                "INVALID_RESPONSE",
+                Some("This may indicate a CLI/API mismatch. Check for updates with `floo update`."),
+            );
+            process::exit(1);
+        }
+        let deploy_id = deploy_data.id.clone();
 
         if !output::is_json_mode() {
             match super::deploy::stream_deploy(client, app_id, &deploy_id) {
@@ -350,47 +306,38 @@ fn trigger_initial_deploy(
         }
     }
 
-    let final_status = deploy_data
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let final_status = deploy_data.status.as_deref().unwrap_or("");
 
     if final_status == "failed" {
         output::error_with_data(
             "Deploy failed.",
             "DEPLOY_FAILED",
             Some("Check build output above, or run `floo logs` for details."),
-            Some(deploy_data),
+            Some(output::to_value(&deploy_data)),
         );
         process::exit(1);
     }
 
-    let url = deploy_data
-        .get("url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let url = deploy_data.url.as_deref().unwrap_or("");
 
-    output::success(&format!("Deployed to {url}"), Some(deploy_data));
+    output::success(
+        &format!("Deployed to {url}"),
+        Some(output::to_value(&deploy_data)),
+    );
 }
 
 pub fn disconnect(app_name: &str) {
     super::require_auth();
     let client = super::init_client(None);
-    let app_data = super::resolve_app_or_exit(&client, app_name);
+    let app = super::resolve_app_or_exit(&client, app_name);
 
-    let app_id = super::expect_str_field(&app_data, "id");
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
-
-    if let Err(e) = client.github_disconnect(app_id) {
+    if let Err(e) = client.github_disconnect(&app.id) {
         output::error(&e.message, &e.code, None);
         process::exit(1);
     }
 
     output::success(
-        &format!("Disconnected {name} from GitHub."),
-        Some(serde_json::json!({"app": name})),
+        &format!("Disconnected {} from GitHub.", app.name),
+        Some(serde_json::json!({"app": app.name})),
     );
 }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -24,10 +24,7 @@ pub fn login(api_key: Option<&str>, force: bool) {
         let client = super::init_client(Some(config));
         match client.whoami() {
             Ok(result) => {
-                let email = result
-                    .get("email")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
+                let email = &result.email;
                 // Save the email too
                 let mut config = load_config();
                 config.user_email = Some(email.to_string());
@@ -54,10 +51,7 @@ pub fn login(api_key: Option<&str>, force: bool) {
             let client = super::init_client(Some(config));
             match client.whoami() {
                 Ok(result) => {
-                    let email = result
-                        .get("email")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
+                    let email = &result.email;
                     output::success(
                         &format!("Already logged in as {email}"),
                         Some(serde_json::json!({"email": email, "already_authenticated": true})),
@@ -88,52 +82,18 @@ pub fn login(api_key: Option<&str>, force: bool) {
         }
     };
 
-    let user_code = auth
-        .get("user_code")
-        .and_then(|v| v.as_str())
-        .unwrap_or_else(|| {
-            output::error("Invalid response: missing user_code", "PARSE_ERROR", None);
-            process::exit(1);
-        });
-    let verification_uri_complete = auth
-        .get("verification_uri_complete")
-        .and_then(|v| v.as_str())
-        .unwrap_or_else(|| {
-            output::error(
-                "Invalid response: missing verification_uri_complete",
-                "PARSE_ERROR",
-                None,
-            );
-            process::exit(1);
-        });
-    let device_code = auth
-        .get("device_code")
-        .and_then(|v| v.as_str())
-        .unwrap_or_else(|| {
-            output::error("Invalid response: missing device_code", "PARSE_ERROR", None);
-            process::exit(1);
-        });
-    let interval = auth
-        .get("interval")
-        .and_then(|v| v.as_u64())
-        .unwrap_or_else(|| {
-            output::error("Invalid response: missing interval", "PARSE_ERROR", None);
-            process::exit(1);
-        });
-    let expires_in = auth
-        .get("expires_in")
-        .and_then(|v| v.as_u64())
-        .unwrap_or_else(|| {
-            output::error("Invalid response: missing expires_in", "PARSE_ERROR", None);
-            process::exit(1);
-        });
+    let user_code = &auth.user_code;
+    let verification_uri_complete = &auth.verification_uri_complete;
+    let device_code = &auth.device_code;
+    let interval = auth.interval;
+    let expires_in = auth.expires_in;
 
     // Step 2: Display code and open browser
     if !output::is_json_mode() {
         eprintln!();
         eprintln!("  Your one-time code is:  {}", user_code.bold());
         eprintln!();
-        eprintln!("  Opening browser to: {}", verification_uri_complete);
+        eprintln!("  Opening browser to: {verification_uri_complete}");
         eprintln!("  If the browser didn't open, visit the URL above and enter the code.");
         eprintln!();
     }
@@ -163,28 +123,8 @@ pub fn login(api_key: Option<&str>, force: bool) {
         match client.device_token(device_code) {
             Ok(result) => {
                 spinner.finish();
-                let api_key = result
-                    .get("api_key")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_else(|| {
-                        output::error(
-                            "Server returned success but API key was missing.",
-                            "PARSE_ERROR",
-                            Some("This may be a server bug. Please try again."),
-                        );
-                        process::exit(1);
-                    });
-                let email = result
-                    .get("email")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_else(|| {
-                        output::error(
-                            "Server returned success but email was missing.",
-                            "PARSE_ERROR",
-                            Some("This may be a server bug. Please try again."),
-                        );
-                        process::exit(1);
-                    });
+                let api_key = &result.api_key;
+                let email = &result.email;
                 let mut config = load_config();
                 config.api_key = Some(api_key.to_string());
                 config.user_email = Some(email.to_string());
@@ -290,28 +230,8 @@ pub fn register(email: &str) {
     match client.register(email) {
         Ok(result) => {
             spinner.finish();
-            let api_key = result
-                .get("api_key")
-                .and_then(|v| v.as_str())
-                .unwrap_or_else(|| {
-                    output::error(
-                        "Server returned success but API key was missing.",
-                        "PARSE_ERROR",
-                        Some("This may be a server bug. Please try again."),
-                    );
-                    process::exit(1);
-                });
-            let resp_email = result
-                .get("email")
-                .and_then(|v| v.as_str())
-                .unwrap_or_else(|| {
-                    output::error(
-                        "Server returned success but email was missing.",
-                        "PARSE_ERROR",
-                        Some("This may be a server bug. Please try again."),
-                    );
-                    process::exit(1);
-                });
+            let api_key = &result.api_key;
+            let resp_email = &result.email;
             let mut config = load_config();
             config.api_key = Some(api_key.to_string());
             config.user_email = Some(resp_email.to_string());
@@ -351,10 +271,10 @@ pub fn update_profile(name: &str) {
 
     match client.update_profile(name) {
         Ok(result) => {
-            let updated_name = result.get("name").and_then(|v| v.as_str()).unwrap_or(name);
+            let updated_name = &result.name;
             output::success(
                 &format!("Profile updated. Name: {updated_name}"),
-                Some(result),
+                Some(output::to_value(&result)),
             );
         }
         Err(e) => {
@@ -391,11 +311,8 @@ pub fn whoami() {
             let client = super::init_client(None);
             match client.whoami() {
                 Ok(result) => {
-                    let email = result
-                        .get("email")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
-                    let name = result.get("name").and_then(|v| v.as_str());
+                    let email = &result.email;
+                    let name = result.name.as_deref();
 
                     let mut data = serde_json::json!({
                         "email": email,

--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -14,39 +14,23 @@ pub fn spend_cap_get() {
         }
     };
 
-    let spend_cap = match org.get("spend_cap") {
-        Some(v) => v.as_u64(),
-        None => {
-            output::error(
-                "Response missing 'spend_cap' field.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        }
-    };
-    let current_spend = org
-        .get("current_period_spend_cents")
-        .and_then(|v| v.as_u64())
-        .unwrap_or_else(|| {
-            output::error(
-                "Response missing 'current_period_spend_cents' field.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        });
-    let exceeded = org
-        .get("spend_cap_exceeded")
-        .and_then(|v| v.as_bool())
-        .unwrap_or_else(|| {
-            output::error(
-                "Response missing 'spend_cap_exceeded' field.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        });
+    let spend_cap = org.spend_cap;
+    let current_spend = org.current_period_spend_cents.unwrap_or_else(|| {
+        output::error(
+            "Response missing 'current_period_spend_cents' field.",
+            "PARSE_ERROR",
+            Some("This is a bug. Please report it."),
+        );
+        process::exit(1);
+    });
+    let exceeded = org.spend_cap_exceeded.unwrap_or_else(|| {
+        output::error(
+            "Response missing 'spend_cap_exceeded' field.",
+            "PARSE_ERROR",
+            Some("This is a bug. Please report it."),
+        );
+        process::exit(1);
+    });
 
     let data = serde_json::json!({
         "spend_cap": spend_cap,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::api_client::FlooClient;
+use crate::api_types::Deploy;
 use crate::archive::create_archive;
 use crate::config::load_config;
 use crate::detection::detect;
@@ -28,20 +29,6 @@ fn status_label(status: &str) -> &str {
         "building" => "Building...",
         "deploying" => "Deploying...",
         _ => "Deploying...",
-    }
-}
-
-fn required_response_id<'a>(value: &'a serde_json::Value, object_name: &str) -> &'a str {
-    match value.get("id").and_then(|v| v.as_str()) {
-        Some(id) if !id.is_empty() => id,
-        _ => {
-            output::error(
-                &format!("Unexpected API response: {object_name} is missing required 'id'."),
-                "INVALID_RESPONSE",
-                Some("This may indicate a CLI/API mismatch. Check for updates with `floo update`."),
-            );
-            process::exit(1);
-        }
     }
 }
 
@@ -101,7 +88,7 @@ pub fn deploy(
                 process::exit(1);
             }
         };
-        let app_id = required_response_id(&app_data, "app").to_string();
+        let app_id = app_data.id.clone();
 
         let svcs = if services_filter.is_empty() {
             None
@@ -144,7 +131,7 @@ pub fn deploy(
                 "RESTART_FAILED",
                 Some("Run `floo logs` for details."),
                 Some(serde_json::json!({
-                    "app": app_data,
+                    "app": output::to_value(&app_data),
                     "deploy": deploy_data,
                 })),
             );
@@ -154,7 +141,7 @@ pub fn deploy(
         output::success(
             &format!("Restarted {url}"),
             Some(serde_json::json!({
-                "app": app_data,
+                "app": output::to_value(&app_data),
                 "deploy": deploy_data,
             })),
         );
@@ -429,7 +416,7 @@ pub fn deploy(
             }
         }
     };
-    let app_id = required_response_id(&app_data, "app").to_string();
+    let app_id = app_data.id.clone();
 
     // Auto-import env vars on first deploy (or force with --sync-env)
     if let Some(ref r) = resolved {
@@ -471,16 +458,13 @@ pub fn deploy(
     cleanup(&archive_path);
 
     // Wait for deploy to complete via SSE streaming or polling
-    let initial_status = deploy_data
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let initial_status = deploy_data.status.as_deref().unwrap_or("");
 
     if TERMINAL_STATUSES.contains(&initial_status) {
         // Phase 1: deploy already complete synchronously, skip streaming/polling
     } else if !output::is_json_mode() {
         // Phase 2 human mode: try SSE streaming, fall back to polling
-        let deploy_id = required_response_id(&deploy_data, "deploy").to_string();
+        let deploy_id = deploy_data.id.clone();
         match stream_deploy(&client, &app_id, &deploy_id) {
             Ok(final_data) => deploy_data = final_data,
             Err(e) => {
@@ -494,30 +478,24 @@ pub fn deploy(
         }
     } else {
         // Phase 2 JSON mode: stream structured NDJSON events via SSE
-        let deploy_id = required_response_id(&deploy_data, "deploy").to_string();
+        let deploy_id = deploy_data.id.clone();
         match stream_deploy_json(&client, &app_id, &deploy_id) {
             Ok(final_data) => deploy_data = final_data,
             Err(_) => deploy_data = poll_deploy(&client, &app_id, &deploy_data),
         }
     }
 
-    let final_status = deploy_data
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let final_status = deploy_data.status.as_deref().unwrap_or("");
 
     if final_status == "failed" {
-        let build_logs = deploy_data
-            .get("build_logs")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
         output::error_with_data(
             "Deploy failed.",
             "DEPLOY_FAILED",
             Some("Check build output above, or run `floo logs` for details."),
             Some(serde_json::json!({
-                "app": app_data,
-                "deploy": deploy_data,
+                "app": output::to_value(&app_data),
+                "deploy": output::to_value(&deploy_data),
                 "build_logs": build_logs,
             })),
         );
@@ -533,10 +511,7 @@ pub fn deploy(
         }
     }
 
-    let url = deploy_data
-        .get("url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let url = deploy_data.url.as_deref().unwrap_or("");
 
     let service_names: Vec<&str> = services
         .as_ref()
@@ -546,8 +521,8 @@ pub fn deploy(
     output::success(
         &format!("Deployed to {url}"),
         Some(serde_json::json!({
-            "app": app_data,
-            "deploy": deploy_data,
+            "app": output::to_value(&app_data),
+            "deploy": output::to_value(&deploy_data),
             "detection": detection.to_value(),
             "services": service_names,
         })),
@@ -642,7 +617,7 @@ pub(crate) fn stream_deploy(
     client: &FlooClient,
     app_id: &str,
     deploy_id: &str,
-) -> Result<serde_json::Value, FlooApiError> {
+) -> Result<Deploy, FlooApiError> {
     let response = client.stream_deploy_logs(app_id, deploy_id)?;
     let reader = std::io::BufReader::new(response);
 
@@ -716,7 +691,7 @@ pub(crate) fn stream_deploy_json(
     client: &FlooClient,
     app_id: &str,
     deploy_id: &str,
-) -> Result<serde_json::Value, FlooApiError> {
+) -> Result<Deploy, FlooApiError> {
     let response = client.stream_deploy_logs(app_id, deploy_id)?;
     let reader = std::io::BufReader::new(response);
 
@@ -783,27 +758,15 @@ pub(crate) fn stream_deploy_json(
 }
 
 /// Poll the deploy endpoint until it reaches a terminal status.
-pub(crate) fn poll_deploy(
-    client: &FlooClient,
-    app_id: &str,
-    initial_data: &serde_json::Value,
-) -> serde_json::Value {
-    let deploy_id = required_response_id(initial_data, "deploy").to_string();
+pub(crate) fn poll_deploy(client: &FlooClient, app_id: &str, initial_data: &Deploy) -> Deploy {
+    let deploy_id = initial_data.id.clone();
     let poll_start = Instant::now();
     let mut last_log_len: usize = 0;
     let mut deploy_data = initial_data.clone();
 
-    while !TERMINAL_STATUSES.contains(
-        &deploy_data
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or(""),
-    ) {
+    while !TERMINAL_STATUSES.contains(&deploy_data.status.as_deref().unwrap_or("")) {
         if !output::is_json_mode() {
-            let build_logs = deploy_data
-                .get("build_logs")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
             if build_logs.len() > last_log_len {
                 let new_logs = &build_logs[last_log_len..];
                 for line in new_logs.trim().lines() {
@@ -812,10 +775,7 @@ pub(crate) fn poll_deploy(
                 last_log_len = build_logs.len();
             }
 
-            let status = deploy_data
-                .get("status")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let status = deploy_data.status.as_deref().unwrap_or("");
             output::bold_line(status_label(status));
         }
 
@@ -844,10 +804,7 @@ pub(crate) fn poll_deploy(
 
     // Print any remaining build logs for the final state
     if !output::is_json_mode() {
-        let build_logs = deploy_data
-            .get("build_logs")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
         if build_logs.len() > last_log_len {
             let new_logs = &build_logs[last_log_len..];
             for line in new_logs.trim().lines() {
@@ -939,30 +896,19 @@ pub(crate) fn sync_env_vars_if_needed(
 
     // Get server-side services — silently return on API error (services may not exist on first deploy)
     let server_services = match client.list_services(app_id) {
-        Ok(r) => match r.get("services").and_then(|v| v.as_array()) {
-            Some(arr) => arr.clone(),
-            None => return,
-        },
+        Ok(r) => r.services,
         Err(_) => return,
     };
 
     for (svc_name, env_file_path) in &env_file_entries {
-        let server_svc = server_services
-            .iter()
-            .find(|s| s.get("name").and_then(|v| v.as_str()) == Some(svc_name));
+        let server_svc = server_services.iter().find(|s| s.name == *svc_name);
 
         let Some(svc) = server_svc else { continue };
-        let Some(svc_id) = svc.get("id").and_then(|v| v.as_str()) else {
-            continue;
-        };
+        let svc_id = &svc.id;
 
         // Check env var count on server
         let env_count = match client.list_env_vars(app_id, Some(svc_id)) {
-            Ok(r) => r
-                .get("env_vars")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.len())
-                .unwrap_or(0),
+            Ok(r) => r.env_vars.len(),
             Err(_) => continue,
         };
 

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -12,20 +12,7 @@ fn check_services_flag(client: &FlooClient, app_id: &str, services: Option<&str>
         }
     };
 
-    let service_list = result
-        .get("services")
-        .and_then(|v| v.as_array())
-        .unwrap_or_else(|| {
-            output::error(
-                "Failed to parse services from API response.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        })
-        .clone();
-
-    if service_list.len() > 1 && services.is_none() {
+    if result.services.len() > 1 && services.is_none() {
         output::error(
             "Multiple services found. Specify --services.",
             "MULTIPLE_SERVICES_NO_TARGET",
@@ -35,9 +22,7 @@ fn check_services_flag(client: &FlooClient, app_id: &str, services: Option<&str>
     }
 
     if let Some(svc_name) = services {
-        let exists = service_list
-            .iter()
-            .any(|s| s.get("name").and_then(|v| v.as_str()) == Some(svc_name));
+        let exists = result.services.iter().any(|s| s.name == svc_name);
         if !exists {
             output::error(
                 &format!("Service '{svc_name}' not found."),
@@ -65,15 +50,18 @@ pub fn add(hostname: &str, app: Option<&str>, services: Option<&str>) {
     };
 
     if output::is_json_mode() {
-        output::success(&format!("Added {hostname}"), Some(result));
+        output::success(
+            &format!("Added {hostname}"),
+            Some(output::to_value(&result)),
+        );
     } else {
         output::success(
             &format!("Added domain {hostname} to {app_name}."),
             Some(serde_json::Value::Null),
         );
-        let status = result.get("status").and_then(|v| v.as_str()).unwrap_or("-");
+        let status = result.status.as_deref().unwrap_or("-");
         output::info(&format!("  Status: {status}"), None);
-        if let Some(dns) = result.get("dns_instructions").and_then(|v| v.as_str()) {
+        if let Some(dns) = result.dns_instructions.as_deref() {
             output::info(&format!("  DNS:    {dns}"), None);
         }
     }
@@ -94,20 +82,7 @@ pub fn list(app: Option<&str>, services: Option<&str>) {
         }
     };
 
-    let domains = result
-        .get("domains")
-        .and_then(|v| v.as_array())
-        .unwrap_or_else(|| {
-            output::error(
-                "Failed to parse domains from API response.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        })
-        .clone();
-
-    if domains.is_empty() {
+    if result.domains.is_empty() {
         if !output::is_json_mode() {
             output::info(
                 &format!(
@@ -121,20 +96,15 @@ pub fn list(app: Option<&str>, services: Option<&str>) {
         return;
     }
 
-    let rows: Vec<Vec<String>> = domains
+    let rows: Vec<Vec<String>> = result
+        .domains
         .iter()
         .map(|d| {
             vec![
-                d.get("hostname")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                d.get("status")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                d.get("dns_instructions")
-                    .and_then(|v| v.as_str())
+                d.hostname.clone(),
+                d.status.as_deref().unwrap_or("-").to_string(),
+                d.dns_instructions
+                    .as_deref()
                     .unwrap_or("\u{2014}")
                     .to_string(),
             ]
@@ -144,7 +114,7 @@ pub fn list(app: Option<&str>, services: Option<&str>) {
     output::table(
         &["Domain", "Status", "DNS"],
         &rows,
-        Some(serde_json::json!({"domains": domains})),
+        Some(output::to_value(&result)),
     );
 }
 

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -37,32 +37,17 @@ fn resolve_service_ids(
         }
     };
 
-    let services = match result.get("services").and_then(|v| v.as_array()) {
-        Some(arr) => arr.clone(),
-        None => {
-            output::error(
-                "Response missing 'services' field.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        }
-    };
+    let services = &result.services;
 
     if service_names.is_empty() {
         match services.len() {
             0 => return vec![(None, None)],
             1 => {
                 let svc = &services[0];
-                let sid = super::expect_str_field(svc, "id").to_string();
-                let sname = super::expect_str_field(svc, "name").to_string();
-                return vec![(Some(sid), Some(sname))];
+                return vec![(Some(svc.id.clone()), Some(svc.name.clone()))];
             }
             _ => {
-                let names: Vec<String> = services
-                    .iter()
-                    .filter_map(|s| s.get("name").and_then(|v| v.as_str()).map(String::from))
-                    .collect();
+                let names: Vec<&str> = services.iter().map(|s| s.name.as_str()).collect();
                 output::error(
                     &format!(
                         "App '{app_name}' has multiple services. Specify which with --services."
@@ -78,19 +63,11 @@ fn resolve_service_ids(
     service_names
         .iter()
         .map(|name| {
-            let found = services
-                .iter()
-                .find(|s| s.get("name").and_then(|v| v.as_str()) == Some(name.as_str()));
+            let found = services.iter().find(|s| s.name == *name);
             match found {
-                Some(svc) => {
-                    let sid = super::expect_str_field(svc, "id").to_string();
-                    (Some(sid), Some(name.clone()))
-                }
+                Some(svc) => (Some(svc.id.clone()), Some(name.clone())),
                 None => {
-                    let available: Vec<String> = services
-                        .iter()
-                        .filter_map(|s| s.get("name").and_then(|v| v.as_str()).map(String::from))
-                        .collect();
+                    let available: Vec<&str> = services.iter().map(|s| s.name.as_str()).collect();
                     output::error(
                         &format!("Service '{name}' not found on app '{app_name}'."),
                         "SERVICE_NOT_FOUND",
@@ -230,9 +207,12 @@ pub fn set(key_value: &str, app_flag: Option<&str>, service_names: &[String], re
         match client.set_env_var(&app_id, &key, value, service_id.as_deref()) {
             Ok(result) => {
                 let target = format_target(&app_name, service_name.as_deref());
-                last_env_result = result.clone();
+                last_env_result = output::to_value(&result);
                 if !restart || !output::is_json_mode() {
-                    output::success(&format!("Set {key} on {target}."), Some(result));
+                    output::success(
+                        &format!("Set {key} on {target}."),
+                        Some(output::to_value(&result)),
+                    );
                 }
             }
             Err(e) => {
@@ -310,21 +290,9 @@ pub fn list(app_flag: Option<&str>, service_names: &[String]) {
             }
         };
 
-        let env_vars = match result.get("env_vars").and_then(|v| v.as_array()) {
-            Some(arr) => arr.clone(),
-            None => {
-                output::error(
-                    "Response missing 'env_vars' field.",
-                    "PARSE_ERROR",
-                    Some("This is a bug. Please report it."),
-                );
-                process::exit(1);
-            }
-        };
-
         let target = format_target(&app_name, service_name.as_deref());
 
-        if env_vars.is_empty() {
+        if result.env_vars.is_empty() {
             if output::is_json_mode() {
                 output::success("No env vars.", Some(serde_json::json!({"env_vars": []})));
             } else {
@@ -333,27 +301,18 @@ pub fn list(app_flag: Option<&str>, service_names: &[String]) {
             continue;
         }
 
-        let rows: Vec<Vec<String>> = env_vars
+        let rows: Vec<Vec<String>> = result
+            .env_vars
             .iter()
             .map(|ev| {
                 vec![
-                    ev.get("key")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("-")
-                        .to_string(),
-                    ev.get("masked_value")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("-")
-                        .to_string(),
+                    ev.key.clone(),
+                    ev.masked_value.as_deref().unwrap_or("-").to_string(),
                 ]
             })
             .collect();
 
-        output::table(
-            &["Key", "Value"],
-            &rows,
-            Some(serde_json::json!({"env_vars": env_vars})),
-        );
+        output::table(&["Key", "Value"], &rows, Some(output::to_value(&result)));
     }
 }
 
@@ -396,7 +355,14 @@ pub fn get(key: &str, app_flag: Option<&str>, service_flag: Option<&str>) {
         }
     };
 
-    let value = super::expect_str_field(&result, "value");
+    let value = result.value.as_deref().unwrap_or_else(|| {
+        output::error(
+            "Response missing 'value' field.",
+            "PARSE_ERROR",
+            Some("This is a bug. Please report it."),
+        );
+        process::exit(1);
+    });
 
     if output::is_json_mode() {
         output::success(
@@ -453,14 +419,8 @@ pub fn import_vars(file_flag: Option<&Path>, app_flag: Option<&str>, service_nam
     let client = super::init_client(None);
     let (app_id, app_name) = match &resolved {
         Some(r) => {
-            let app_data = super::resolve_app_or_exit(&client, &r.app_name);
-            let app_id = super::expect_str_field(&app_data, "id").to_string();
-            let app_name = app_data
-                .get("name")
-                .and_then(|v| v.as_str())
-                .unwrap_or(&r.app_name)
-                .to_string();
-            (app_id, app_name)
+            let app = super::resolve_app_or_exit(&client, &r.app_name);
+            (app.id.clone(), app.name.clone())
         }
         None => super::resolve_app_from_config(&client, app_flag),
     };
@@ -569,27 +529,13 @@ pub fn import_all_services(app_flag: Option<&str>) {
     }
 
     let client = super::init_client(None);
-    let app_data = super::resolve_app_or_exit(&client, &resolved.app_name);
-    let app_id = super::expect_str_field(&app_data, "id").to_string();
-    let app_name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name)
-        .to_string();
+    let app = super::resolve_app_or_exit(&client, &resolved.app_name);
+    let app_id = app.id.clone();
+    let app_name = app.name.clone();
 
     // Resolve all service IDs from server
     let server_services = match client.list_services(&app_id) {
-        Ok(r) => match r.get("services").and_then(|v| v.as_array()) {
-            Some(arr) => arr.clone(),
-            None => {
-                output::error(
-                    "Response missing 'services' field.",
-                    "PARSE_ERROR",
-                    Some("This is a bug. Please report it."),
-                );
-                process::exit(1);
-            }
-        },
+        Ok(r) => r.services,
         Err(e) => {
             output::error(&e.message, &e.code, None);
             process::exit(1);
@@ -604,11 +550,10 @@ pub fn import_all_services(app_flag: Option<&str>) {
         let count = vars.len();
 
         // Find service ID on server
-        let server_svc = server_services
+        let service_id = server_services
             .iter()
-            .find(|s| s.get("name").and_then(|v| v.as_str()) == Some(svc_name));
-
-        let service_id = server_svc.and_then(|s| s.get("id").and_then(|v| v.as_str()));
+            .find(|s| s.name == *svc_name)
+            .map(|s| s.id.as_str());
 
         match client.import_env_vars(&app_id, &vars, service_id) {
             Ok(result) => {

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use colored::Colorize;
 
+use crate::api_types::LogEntry;
 use crate::output;
 use crate::project_config::{self, AppSource};
 use crate::resolve::resolve_app;
@@ -19,14 +20,10 @@ struct LogsFilter<'a> {
     search: Option<&'a str>,
 }
 
-fn extract_field<'a>(entry: &'a serde_json::Value, key: &str) -> Option<&'a str> {
-    entry.get(key).and_then(|v| v.as_str())
-}
-
-fn format_log_line(entry: &serde_json::Value, show_service_prefix: bool) -> String {
-    let ts = extract_field(entry, "timestamp").unwrap_or("");
-    let sev = extract_field(entry, "severity").unwrap_or("DEFAULT");
-    let msg = extract_field(entry, "message").unwrap_or("");
+fn format_log_line(entry: &LogEntry, show_service_prefix: bool) -> String {
+    let ts = entry.timestamp.as_deref().unwrap_or("");
+    let sev = entry.severity.as_deref().unwrap_or("DEFAULT");
+    let msg = entry.message.as_deref().unwrap_or("");
     let colored_sev = match sev {
         "ERROR" | "CRITICAL" => sev.red().bold().to_string(),
         "WARNING" => sev.yellow().to_string(),
@@ -36,7 +33,7 @@ fn format_log_line(entry: &serde_json::Value, show_service_prefix: bool) -> Stri
     };
 
     if show_service_prefix {
-        let service = extract_field(entry, "service_name").unwrap_or("unknown");
+        let service = entry.service_name.as_deref().unwrap_or("unknown");
         let colored_service = format!("[{}]", service).blue().bold().to_string();
         format!("{colored_service} {ts} [{colored_sev}] {msg}")
     } else {
@@ -44,25 +41,27 @@ fn format_log_line(entry: &serde_json::Value, show_service_prefix: bool) -> Stri
     }
 }
 
-fn format_log_line_plain(entry: &serde_json::Value, show_service_prefix: bool) -> String {
-    let ts = extract_field(entry, "timestamp").unwrap_or("");
-    let sev = extract_field(entry, "severity").unwrap_or("DEFAULT");
-    let msg = extract_field(entry, "message").unwrap_or("");
+fn format_log_line_plain(entry: &LogEntry, show_service_prefix: bool) -> String {
+    let ts = entry.timestamp.as_deref().unwrap_or("");
+    let sev = entry.severity.as_deref().unwrap_or("DEFAULT");
+    let msg = entry.message.as_deref().unwrap_or("");
 
     if show_service_prefix {
-        let svc = extract_field(entry, "service_name").unwrap_or("unknown");
+        let svc = entry.service_name.as_deref().unwrap_or("unknown");
         format!("[{svc}] {ts} [{sev}] {msg}")
     } else {
         format!("{ts} [{sev}] {msg}")
     }
 }
 
-fn apply_search_filter(entries: Vec<serde_json::Value>, search: &str) -> Vec<serde_json::Value> {
+fn apply_search_filter(entries: Vec<LogEntry>, search: &str) -> Vec<LogEntry> {
     let needle = search.to_lowercase();
     entries
         .into_iter()
         .filter(|entry| {
-            extract_field(entry, "message")
+            entry
+                .message
+                .as_deref()
                 .map(|msg| msg.to_lowercase().contains(&needle))
                 .unwrap_or(false)
         })
@@ -74,7 +73,7 @@ fn fetch_logs(
     app_id: &str,
     tail: u32,
     filter: &LogsFilter,
-) -> Vec<serde_json::Value> {
+) -> Vec<LogEntry> {
     if filter.services.len() <= 1 {
         let service = filter.services.first().map(|s| s.as_str());
         let result = match client.get_logs(app_id, tail, filter.since, filter.severity, service) {
@@ -84,7 +83,7 @@ fn fetch_logs(
                 process::exit(1);
             }
         };
-        parse_logs_array(&result)
+        result.logs
     } else {
         let mut all_logs = Vec::new();
         for svc in filter.services {
@@ -100,11 +99,11 @@ fn fetch_logs(
                         process::exit(1);
                     }
                 };
-            all_logs.extend(parse_logs_array(&result));
+            all_logs.extend(result.logs);
         }
         all_logs.sort_by(|a, b| {
-            let ts_a = extract_field(a, "timestamp").unwrap_or("");
-            let ts_b = extract_field(b, "timestamp").unwrap_or("");
+            let ts_a = a.timestamp.as_deref().unwrap_or("");
+            let ts_b = b.timestamp.as_deref().unwrap_or("");
             ts_a.cmp(ts_b)
         });
         all_logs
@@ -116,37 +115,23 @@ fn try_fetch_logs(
     app_id: &str,
     tail: u32,
     filter: &LogsFilter,
-) -> Result<Vec<serde_json::Value>, crate::errors::FlooApiError> {
+) -> Result<Vec<LogEntry>, crate::errors::FlooApiError> {
     if filter.services.len() <= 1 {
         let service = filter.services.first().map(|s| s.as_str());
         let result = client.get_logs(app_id, tail, filter.since, filter.severity, service)?;
-        Ok(parse_logs_array(&result))
+        Ok(result.logs)
     } else {
         let mut all_logs = Vec::new();
         for svc in filter.services {
             let result = client.get_logs(app_id, tail, filter.since, filter.severity, Some(svc))?;
-            all_logs.extend(parse_logs_array(&result));
+            all_logs.extend(result.logs);
         }
         all_logs.sort_by(|a, b| {
-            let ts_a = extract_field(a, "timestamp").unwrap_or("");
-            let ts_b = extract_field(b, "timestamp").unwrap_or("");
+            let ts_a = a.timestamp.as_deref().unwrap_or("");
+            let ts_b = b.timestamp.as_deref().unwrap_or("");
             ts_a.cmp(ts_b)
         });
         Ok(all_logs)
-    }
-}
-
-fn parse_logs_array(result: &serde_json::Value) -> Vec<serde_json::Value> {
-    match result.get("logs").and_then(|v| v.as_array()) {
-        Some(arr) => arr.clone(),
-        None => {
-            output::error(
-                "Unexpected response format from the API.",
-                "PARSE_ERROR",
-                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | bash"),
-            );
-            process::exit(1);
-        }
     }
 }
 
@@ -188,8 +173,8 @@ fn source_label(source: &AppSource, config_dir: &Path) -> String {
     }
 }
 
-fn update_last_timestamp(last: &mut Option<String>, entry: &serde_json::Value) {
-    if let Some(ts) = extract_field(entry, "timestamp") {
+fn update_last_timestamp(last: &mut Option<String>, entry: &LogEntry) {
+    if let Some(ts) = entry.timestamp.as_deref() {
         let is_newer = match last.as_deref() {
             Some(prev) => ts > prev,
             None => true,
@@ -250,7 +235,7 @@ pub fn logs(
         }
     };
 
-    let app_id = super::expect_str_field(&app_data, "id");
+    let app_id = &app_data.id;
     let show_service_prefix = services.len() != 1;
 
     let filter = LogsFilter {
@@ -337,12 +322,7 @@ fn batch_logs(
     }
 }
 
-fn write_logs_to_file(
-    path: &Path,
-    logs: &[serde_json::Value],
-    app_name: &str,
-    show_service_prefix: bool,
-) {
+fn write_logs_to_file(path: &Path, logs: &[LogEntry], app_name: &str, show_service_prefix: bool) {
     let content = if output::is_json_mode() {
         let payload = serde_json::json!({
             "logs": logs,
@@ -412,7 +392,7 @@ fn live_logs(
 
     for entry in &logs {
         if is_json {
-            output::print_json(entry);
+            output::print_json(&output::to_value(entry));
         } else {
             output::dim_line(&format_log_line(entry, show_service_prefix));
         }
@@ -478,7 +458,9 @@ fn live_logs(
             Some(last_ts) => new_logs
                 .into_iter()
                 .filter(|entry| {
-                    extract_field(entry, "timestamp")
+                    entry
+                        .timestamp
+                        .as_deref()
                         .map(|ts| ts > last_ts.as_str())
                         .unwrap_or(false)
                 })
@@ -487,7 +469,7 @@ fn live_logs(
 
         for entry in &new_entries {
             if is_json {
-                output::print_json(entry);
+                output::print_json(&output::to_value(entry));
             } else {
                 output::dim_line(&format_log_line(entry, show_service_prefix));
             }
@@ -499,27 +481,44 @@ fn live_logs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+
+    fn make_log(ts: &str, sev: &str, msg: &str) -> LogEntry {
+        LogEntry {
+            timestamp: Some(ts.to_string()),
+            severity: Some(sev.to_string()),
+            message: Some(msg.to_string()),
+            service_name: None,
+        }
+    }
+
+    fn make_log_with_service(ts: &str, sev: &str, msg: &str, svc: &str) -> LogEntry {
+        LogEntry {
+            timestamp: Some(ts.to_string()),
+            severity: Some(sev.to_string()),
+            message: Some(msg.to_string()),
+            service_name: Some(svc.to_string()),
+        }
+    }
 
     #[test]
     fn test_apply_search_filter_matches_case_insensitive() {
         let entries = vec![
-            json!({"message": "Server started", "timestamp": "t1", "severity": "INFO"}),
-            json!({"message": "Error: connection failed", "timestamp": "t2", "severity": "ERROR"}),
-            json!({"message": "Request handled", "timestamp": "t3", "severity": "INFO"}),
+            make_log("t1", "INFO", "Server started"),
+            make_log("t2", "ERROR", "Error: connection failed"),
+            make_log("t3", "INFO", "Request handled"),
         ];
 
         let result = apply_search_filter(entries, "error");
         assert_eq!(result.len(), 1);
         assert_eq!(
-            result[0].get("message").unwrap().as_str().unwrap(),
+            result[0].message.as_deref().unwrap(),
             "Error: connection failed"
         );
     }
 
     #[test]
     fn test_apply_search_filter_empty_query_matches_all() {
-        let entries = vec![json!({"message": "Hello", "timestamp": "t1", "severity": "INFO"})];
+        let entries = vec![make_log("t1", "INFO", "Hello")];
 
         let result = apply_search_filter(entries, "");
         assert_eq!(result.len(), 1);
@@ -527,8 +526,7 @@ mod tests {
 
     #[test]
     fn test_apply_search_filter_no_match() {
-        let entries =
-            vec![json!({"message": "Hello world", "timestamp": "t1", "severity": "INFO"})];
+        let entries = vec![make_log("t1", "INFO", "Hello world")];
 
         let result = apply_search_filter(entries, "zzz_nonexistent");
         assert!(result.is_empty());
@@ -536,7 +534,12 @@ mod tests {
 
     #[test]
     fn test_apply_search_filter_missing_message_field() {
-        let entries = vec![json!({"timestamp": "t1", "severity": "INFO"})];
+        let entries = vec![LogEntry {
+            timestamp: Some("t1".to_string()),
+            severity: Some("INFO".to_string()),
+            message: None,
+            service_name: None,
+        }];
 
         let result = apply_search_filter(entries, "anything");
         assert!(result.is_empty());
@@ -544,12 +547,7 @@ mod tests {
 
     #[test]
     fn test_format_log_line_without_prefix() {
-        let entry = json!({
-            "timestamp": "2024-01-01T00:00:00Z",
-            "severity": "INFO",
-            "message": "Server started",
-            "service_name": "api"
-        });
+        let entry = make_log_with_service("2024-01-01T00:00:00Z", "INFO", "Server started", "api");
 
         let line = format_log_line(&entry, false);
         assert!(line.contains("2024-01-01T00:00:00Z"));
@@ -559,12 +557,7 @@ mod tests {
 
     #[test]
     fn test_format_log_line_with_prefix() {
-        let entry = json!({
-            "timestamp": "2024-01-01T00:00:00Z",
-            "severity": "INFO",
-            "message": "Server started",
-            "service_name": "api"
-        });
+        let entry = make_log_with_service("2024-01-01T00:00:00Z", "INFO", "Server started", "api");
 
         let line = format_log_line(&entry, true);
         assert!(line.contains("2024-01-01T00:00:00Z"));
@@ -574,11 +567,12 @@ mod tests {
 
     #[test]
     fn test_format_log_line_with_prefix_missing_service_name() {
-        let entry = json!({
-            "timestamp": "2024-01-01T00:00:00Z",
-            "severity": "ERROR",
-            "message": "something broke"
-        });
+        let entry = LogEntry {
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            severity: Some("ERROR".to_string()),
+            message: Some("something broke".to_string()),
+            service_name: None,
+        };
 
         let line = format_log_line(&entry, true);
         assert!(line.contains("[unknown]"));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 use std::process;
 
 use crate::api_client::FlooClient;
+use crate::api_types::App;
 use crate::config::{load_config, FlooConfig};
 use crate::output;
 
@@ -48,27 +49,7 @@ pub(crate) fn require_auth() {
     }
 }
 
-pub(crate) fn expect_str_field<'a>(data: &'a serde_json::Value, field: &str) -> &'a str {
-    let value = data.get(field).and_then(|v| v.as_str()).unwrap_or_else(|| {
-        output::error(
-            &format!("Response missing '{field}' field."),
-            "PARSE_ERROR",
-            Some("This is a bug. Please report it."),
-        );
-        process::exit(1);
-    });
-    if value.is_empty() {
-        output::error(
-            &format!("Response field '{field}' is empty."),
-            "PARSE_ERROR",
-            Some("This may indicate a CLI/API version mismatch. Try `floo update`."),
-        );
-        process::exit(1);
-    }
-    value
-}
-
-pub(crate) fn resolve_app_or_exit(client: &FlooClient, app_name: &str) -> serde_json::Value {
+pub(crate) fn resolve_app_or_exit(client: &FlooClient, app_name: &str) -> App {
     match crate::resolve::resolve_app(client, app_name) {
         Ok(a) => a,
         Err(e) => {
@@ -105,14 +86,8 @@ pub(crate) fn resolve_app_from_config(
             process::exit(1);
         }
     };
-    let app_data = resolve_app_or_exit(client, &resolved.app_name);
-    let app_id = expect_str_field(&app_data, "id").to_string();
-    let app_name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(&resolved.app_name)
-        .to_string();
-    (app_id, app_name)
+    let app = resolve_app_or_exit(client, &resolved.app_name);
+    (app.id.clone(), app.name.clone())
 }
 
 /// Detect the deploy env file in a directory: prefers .floo.env, falls back to .env.

--- a/src/commands/orgs.rs
+++ b/src/commands/orgs.rs
@@ -13,9 +13,8 @@ pub fn list_members() {
             process::exit(1);
         }
     };
-    let org_id = super::expect_str_field(&org, "id");
 
-    let result = match client.list_members(org_id) {
+    let result = match client.list_members(&org.id) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, None);
@@ -23,44 +22,22 @@ pub fn list_members() {
         }
     };
 
-    let members = result
-        .get("members")
-        .and_then(|v| v.as_array())
-        .unwrap_or_else(|| {
-            output::error(
-                "Failed to parse members from API response.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        });
-
-    if members.is_empty() {
+    if result.members.is_empty() {
         output::info("No members found.", None);
         return;
     }
 
-    let rows: Vec<Vec<String>> = members
+    let rows: Vec<Vec<String>> = result
+        .members
         .iter()
-        .map(|m| {
-            vec![
-                m.get("user_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                m.get("email")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                m.get("role")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-            ]
-        })
+        .map(|m| vec![m.user_id.clone(), m.email.clone(), m.role.clone()])
         .collect();
 
-    output::table(&["USER ID", "EMAIL", "ROLE"], &rows, Some(result));
+    output::table(
+        &["USER ID", "EMAIL", "ROLE"],
+        &rows,
+        Some(output::to_value(&result)),
+    );
 }
 
 pub fn set_role(user_id: &str, role: &str) {
@@ -84,18 +61,12 @@ pub fn set_role(user_id: &str, role: &str) {
             process::exit(1);
         }
     };
-    let org_id = super::expect_str_field(&org, "id");
 
-    match client.update_member_role(org_id, user_id, role) {
+    match client.update_member_role(&org.id, user_id, role) {
         Ok(result) => {
-            let email = result
-                .get("email")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            let new_role = result.get("role").and_then(|v| v.as_str()).unwrap_or(role);
             output::success(
-                &format!("Updated {email} to role '{new_role}'."),
-                Some(result),
+                &format!("Updated {} to role '{}'.", result.email, result.role),
+                Some(output::to_value(&result)),
             );
         }
         Err(e) => {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -28,13 +28,13 @@ pub fn promote(app: Option<&str>, tag: Option<&str>) {
         }
     };
 
-    let result_tag = super::expect_str_field(&result, "tag");
-    let release_url = super::expect_str_field(&result, "release_url");
+    let result_tag = &result.tag;
+    let release_url = &result.release_url;
 
     if output::is_json_mode() {
         output::success(
             &format!("Promoted {name} \u{2192} prod ({result_tag})"),
-            Some(result),
+            Some(output::to_value(&result)),
         );
     } else {
         output::success(
@@ -67,20 +67,7 @@ pub fn list(app: Option<&str>) {
         }
     };
 
-    let releases = result
-        .get("releases")
-        .and_then(|v| v.as_array())
-        .unwrap_or_else(|| {
-            output::error(
-                "Failed to parse releases from API response.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        })
-        .clone();
-
-    if releases.is_empty() {
+    if result.releases.is_empty() {
         if output::is_json_mode() {
             output::success("No releases.", Some(serde_json::json!({"releases": []})));
         } else {
@@ -89,33 +76,24 @@ pub fn list(app: Option<&str>) {
         return;
     }
 
-    let rows: Vec<Vec<String>> = releases
+    let rows: Vec<Vec<String>> = result
+        .releases
         .iter()
         .map(|r| {
-            let sha = r.get("commit_sha").and_then(|v| v.as_str()).unwrap_or("-");
+            let sha = r.commit_sha.as_deref().unwrap_or("-");
             let short_sha = if sha.len() > 7 && sha.is_ascii() {
                 &sha[..7]
             } else {
                 sha
             };
             vec![
-                r.get("release_number")
-                    .and_then(|v| v.as_u64())
+                r.release_number
                     .map(|n| format!("#{n}"))
                     .unwrap_or_else(|| "-".to_string()),
-                r.get("tag")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
+                r.tag.as_deref().unwrap_or("-").to_string(),
                 short_sha.to_string(),
-                r.get("promoted_by")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                r.get("created_at")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
+                r.promoted_by.as_deref().unwrap_or("-").to_string(),
+                r.created_at.as_deref().unwrap_or("-").to_string(),
             ]
         })
         .collect();
@@ -123,7 +101,7 @@ pub fn list(app: Option<&str>) {
     output::table(
         &["#", "Tag", "Commit", "Promoted By", "Created"],
         &rows,
-        Some(result),
+        Some(output::to_value(&result)),
     );
 }
 
@@ -151,38 +129,19 @@ pub fn show(release_id: &str, app: Option<&str>) {
     };
 
     if output::is_json_mode() {
-        let tag = release
-            .get("tag")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        output::success(&format!("Release {tag}"), Some(release));
+        let tag = release.tag.as_deref().unwrap_or("unknown");
+        output::success(&format!("Release {tag}"), Some(output::to_value(&release)));
     } else {
-        let tag = release.get("tag").and_then(|v| v.as_str()).unwrap_or("-");
+        let tag = release.tag.as_deref().unwrap_or("-");
         let number = release
-            .get("release_number")
-            .and_then(|v| v.as_u64())
+            .release_number
             .map(|n| format!("#{n}"))
             .unwrap_or_else(|| "-".to_string());
-        let sha = release
-            .get("commit_sha")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let promoted_by = release
-            .get("promoted_by")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let created = release
-            .get("created_at")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let deploy_id = release
-            .get("deploy_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let image = release
-            .get("image_digest")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
+        let sha = release.commit_sha.as_deref().unwrap_or("-");
+        let promoted_by = release.promoted_by.as_deref().unwrap_or("-");
+        let created = release.created_at.as_deref().unwrap_or("-");
+        let deploy_id = release.deploy_id.as_deref().unwrap_or("-");
+        let image = release.image_digest.as_deref().unwrap_or("-");
 
         output::info(&format!("Release {tag} ({number})"), None);
         output::info(&format!("  Tag:         {tag}"), None);

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -17,19 +17,7 @@ pub fn list(app: Option<&str>) {
         }
     };
 
-    let deploys = match result.get("deploys").and_then(|v| v.as_array()) {
-        Some(arr) => arr.clone(),
-        None => {
-            output::error(
-                "Unexpected response format from the API.",
-                "PARSE_ERROR",
-                Some("Try updating the CLI: curl -fsSL https://getfloo.com/install.sh | bash"),
-            );
-            process::exit(1);
-        }
-    };
-
-    if deploys.is_empty() {
+    if result.deploys.is_empty() {
         if output::is_json_mode() {
             output::success(
                 "No deploys found.",
@@ -41,26 +29,15 @@ pub fn list(app: Option<&str>) {
         return;
     }
 
-    let rows: Vec<Vec<String>> = deploys
+    let rows: Vec<Vec<String>> = result
+        .deploys
         .iter()
         .map(|d| {
             vec![
-                d.get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                d.get("status")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
-                d.get("runtime")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("\u{2014}")
-                    .to_string(),
-                d.get("created_at")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
+                d.id.clone(),
+                d.status.as_deref().unwrap_or("-").to_string(),
+                d.runtime.as_deref().unwrap_or("\u{2014}").to_string(),
+                d.created_at.as_deref().unwrap_or("-").to_string(),
             ]
         })
         .collect();
@@ -68,7 +45,7 @@ pub fn list(app: Option<&str>) {
     output::table(
         &["Deploy ID", "Status", "Runtime", "Created"],
         &rows,
-        Some(serde_json::json!({"deploys": deploys})),
+        Some(output::to_value(&result)),
     );
 }
 
@@ -77,11 +54,8 @@ pub fn rollback(app_name: &str, deploy_id: &str, force: bool) {
     let client = super::init_client(None);
 
     let app_data = super::resolve_app_or_exit(&client, app_name);
-    let name = app_data
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or(app_name);
-    let app_id = super::expect_str_field(&app_data, "id");
+    let name = &app_data.name;
+    let app_id = &app_data.id;
 
     if !force
         && !output::confirm(&format!(

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -18,20 +18,7 @@ pub fn list(app: Option<&str>) {
         }
     };
 
-    let services = result
-        .get("services")
-        .and_then(|v| v.as_array())
-        .unwrap_or_else(|| {
-            output::error(
-                "Failed to parse services from API response.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        })
-        .clone();
-
-    if services.is_empty() {
+    if result.services.is_empty() {
         if output::is_json_mode() {
             output::success(
                 &format!("No services on {app_name}."),
@@ -43,17 +30,15 @@ pub fn list(app: Option<&str>) {
         return;
     }
 
-    let rows: Vec<Vec<String>> = services
+    let rows: Vec<Vec<String>> = result
+        .services
         .iter()
         .map(|s| {
             vec![
-                super::expect_str_field(s, "name").to_string(),
-                super::expect_str_field(s, "type").to_string(),
-                super::expect_str_field(s, "status").to_string(),
-                s.get("cloud_run_url")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string(),
+                s.name.clone(),
+                s.service_type.as_deref().unwrap_or("-").to_string(),
+                s.status.as_deref().unwrap_or("-").to_string(),
+                s.cloud_run_url.as_deref().unwrap_or("-").to_string(),
             ]
         })
         .collect();
@@ -61,7 +46,7 @@ pub fn list(app: Option<&str>) {
     output::table(
         &["Name", "Type", "Status", "URL"],
         &rows,
-        Some(serde_json::json!({"services": services})),
+        Some(output::to_value(&result)),
     );
 }
 
@@ -73,7 +58,7 @@ pub fn info(service_name: &str, app: Option<&str>) {
     let app_id = app_id.as_str();
     let app_name = app_name.as_str();
 
-    let services_result = match client.list_services(app_id) {
+    let result = match client.list_services(app_id) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, None);
@@ -81,43 +66,24 @@ pub fn info(service_name: &str, app: Option<&str>) {
         }
     };
 
-    let services = services_result
-        .get("services")
-        .and_then(|v| v.as_array())
-        .unwrap_or_else(|| {
-            output::error(
-                "Failed to parse services from API response.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        })
-        .clone();
-
     // Check if any user-managed service matches the given name
-    let matched = services
-        .iter()
-        .find(|s| s.get("name").and_then(|v| v.as_str()) == Some(service_name));
+    let matched = result.services.iter().find(|s| s.name == service_name);
 
     if let Some(svc) = matched {
         // User-managed service found — display its details
         if output::is_json_mode() {
             output::success(
                 &format!("Service {service_name} on {app_name}"),
-                Some(svc.clone()),
+                Some(output::to_value(svc)),
             );
             return;
         }
 
-        let svc_type = svc.get("type").and_then(|v| v.as_str()).unwrap_or("-");
-        let status = svc.get("status").and_then(|v| v.as_str()).unwrap_or("-");
-        let url = svc
-            .get("cloud_run_url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
+        let svc_type = svc.service_type.as_deref().unwrap_or("-");
+        let status = svc.status.as_deref().unwrap_or("-");
+        let url = svc.cloud_run_url.as_deref().unwrap_or("-");
         let port = svc
-            .get("port")
-            .and_then(|v| v.as_u64())
+            .port
             .map(|p| p.to_string())
             .unwrap_or_else(|| "-".to_string());
 
@@ -131,11 +97,8 @@ pub fn info(service_name: &str, app: Option<&str>) {
 
     // No user-managed service found with that name.
     // If the app has user-managed services, the name is simply wrong.
-    if !services.is_empty() {
-        let names: Vec<&str> = services
-            .iter()
-            .filter_map(|s| s.get("name").and_then(|v| v.as_str()))
-            .collect();
+    if !result.services.is_empty() {
+        let names: Vec<&str> = result.services.iter().map(|s| s.name.as_str()).collect();
         let suggestion = format!(
             "Available services: {}. Run 'floo services list' for details.",
             names.join(", ")
@@ -168,36 +131,25 @@ pub fn info(service_name: &str, app: Option<&str>) {
     if output::is_json_mode() {
         output::success(
             &format!("Service {service_name} on {app_name}"),
-            Some(db_data),
+            Some(output::to_value(&db_data)),
         );
         return;
     }
 
-    let host = super::expect_str_field(&db_data, "host");
-    let port = db_data
-        .get("port")
-        .and_then(|v| v.as_u64())
-        .map(|p| p.to_string())
-        .unwrap_or_else(|| {
-            output::error(
-                "Response missing 'port' field.",
-                "PARSE_ERROR",
-                Some("This is a bug. Please report it."),
-            );
-            process::exit(1);
-        });
-    let database = super::expect_str_field(&db_data, "database");
-    let status = super::expect_str_field(&db_data, "status");
+    let host = &db_data.host;
+    let port = db_data.port.to_string();
+    let database = &db_data.database;
+    let status = db_data.status.as_deref().unwrap_or("-");
 
     output::info(&format!("Service {service_name} ({app_name}):"), None);
     output::info(&format!("  Host:     {host}"), None);
     output::info(&format!("  Port:     {port}"), None);
     output::info(&format!("  Database: {database}"), None);
     output::info(&format!("  Status:   {status}"), None);
-    if let Some(username) = db_data.get("username").and_then(|v| v.as_str()) {
+    if let Some(username) = db_data.username.as_deref() {
         output::info(&format!("  Username: {username}"), None);
     }
-    if let Some(schema) = db_data.get("schema_name").and_then(|v| v.as_str()) {
+    if let Some(schema) = db_data.schema_name.as_deref() {
         output::info(&format!("  Schema:   {schema}"), None);
     }
     output::info("", None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod api_client;
+mod api_types;
 mod archive;
 mod cli;
 mod commands;

--- a/src/output.rs
+++ b/src/output.rs
@@ -192,7 +192,6 @@ pub fn bold_line(line: &str) {
 }
 
 /// Helper to serialize any Serialize type to a Value.
-#[allow(dead_code)]
 pub fn to_value<T: Serialize>(val: &T) -> Value {
     serde_json::to_value(val).unwrap_or(Value::Null)
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,19 +1,18 @@
-use serde_json::Value;
-
 use crate::api_client::FlooClient;
+use crate::api_types::{App, ListAppsResponse};
 use crate::errors::FlooApiError;
 
 trait AppResolverClient {
-    fn get_app(&self, app_id: &str) -> Result<Value, FlooApiError>;
-    fn list_apps(&self, page: u32, per_page: u32) -> Result<Value, FlooApiError>;
+    fn get_app(&self, app_id: &str) -> Result<App, FlooApiError>;
+    fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError>;
 }
 
 impl AppResolverClient for FlooClient {
-    fn get_app(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    fn get_app(&self, app_id: &str) -> Result<App, FlooApiError> {
         FlooClient::get_app(self, app_id)
     }
 
-    fn list_apps(&self, page: u32, per_page: u32) -> Result<Value, FlooApiError> {
+    fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError> {
         FlooClient::list_apps(self, page, per_page)
     }
 }
@@ -42,22 +41,11 @@ fn is_uuid_identifier(identifier: &str) -> bool {
 }
 
 fn match_app_from_list_response(
-    list_response: &Value,
+    list_response: &ListAppsResponse,
     identifier: &str,
-) -> Result<Value, FlooApiError> {
-    let apps = list_response
-        .get("apps")
-        .and_then(|value| value.as_array())
-        .ok_or_else(|| {
-            FlooApiError::new(
-                500,
-                "PARSE_ERROR",
-                "Failed to parse app list response from API.",
-            )
-        })?;
-
-    for app in apps {
-        if app.get("name").and_then(|value| value.as_str()) == Some(identifier) {
+) -> Result<App, FlooApiError> {
+    for app in &list_response.apps {
+        if app.name == identifier {
             return Ok(app.clone());
         }
     }
@@ -68,7 +56,7 @@ fn match_app_from_list_response(
 fn resolve_app_with_client<C: AppResolverClient>(
     client: &C,
     identifier: &str,
-) -> Result<Value, FlooApiError> {
+) -> Result<App, FlooApiError> {
     // Only hit the /apps/{id} endpoint for UUID identifiers.
     if is_uuid_identifier(identifier) {
         return client.get_app(identifier);
@@ -79,7 +67,7 @@ fn resolve_app_with_client<C: AppResolverClient>(
     match_app_from_list_response(&response, identifier)
 }
 
-pub fn resolve_app(client: &FlooClient, identifier: &str) -> Result<Value, FlooApiError> {
+pub fn resolve_app(client: &FlooClient, identifier: &str) -> Result<App, FlooApiError> {
     resolve_app_with_client(client, identifier)
 }
 
@@ -87,21 +75,19 @@ pub fn resolve_app(client: &FlooClient, identifier: &str) -> Result<Value, FlooA
 mod tests {
     use std::cell::{Cell, RefCell};
 
-    use serde_json::json;
-
     use super::*;
 
     struct FakeClient {
-        app_lookup_result: Result<Value, (u16, String, String)>,
-        list_lookup_result: Result<Value, (u16, String, String)>,
+        app_lookup_result: Result<App, (u16, String, String)>,
+        list_lookup_result: Result<ListAppsResponse, (u16, String, String)>,
         app_lookup_calls: RefCell<Vec<String>>,
         list_lookup_calls: Cell<u32>,
     }
 
     impl FakeClient {
         fn new(
-            app_lookup_result: Result<Value, (u16, String, String)>,
-            list_lookup_result: Result<Value, (u16, String, String)>,
+            app_lookup_result: Result<App, (u16, String, String)>,
+            list_lookup_result: Result<ListAppsResponse, (u16, String, String)>,
         ) -> Self {
             Self {
                 app_lookup_result,
@@ -111,24 +97,36 @@ mod tests {
             }
         }
 
-        fn ok_app(app: Value) -> Result<Value, (u16, String, String)> {
+        fn ok_app(app: App) -> Result<App, (u16, String, String)> {
             Ok(app)
         }
 
-        fn err(
+        fn ok_list(response: ListAppsResponse) -> Result<ListAppsResponse, (u16, String, String)> {
+            Ok(response)
+        }
+
+        fn err_app(
             status_code: u16,
             code: &str,
             message: &str,
-        ) -> Result<Value, (u16, String, String)> {
+        ) -> Result<App, (u16, String, String)> {
+            Err((status_code, code.to_string(), message.to_string()))
+        }
+
+        fn err_list(
+            status_code: u16,
+            code: &str,
+            message: &str,
+        ) -> Result<ListAppsResponse, (u16, String, String)> {
             Err((status_code, code.to_string(), message.to_string()))
         }
     }
 
     impl AppResolverClient for FakeClient {
-        fn get_app(&self, app_id: &str) -> Result<Value, FlooApiError> {
+        fn get_app(&self, app_id: &str) -> Result<App, FlooApiError> {
             self.app_lookup_calls.borrow_mut().push(app_id.to_string());
             match &self.app_lookup_result {
-                Ok(value) => Ok(value.clone()),
+                Ok(app) => Ok(app.clone()),
                 Err((status_code, code, message)) => Err(FlooApiError::new(
                     *status_code,
                     code.clone(),
@@ -137,10 +135,10 @@ mod tests {
             }
         }
 
-        fn list_apps(&self, _page: u32, _per_page: u32) -> Result<Value, FlooApiError> {
+        fn list_apps(&self, _page: u32, _per_page: u32) -> Result<ListAppsResponse, FlooApiError> {
             self.list_lookup_calls.set(self.list_lookup_calls.get() + 1);
             match &self.list_lookup_result {
-                Ok(value) => Ok(value.clone()),
+                Ok(response) => Ok(response.clone()),
                 Err((status_code, code, message)) => Err(FlooApiError::new(
                     *status_code,
                     code.clone(),
@@ -150,13 +148,29 @@ mod tests {
         }
     }
 
+    fn make_app(id: &str, name: &str) -> App {
+        App {
+            id: id.to_string(),
+            name: name.to_string(),
+            status: None,
+            url: None,
+            runtime: None,
+            created_at: None,
+        }
+    }
+
+    fn make_list(apps: Vec<App>) -> ListAppsResponse {
+        ListAppsResponse { apps, total: None }
+    }
+
     #[test]
     fn non_uuid_identifier_skips_id_endpoint_lookup() {
         let client = FakeClient::new(
-            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
-            FakeClient::ok_app(
-                json!({"apps":[{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"my-app"}]}),
-            ),
+            FakeClient::err_app(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_list(make_list(vec![make_app(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "my-app",
+            )])),
         );
 
         let resolved = resolve_app_with_client(&client, "my-app");
@@ -170,10 +184,11 @@ mod tests {
     fn uuid_identifier_uses_id_endpoint_first() {
         let app_id = "11111111-1111-1111-1111-111111111111";
         let client = FakeClient::new(
-            FakeClient::ok_app(json!({"id":app_id,"name":"uuid-app"})),
-            FakeClient::ok_app(
-                json!({"apps":[{"id":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","name":"fallback-app"}]}),
-            ),
+            FakeClient::ok_app(make_app(app_id, "uuid-app")),
+            FakeClient::ok_list(make_list(vec![make_app(
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "fallback-app",
+            )])),
         );
 
         let resolved = resolve_app_with_client(&client, app_id);
@@ -190,8 +205,8 @@ mod tests {
     fn uuid_identifier_does_not_fall_back_when_id_lookup_fails() {
         let identifier = "22222222-2222-2222-2222-222222222222";
         let client = FakeClient::new(
-            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
-            FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":identifier}]})),
+            FakeClient::err_app(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_list(make_list(vec![make_app(identifier, identifier)])),
         );
 
         let error = resolve_app_with_client(&client, identifier).unwrap_err();
@@ -209,8 +224,8 @@ mod tests {
     fn uuid_identifier_propagates_non_404_lookup_errors() {
         let identifier = "33333333-3333-3333-3333-333333333333";
         let client = FakeClient::new(
-            FakeClient::err(500, "INTERNAL_ERROR", "Server error"),
-            FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":identifier}]})),
+            FakeClient::err_app(500, "INTERNAL_ERROR", "Server error"),
+            FakeClient::ok_list(make_list(vec![make_app(identifier, identifier)])),
         );
 
         let error = resolve_app_with_client(&client, identifier).unwrap_err();
@@ -224,8 +239,8 @@ mod tests {
     fn uuid_identifier_propagates_validation_errors_without_fallback() {
         let identifier = "44444444-4444-4444-4444-444444444444";
         let client = FakeClient::new(
-            FakeClient::err(422, "VALIDATION_ERROR", "Invalid UUID"),
-            FakeClient::ok_app(json!({"apps":[{"id":identifier,"name":"uuid-app"}]})),
+            FakeClient::err_app(422, "VALIDATION_ERROR", "Invalid UUID"),
+            FakeClient::ok_list(make_list(vec![make_app(identifier, "uuid-app")])),
         );
 
         let error = resolve_app_with_client(&client, identifier).unwrap_err();
@@ -238,8 +253,8 @@ mod tests {
     #[test]
     fn non_uuid_identifier_propagates_list_errors() {
         let client = FakeClient::new(
-            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
-            FakeClient::err(401, "UNAUTHORIZED", "Unauthorized"),
+            FakeClient::err_app(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::err_list(401, "UNAUTHORIZED", "Unauthorized"),
         );
 
         let error = resolve_app_with_client(&client, "my-app").unwrap_err();
@@ -251,26 +266,13 @@ mod tests {
     #[test]
     fn returns_app_not_found_when_name_lookup_misses() {
         let client = FakeClient::new(
-            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
-            FakeClient::ok_app(json!({"apps":[{"id":"id-1","name":"other-app"}]})),
+            FakeClient::err_app(404, "APP_NOT_FOUND", "App not found."),
+            FakeClient::ok_list(make_list(vec![make_app("id-1", "other-app")])),
         );
 
         let error = resolve_app_with_client(&client, "my-app").unwrap_err();
 
         assert_eq!(error.status_code, 404);
         assert_eq!(error.code, "APP_NOT_FOUND");
-    }
-
-    #[test]
-    fn returns_parse_error_when_list_response_is_malformed() {
-        let client = FakeClient::new(
-            FakeClient::err(404, "APP_NOT_FOUND", "App not found."),
-            FakeClient::ok_app(json!({"unexpected":"payload"})),
-        );
-
-        let error = resolve_app_with_client(&client, "my-app").unwrap_err();
-
-        assert_eq!(error.status_code, 500);
-        assert_eq!(error.code, "PARSE_ERROR");
     }
 }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -99,7 +99,7 @@ fn mock_services_single(server: &mut Server) -> Mock {
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"services":[{"name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000}]}"#)
+        .with_body(r#"{"services":[{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000}]}"#)
         .create()
 }
 
@@ -116,7 +116,7 @@ fn mock_services_multi(server: &mut Server) -> Mock {
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"services":[{"name":"api","type":"api","status":"live","cloud_run_url":"https://api.floo.app","port":8000},{"name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000}]}"#)
+        .with_body(r#"{"services":[{"id":"svc-api-1","name":"api","type":"api","status":"live","cloud_run_url":"https://api.floo.app","port":8000},{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000}]}"#)
         .create()
 }
 
@@ -1295,8 +1295,8 @@ fn test_deploy_fails_with_invalid_response_when_app_id_missing() {
         .env("HOME", home.path())
         .assert()
         .failure()
-        .stdout(predicate::str::contains(r#""code":"INVALID_RESPONSE""#))
-        .stdout(predicate::str::contains("missing required 'id'"));
+        .stdout(predicate::str::contains(r#""code":"PARSE_ERROR""#))
+        .stdout(predicate::str::contains("Failed to parse response"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `src/api_types.rs` with 30+ typed response structs (`App`, `Deploy`, `LogEntry`, `Release`, `AnalyticsSummary`, etc.) — all `#[derive(Serialize, Deserialize)]` with `Option<T>` for nullable fields
- Make `handle_response<T: DeserializeOwned>` generic in `api_client.rs`, updating all method return types from `Result<Value>` to typed equivalents
- Update all 12 command files to use direct field access (`app.name`, `deploy.status.as_deref()`) instead of `.get("field").and_then(|v| v.as_str()).unwrap_or("-")` chains
- Remove `expect_str_field`, `extract_field`, `required_response_id`, and 4 analytics helper functions — no longer needed with typed fields
- Net reduction of ~480 lines across the codebase

## Test plan

- [x] `cargo test` — 250/250 pass (unit + integration + mock API)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Mock API test fixtures updated for typed struct shapes
- [ ] Smoke test: `cargo run -- apps list --json 2>/dev/null | python3 -m json.tool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)