### PR TITLE
[Feature] [#214] CLI support for password-mode deploy and apps password subcommand

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -257,6 +257,11 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_app_password(&self, app_id: &str) -> Result<AppPasswordResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/password"))?;
+        self.handle_response(resp)
+    }
+
     pub fn delete_app(&self, app_id: &str) -> Result<(), FlooApiError> {
         let resp = self.delete(&format!("/v1/apps/{app_id}"))?;
         if resp.status().as_u16() == 204 {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -88,6 +88,12 @@ pub struct Deploy {
     pub build_logs: Option<String>,
     pub runtime: Option<String>,
     pub created_at: Option<String>,
+    pub generated_password: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppPasswordResponse {
+    pub password: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -318,6 +318,12 @@ pub enum AppsCommands {
         #[arg(short, long)]
         app: String,
     },
+
+    /// Show the shared password for a password-protected app.
+    Password {
+        /// App name or ID.
+        app_name: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -608,6 +614,7 @@ pub fn run() {
                 no_deploy,
             ),
             AppsCommands::Disconnect { app } => commands::apps::disconnect(&app),
+            AppsCommands::Password { app_name } => commands::apps::show_password(&app_name),
         },
 
         Commands::Env(sub) => match sub {

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -342,3 +342,20 @@ pub fn disconnect(app_name: &str) {
         Some(serde_json::json!({"app": app.name})),
     );
 }
+
+pub fn show_password(app_name: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let app = super::resolve_app_or_exit(&client, app_name);
+
+    match client.get_app_password(&app.id) {
+        Ok(resp) => output::success(
+            "App password",
+            Some(serde_json::json!({ "password": resp.password })),
+        ),
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -416,11 +416,16 @@ pub fn deploy(
         sync_env_vars_if_needed(&client, &app_id, r, sync_env);
     }
 
-    // Extract access_mode from config: app_config wins over service_config
+    // Extract access_mode: [environments.dev] override > [app] level > service_config
     let access_mode: Option<AppAccessMode> = resolved.as_ref().and_then(|r| {
         r.app_config
             .as_ref()
-            .and_then(|c| c.app.access_mode)
+            .and_then(|c| {
+                c.environments
+                    .get("dev")
+                    .and_then(|env| env.access_mode)
+                    .or(c.app.access_mode)
+            })
             .or_else(|| r.service_config.as_ref().and_then(|c| c.app.access_mode))
     });
 
@@ -442,7 +447,13 @@ pub fn deploy(
         Err(e) => {
             spinner.finish();
             cleanup(&archive_path);
-            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            let suggestion = match e.code.as_str() {
+                "PLAN_FEATURE_PASSWORD" | "PLAN_FEATURE_FLOO_ACCOUNTS" => {
+                    Some("Upgrade your plan at https://app.getfloo.com/settings/billing")
+                }
+                _ => None,
+            };
+            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
             process::exit(1);
         }
     };
@@ -506,6 +517,16 @@ pub fn deploy(
 
     let url = deploy_data.url.as_deref().unwrap_or("");
 
+    if !output::is_json_mode() {
+        if let Some(ref password) = deploy_data.generated_password {
+            output::info(&format!("  Generated password: {password}"), None);
+            output::info("  To retrieve later: floo apps password <name>", None);
+        }
+        if let Some(ref mode) = access_mode {
+            output::info(&format!("  Access: {}", mode.as_str()), None);
+        }
+    }
+
     let service_names: Vec<&str> = services
         .as_ref()
         .map(|svcs| svcs.iter().map(|s| s.name.as_str()).collect())
@@ -556,6 +577,7 @@ fn prompt_first_deploy(detection: &crate::detection::DetectionResult) -> FirstDe
             path: ".".to_string(),
             port,
             ingress: ServiceIngress::Public,
+            domain: None,
         },
     }
 }
@@ -574,6 +596,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
             port: service.port,
             ingress: Some(service.ingress),
             env_file,
+            domain: service.domain.clone(),
         },
     };
 
@@ -583,6 +606,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
             access_mode: None,
         },
         services: HashMap::new(),
+        environments: HashMap::new(),
     };
 
     if let Err(e) = project_config::write_app_config(project_path, &app_file) {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -91,6 +91,7 @@ fn init_non_interactive(
             port,
             ingress: Some(ServiceIngress::Public),
             env_file,
+            domain: None,
         },
     };
 
@@ -100,6 +101,7 @@ fn init_non_interactive(
             access_mode: None,
         },
         services: HashMap::new(),
+        environments: HashMap::new(),
     };
 
     let mut files_written = Vec::new();
@@ -225,6 +227,7 @@ fn init_interactive(
                         version: None,
                         plan: None,
                         ingress: None,
+                        domain: None,
                     },
                 );
             }
@@ -242,6 +245,7 @@ fn init_interactive(
                         port,
                         ingress: Some(ServiceIngress::Public),
                         env_file: env_file.clone(),
+                        domain: None,
                     },
                 });
             } else {
@@ -259,6 +263,7 @@ fn init_interactive(
                             port,
                             ingress: Some(ServiceIngress::Public),
                             env_file: env_file.clone(),
+                            domain: None,
                         },
                     };
                     if let Err(e) = project_config::write_service_config(&svc_dir, &svc_file) {
@@ -295,6 +300,7 @@ fn init_interactive(
                 port: detection.default_port(),
                 ingress: Some(ServiceIngress::Public),
                 env_file,
+                domain: None,
             },
         });
     }
@@ -306,6 +312,7 @@ fn init_interactive(
             access_mode: None,
         },
         services: services_map,
+        environments: HashMap::new(),
     };
 
     if let Err(e) = project_config::write_app_config(project_path, &app_file) {

--- a/src/commands/service_mgmt.rs
+++ b/src/commands/service_mgmt.rs
@@ -173,6 +173,7 @@ pub fn add(
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
     }
@@ -205,6 +206,7 @@ pub fn add(
             port: resolved_port,
             ingress: Some(svc_ingress),
             env_file: env_file_val.clone(),
+            domain: None,
         },
     };
 

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -14,6 +14,15 @@ pub struct AppFileConfig {
     pub app: AppFileAppSection,
     #[serde(default)]
     pub services: HashMap<String, AppServiceEntry>,
+    #[serde(default)]
+    pub environments: HashMap<String, AppEnvironmentOverrides>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct AppEnvironmentOverrides {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_mode: Option<AppAccessMode>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
@@ -57,6 +66,8 @@ pub struct AppServiceEntry {
     pub plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ingress: Option<ServiceIngress>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -296,6 +307,7 @@ type = "mysql"
                 access_mode: None,
             },
             services: HashMap::new(),
+            environments: HashMap::new(),
         };
 
         write_app_config(dir.path(), &config).unwrap();

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -65,11 +65,14 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
 
             let mut svc = svc_file.service.to_api_service_config(normalized_path);
 
-            // Let floo.app.toml ingress override floo.service.toml value
+            // Let floo.app.toml override floo.service.toml values
             if let Some(ref app_cfg) = resolved.app_config {
                 if let Some(entry) = app_cfg.services.get(name) {
                     if let Some(override_ingress) = entry.ingress {
                         svc.ingress = override_ingress;
+                    }
+                    if entry.domain.is_some() {
+                        svc.domain = entry.domain.clone();
                     }
                 }
             }
@@ -235,6 +238,7 @@ ingress = "public"
                 port: 8000,
                 ingress: Some(ServiceIngress::Public),
                 env_file: None,
+                domain: None,
             },
         };
         let resolved = make_resolved(
@@ -282,6 +286,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
         services_map.insert(
@@ -293,6 +298,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -302,6 +308,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -344,6 +351,7 @@ ingress = "public"
                 port: 3000,
                 ingress: Some(ServiceIngress::Public),
                 env_file: None,
+                domain: None,
             },
         };
 
@@ -366,6 +374,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -375,6 +384,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -412,6 +422,7 @@ ingress = "public"
                 port: 3000,
                 ingress: Some(ServiceIngress::Public),
                 env_file: None,
+                domain: None,
             },
         };
 
@@ -425,6 +436,7 @@ ingress = "public"
                 version: Some("16".to_string()),
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
         services_map.insert(
@@ -436,6 +448,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -445,6 +458,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -479,6 +493,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -488,6 +503,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -525,6 +541,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -534,6 +551,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -566,6 +584,7 @@ ingress = "public"
                 port: 8000,
                 ingress: Some(ServiceIngress::Public),
                 env_file: None,
+                domain: None,
             },
         };
 
@@ -588,6 +607,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -597,6 +617,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -626,6 +647,7 @@ ingress = "public"
                 version: Some("16".to_string()),
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -635,6 +657,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -671,6 +694,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -680,6 +704,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -704,6 +729,7 @@ ingress = "public"
                 path: "frontend".to_string(),
                 port: 3000,
                 ingress: ServiceIngress::Public,
+                domain: None,
             },
             ServiceConfig {
                 name: "api".to_string(),
@@ -711,6 +737,7 @@ ingress = "public"
                 path: "backend".to_string(),
                 port: 8000,
                 ingress: ServiceIngress::Public,
+                domain: None,
             },
         ];
 
@@ -727,6 +754,7 @@ ingress = "public"
                 path: "frontend".to_string(),
                 port: 3000,
                 ingress: ServiceIngress::Public,
+                domain: None,
             },
             ServiceConfig {
                 name: "api".to_string(),
@@ -734,6 +762,7 @@ ingress = "public"
                 path: "backend".to_string(),
                 port: 8000,
                 ingress: ServiceIngress::Public,
+                domain: None,
             },
         ];
 
@@ -751,6 +780,7 @@ ingress = "public"
                 path: "frontend".to_string(),
                 port: 3000,
                 ingress: ServiceIngress::Public,
+                domain: None,
             },
             ServiceConfig {
                 name: "api".to_string(),
@@ -758,6 +788,7 @@ ingress = "public"
                 path: "backend".to_string(),
                 port: 8000,
                 ingress: ServiceIngress::Public,
+                domain: None,
             },
         ];
 
@@ -793,6 +824,7 @@ ingress = "public"
                 port: 3000,
                 ingress: Some(ServiceIngress::Public),
                 env_file: None,
+                domain: None,
             },
         };
 
@@ -806,6 +838,7 @@ ingress = "public"
                 version: None,
                 plan: None,
                 ingress: Some(ServiceIngress::Internal),
+                domain: None,
             },
         );
 
@@ -815,6 +848,7 @@ ingress = "public"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(
@@ -877,6 +911,7 @@ ingress = "internal"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
         services_map.insert(
@@ -888,6 +923,7 @@ ingress = "internal"
                 version: None,
                 plan: None,
                 ingress: None,
+                domain: None,
             },
         );
 
@@ -897,6 +933,7 @@ ingress = "internal"
                 access_mode: None,
             },
             services: services_map,
+            environments: HashMap::new(),
         };
 
         let resolved = make_resolved(

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -947,4 +947,121 @@ ingress = "internal"
         let err = discover_services(&resolved).unwrap_err();
         assert_eq!(err.code, ErrorCode::NoPublicServices);
     }
+
+    #[test]
+    fn test_app_toml_domain_overrides_service_toml() {
+        let dir = TempDir::new().unwrap();
+
+        // Sub-service declares domain = "svc.example.com"
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            r#"[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+ingress = "public"
+domain = "svc.example.com"
+"#,
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                ingress: None,
+                domain: Some("app.example.com".to_string()),
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            services: services_map,
+            environments: HashMap::new(),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        let api = services.iter().find(|s| s.name == "api").unwrap();
+        // floo.app.toml domain should override floo.service.toml domain
+        assert_eq!(api.domain.as_deref(), Some("app.example.com"));
+    }
+
+    #[test]
+    fn test_service_toml_domain_preserved_when_no_app_override() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        fs::write(
+            backend.join("floo.service.toml"),
+            r#"[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+ingress = "public"
+domain = "svc.example.com"
+"#,
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                ingress: None,
+                domain: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            services: services_map,
+            environments: HashMap::new(),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        let api = services.iter().find(|s| s.name == "api").unwrap();
+        // Domain from floo.service.toml should be preserved
+        assert_eq!(api.domain.as_deref(), Some("svc.example.com"));
+    }
 }

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -438,4 +438,114 @@ port = 8000
         assert!(config.service.ingress.is_none());
         assert_eq!(config.service.resolved_ingress(), ServiceIngress::Public);
     }
+
+    #[test]
+    fn test_load_service_config_with_domain() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "web"
+type = "web"
+port = 3000
+ingress = "public"
+domain = "getfloo.com"
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.service.domain.as_deref(), Some("getfloo.com"));
+    }
+
+    #[test]
+    fn test_load_service_config_without_domain() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert!(config.service.domain.is_none());
+    }
+
+    #[test]
+    fn test_to_api_service_config_passes_domain() {
+        let section = ServiceSection {
+            name: "web".to_string(),
+            service_type: ServiceType::Web,
+            port: 3000,
+            ingress: Some(ServiceIngress::Public),
+            env_file: None,
+            domain: Some("getfloo.com".to_string()),
+        };
+
+        let api_config = section.to_api_service_config(".");
+        assert_eq!(api_config.domain.as_deref(), Some("getfloo.com"));
+    }
+
+    #[test]
+    fn test_service_config_json_domain_omitted_when_none() {
+        let config = ServiceConfig {
+            name: "api".to_string(),
+            service_type: ServiceType::Api,
+            path: "backend".to_string(),
+            port: 8000,
+            ingress: ServiceIngress::Public,
+            domain: None,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(json.get("domain").is_none());
+    }
+
+    #[test]
+    fn test_service_config_json_domain_included_when_set() {
+        let config = ServiceConfig {
+            name: "web".to_string(),
+            service_type: ServiceType::Web,
+            path: ".".to_string(),
+            port: 3000,
+            ingress: ServiceIngress::Public,
+            domain: Some("getfloo.com".to_string()),
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["domain"], "getfloo.com");
+    }
+
+    #[test]
+    fn test_write_and_reload_service_config_with_domain() {
+        let dir = TempDir::new().unwrap();
+        let config = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            service: ServiceSection {
+                name: "web".to_string(),
+                service_type: ServiceType::Web,
+                port: 3000,
+                ingress: Some(ServiceIngress::Public),
+                env_file: None,
+                domain: Some("getfloo.com".to_string()),
+            },
+        };
+
+        write_service_config(dir.path(), &config).unwrap();
+        let loaded = load_service_config(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.service.domain.as_deref(), Some("getfloo.com"));
+    }
 }

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -19,6 +19,8 @@ pub struct ServiceConfig {
     pub path: String,
     pub port: u16,
     pub ingress: ServiceIngress,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
@@ -83,6 +85,8 @@ pub struct ServiceSection {
     pub ingress: Option<ServiceIngress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
 }
 
 impl ServiceSection {
@@ -102,6 +106,7 @@ impl ServiceSection {
             path: path.to_string(),
             port: self.port,
             ingress: self.resolved_ingress(),
+            domain: self.domain.clone(),
         }
     }
 }
@@ -270,6 +275,7 @@ ingress = "internal"
                 port: 3000,
                 ingress: Some(ServiceIngress::Public),
                 env_file: None,
+                domain: None,
             },
         };
 
@@ -288,6 +294,7 @@ ingress = "internal"
             port: 8000,
             ingress: Some(ServiceIngress::Internal),
             env_file: None,
+            domain: None,
         };
 
         let api_config = section.to_api_service_config("backend");
@@ -306,6 +313,7 @@ ingress = "internal"
             path: "backend".to_string(),
             port: 8000,
             ingress: ServiceIngress::Internal,
+            domain: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["name"], "api");


### PR DESCRIPTION
## Summary

- `floo deploy` with `access_mode = "password"` shows generated password in terminal output; tier-gating errors (`PLAN_FEATURE_PASSWORD`, `PLAN_FEATURE_FLOO_ACCOUNTS`) surface an upgrade hint
- Per-environment access_mode overrides: `[environments.dev]` in `floo.app.toml` takes precedence over `[app]` level
- New `floo apps password <name>` subcommand retrieves the current app password
- `AppEnvironmentOverrides` struct + `environments` field added to `AppFileConfig`
- `domain` field propagated through `ServiceSection`, `ServiceConfig`, `AppServiceEntry`, and all callsites in init/discover/service_mgmt

## Test plan

- [ ] `cargo test` — all 46 tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] Deploy with `access_mode = "password"`: generated password shown in output
- [ ] Redeploy: no password shown (not regenerated)
- [ ] `floo apps password <name>`: prints the app password
- [ ] `[environments.dev] access_mode = "public"`: override sent to API

Closes getfloo/floo#214

🤖 Generated with [Claude Code](https://claude.com/claude-code)