### PR TITLE
[Feature] [#259] Private networking — worker default ingress and CLI display

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -289,6 +289,6 @@ fn validate_service(
         "path": path,
         "port": service.port,
         "type": service.service_type.to_string(),
-        "ingress": service.ingress.to_string(),
+        "ingress": service.resolved_ingress().to_string(),
     }));
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -265,7 +265,7 @@ pub fn deploy(
                         svc.service.name,
                         svc.service.service_type,
                         svc.service.port,
-                        svc.service.ingress
+                        svc.service.resolved_ingress()
                     ),
                     None,
                 );
@@ -604,7 +604,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
             name: service.name.clone(),
             service_type: service.service_type,
             port: service.port,
-            ingress: service.ingress,
+            ingress: Some(service.ingress),
             env_file,
         },
     };

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -88,7 +88,7 @@ fn init_non_interactive(
             name: service_name.clone(),
             service_type,
             port,
-            ingress: ServiceIngress::Public,
+            ingress: Some(ServiceIngress::Public),
             env_file,
         },
     };
@@ -223,6 +223,7 @@ fn init_interactive(
                         repo: None,
                         version: None,
                         plan: None,
+                        ingress: None,
                     },
                 );
             }
@@ -238,7 +239,7 @@ fn init_interactive(
                         name: svc_name.clone(),
                         service_type,
                         port,
-                        ingress: ServiceIngress::Public,
+                        ingress: Some(ServiceIngress::Public),
                         env_file: env_file.clone(),
                     },
                 });
@@ -255,7 +256,7 @@ fn init_interactive(
                             name: svc_name.clone(),
                             service_type,
                             port,
-                            ingress: ServiceIngress::Public,
+                            ingress: Some(ServiceIngress::Public),
                             env_file: env_file.clone(),
                         },
                     };
@@ -291,7 +292,7 @@ fn init_interactive(
                 name: default_type.to_string(),
                 service_type,
                 port: detection.default_port(),
-                ingress: ServiceIngress::Public,
+                ingress: Some(ServiceIngress::Public),
                 env_file,
             },
         });

--- a/src/commands/service_mgmt.rs
+++ b/src/commands/service_mgmt.rs
@@ -171,6 +171,7 @@ pub fn add(
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
     }
@@ -203,7 +204,7 @@ pub fn add(
             name: name.to_string(),
             service_type: svc_type,
             port: resolved_port,
-            ingress: svc_ingress,
+            ingress: Some(svc_ingress),
             env_file: env_file_val.clone(),
         },
     };

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -87,6 +87,10 @@ pub fn list(app: Option<&str>) {
                 super::expect_str_field(s, "name").to_string(),
                 super::expect_str_field(s, "type").to_string(),
                 super::expect_str_field(s, "status").to_string(),
+                s.get("ingress")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string(),
                 s.get("cloud_run_url")
                     .and_then(|v| v.as_str())
                     .unwrap_or("-")
@@ -96,7 +100,7 @@ pub fn list(app: Option<&str>) {
         .collect();
 
     output::table(
-        &["Name", "Type", "Status", "URL"],
+        &["Name", "Type", "Status", "Ingress", "URL"],
         &rows,
         Some(serde_json::json!({"services": services})),
     );
@@ -182,6 +186,7 @@ pub fn info(service_name: &str, app: Option<&str>) {
 
         let svc_type = svc.get("type").and_then(|v| v.as_str()).unwrap_or("-");
         let status = svc.get("status").and_then(|v| v.as_str()).unwrap_or("-");
+        let ingress = svc.get("ingress").and_then(|v| v.as_str()).unwrap_or("-");
         let url = svc
             .get("cloud_run_url")
             .and_then(|v| v.as_str())
@@ -193,10 +198,11 @@ pub fn info(service_name: &str, app: Option<&str>) {
             .unwrap_or_else(|| "-".to_string());
 
         output::info(&format!("Service {service_name} ({app_name}):"), None);
-        output::info(&format!("  Type:   {svc_type}"), None);
-        output::info(&format!("  Status: {status}"), None);
-        output::info(&format!("  URL:    {url}"), None);
-        output::info(&format!("  Port:   {port}"), None);
+        output::info(&format!("  Type:    {svc_type}"), None);
+        output::info(&format!("  Status:  {status}"), None);
+        output::info(&format!("  Ingress: {ingress}"), None);
+        output::info(&format!("  URL:     {url}"), None);
+        output::info(&format!("  Port:    {port}"), None);
         return;
     }
 

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::FlooError;
 
+use super::service_config::ServiceIngress;
 use super::SCHEMA_URL;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -54,6 +55,8 @@ pub struct AppServiceEntry {
     pub version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ingress: Option<ServiceIngress>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -400,6 +403,37 @@ name = "my-app"
 
         let config = load_app_config(dir.path()).unwrap().unwrap();
         assert!(config.app.access_mode.is_none());
+    }
+
+    #[test]
+    fn test_load_app_config_with_service_ingress() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.worker]
+type = "worker"
+path = "./worker"
+ingress = "internal"
+
+[services.api]
+type = "api"
+path = "./backend"
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        let worker = &config.services["worker"];
+        assert_eq!(
+            worker.ingress,
+            Some(super::super::service_config::ServiceIngress::Internal)
+        );
+        let api = &config.services["api"];
+        assert!(api.ingress.is_none());
     }
 
     #[test]

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -4,7 +4,7 @@ use crate::errors::FlooError;
 
 use super::app_config::AppServiceType;
 use super::resolve::ResolvedApp;
-use super::service_config::{load_service_config, ServiceConfig};
+use super::service_config::{load_service_config, ServiceConfig, ServiceIngress};
 
 /// Discover all deployable services from resolved config files.
 ///
@@ -16,7 +16,7 @@ use super::service_config::{load_service_config, ServiceConfig};
 pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, FlooError> {
     let path_entries = user_managed_path_entries(resolved);
 
-    if !path_entries.is_empty() {
+    let services = if !path_entries.is_empty() {
         // Branch 1: app.toml has user-managed services with path fields
         let mut services = Vec::new();
         let mut seen_names = HashSet::new();
@@ -63,7 +63,16 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
                 ));
             }
 
-            let svc = svc_file.service.to_api_service_config(normalized_path);
+            let mut svc = svc_file.service.to_api_service_config(normalized_path);
+
+            // Let floo.app.toml ingress override floo.service.toml value
+            if let Some(ref app_cfg) = resolved.app_config {
+                if let Some(entry) = app_cfg.services.get(name) {
+                    if let Some(override_ingress) = entry.ingress {
+                        svc.ingress = override_ingress;
+                    }
+                }
+            }
 
             if !seen_names.insert(svc.name.clone()) {
                 return Err(FlooError::new(
@@ -78,13 +87,13 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
             services.push(svc);
         }
 
-        Ok(services)
+        services
     } else if let Some(ref svc_file) = resolved.service_config {
         // Branch 2: single floo.service.toml only
-        Ok(vec![svc_file.service.to_api_service_config(".")])
+        vec![svc_file.service.to_api_service_config(".")]
     } else {
         // Branch 3: app.toml only with no deployable services
-        Err(FlooError::with_suggestion(
+        return Err(FlooError::with_suggestion(
             "NO_DEPLOYABLE_SERVICES",
             format!(
                 "{} has no deployable services (only Floo-managed services like postgres/redis).",
@@ -94,8 +103,19 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
                 "Add a user-managed service with a 'path' field, or create a {} in your project root.",
                 super::SERVICE_CONFIG_FILE,
             ),
-        ))
+        ));
+    };
+
+    // Multi-service apps must have at least one public service
+    if services.len() > 1 && !services.iter().any(|s| s.ingress == ServiceIngress::Public) {
+        return Err(FlooError::with_suggestion(
+            "NO_PUBLIC_SERVICES",
+            "At least one service must have ingress 'public'. All services are currently set to 'internal'.",
+            "Set ingress = \"public\" on at least one service in its floo.service.toml, or override it in floo.app.toml.",
+        ));
     }
+
+    Ok(services)
 }
 
 /// Filter services by name. Empty filter returns all.
@@ -213,7 +233,7 @@ ingress = "public"
                 name: "api".to_string(),
                 service_type: ServiceType::Api,
                 port: 8000,
-                ingress: ServiceIngress::Public,
+                ingress: Some(ServiceIngress::Public),
                 env_file: None,
             },
         };
@@ -261,6 +281,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
         services_map.insert(
@@ -271,6 +292,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -320,7 +342,7 @@ ingress = "public"
                 name: "web".to_string(),
                 service_type: ServiceType::Web,
                 port: 3000,
-                ingress: ServiceIngress::Public,
+                ingress: Some(ServiceIngress::Public),
                 env_file: None,
             },
         };
@@ -343,6 +365,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -387,7 +410,7 @@ ingress = "public"
                 name: "web".to_string(),
                 service_type: ServiceType::Web,
                 port: 3000,
-                ingress: ServiceIngress::Public,
+                ingress: Some(ServiceIngress::Public),
                 env_file: None,
             },
         };
@@ -401,6 +424,7 @@ ingress = "public"
                 repo: None,
                 version: Some("16".to_string()),
                 plan: None,
+                ingress: None,
             },
         );
         services_map.insert(
@@ -411,6 +435,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -453,6 +478,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -498,6 +524,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -537,7 +564,7 @@ ingress = "public"
                 name: "api".to_string(),
                 service_type: ServiceType::Api,
                 port: 8000,
-                ingress: ServiceIngress::Public,
+                ingress: Some(ServiceIngress::Public),
                 env_file: None,
             },
         };
@@ -560,6 +587,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -597,6 +625,7 @@ ingress = "public"
                 repo: None,
                 version: Some("16".to_string()),
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -641,6 +670,7 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                ingress: None,
             },
         );
 
@@ -736,5 +766,148 @@ ingress = "public"
         assert!(err.message.contains("nonexistent"));
         assert!(err.suggestion.as_deref().unwrap().contains("web"));
         assert!(err.suggestion.as_deref().unwrap().contains("api"));
+    }
+
+    #[test]
+    fn test_app_toml_ingress_overrides_service_toml() {
+        let dir = TempDir::new().unwrap();
+
+        // Sub-service declares ingress = "public"
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "my-app", "api", 8000),
+        )
+        .unwrap();
+
+        // Root service to satisfy at-least-one-public
+        let root_svc = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            service: ServiceSection {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                port: 3000,
+                ingress: Some(ServiceIngress::Public),
+                env_file: None,
+            },
+        };
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                ingress: Some(ServiceIngress::Internal),
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            Some(root_svc),
+            Some(app_config),
+            AppSource::ServiceFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        let api = services.iter().find(|s| s.name == "api").unwrap();
+        assert_eq!(api.ingress, ServiceIngress::Internal);
+    }
+
+    #[test]
+    fn test_all_internal_multi_service_errors() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        let worker_dir = dir.path().join("worker");
+        fs::create_dir(&backend).unwrap();
+        fs::create_dir(&worker_dir).unwrap();
+
+        // Both services declare internal ingress via TOML
+        fs::write(
+            backend.join("floo.service.toml"),
+            r#"[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+ingress = "internal"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            worker_dir.join("floo.service.toml"),
+            r#"[app]
+name = "my-app"
+
+[service]
+name = "bg"
+type = "worker"
+port = 9000
+ingress = "internal"
+"#,
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                ingress: None,
+            },
+        );
+        services_map.insert(
+            "bg".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Worker,
+                path: Some("./worker".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                ingress: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            services: services_map,
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let err = discover_services(&resolved).unwrap_err();
+        assert_eq!(err.code, "NO_PUBLIC_SERVICES");
     }
 }

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -79,19 +79,29 @@ pub struct ServiceSection {
     #[serde(rename = "type")]
     pub service_type: ServiceType,
     pub port: u16,
-    pub ingress: ServiceIngress,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress: Option<ServiceIngress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env_file: Option<String>,
 }
 
 impl ServiceSection {
+    /// Resolve the effective ingress mode: explicit value if set,
+    /// otherwise `Internal` for workers, `Public` for everything else.
+    pub fn resolved_ingress(&self) -> ServiceIngress {
+        self.ingress.unwrap_or(match self.service_type {
+            ServiceType::Worker => ServiceIngress::Internal,
+            _ => ServiceIngress::Public,
+        })
+    }
+
     pub fn to_api_service_config(&self, path: &str) -> ServiceConfig {
         ServiceConfig {
             name: self.name.clone(),
             service_type: self.service_type,
             path: path.to_string(),
             port: self.port,
-            ingress: self.ingress,
+            ingress: self.resolved_ingress(),
         }
     }
 }
@@ -167,7 +177,7 @@ ingress = "public"
         assert_eq!(config.service.name, "api");
         assert_eq!(config.service.service_type, ServiceType::Api);
         assert_eq!(config.service.port, 8000);
-        assert_eq!(config.service.ingress, ServiceIngress::Public);
+        assert_eq!(config.service.ingress, Some(ServiceIngress::Public));
         assert!(config.service.env_file.is_none());
     }
 
@@ -258,7 +268,7 @@ ingress = "internal"
                 name: "web".to_string(),
                 service_type: ServiceType::Web,
                 port: 3000,
-                ingress: ServiceIngress::Public,
+                ingress: Some(ServiceIngress::Public),
                 env_file: None,
             },
         };
@@ -276,7 +286,7 @@ ingress = "internal"
             name: "api".to_string(),
             service_type: ServiceType::Api,
             port: 8000,
-            ingress: ServiceIngress::Internal,
+            ingress: Some(ServiceIngress::Internal),
             env_file: None,
         };
 
@@ -349,5 +359,75 @@ ingress = "public"
 
         let config = load_service_config(dir.path()).unwrap().unwrap();
         assert!(config.app.access_mode.is_none());
+    }
+
+    #[test]
+    fn test_worker_defaults_to_internal_ingress() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "bg"
+type = "worker"
+port = 8000
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert!(config.service.ingress.is_none());
+        assert_eq!(config.service.resolved_ingress(), ServiceIngress::Internal);
+
+        let api_cfg = config.service.to_api_service_config(".");
+        assert_eq!(api_cfg.ingress, ServiceIngress::Internal);
+    }
+
+    #[test]
+    fn test_worker_explicit_public_overrides_default() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "bg"
+type = "worker"
+port = 8000
+ingress = "public"
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.service.ingress, Some(ServiceIngress::Public));
+        assert_eq!(config.service.resolved_ingress(), ServiceIngress::Public);
+    }
+
+    #[test]
+    fn test_api_defaults_to_public_ingress() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert!(config.service.ingress.is_none());
+        assert_eq!(config.service.resolved_ingress(), ServiceIngress::Public);
     }
 }


### PR DESCRIPTION
## Summary
- Worker services default to `ingress = "internal"` when `ingress` is omitted from `floo.service.toml`
- `floo.app.toml` service entries can override ingress via new `ingress` field
- Multi-service apps validated: at least one service must be public (`NO_PUBLIC_SERVICES` error)
- `floo services list` now shows Ingress column (Name, Type, Status, Ingress, URL)
- `floo services info` shows Ingress field in output

## Test plan
- [x] All 46 CLI tests pass
- [x] Pre-existing clippy/fmt issues only (no new warnings from these changes)
- [ ] Manual test: `floo init` with worker type, verify `ingress` omitted from generated TOML
- [ ] Manual test: `floo services list` shows Ingress column
- [ ] Manual test: deploy with all-internal services → error

Closes getfloo/floo#259

🤖 Generated with [Claude Code](https://claude.com/claude-code)