### PR TITLE
feat: surface org_id in app output

### DIFF
--- a/skills/floo.md
+++ b/skills/floo.md
@@ -81,11 +81,13 @@ floo deploy [path] --json
 
 JSON output: `data.app`, `data.deploy`, `data.detection`
 
+`apps status` human output shows `Org:` line with the org slug. `apps list` includes an `Org` column. JSON output for both commands includes `org_id` per app.
+
 ### Apps
 
 ```bash
-floo apps list --json                    # list all apps
-floo apps status <name> --json           # app details + services + deploy status
+floo apps list --json                    # list all apps (includes Org column)
+floo apps status <name> --json           # app details + org + services + deploy status
 floo apps delete <name> --json           # delete an app (--force to skip prompt)
 floo apps connect --repo owner/repo --installation-id <id> --app <name>  # GitHub auto-deploy
 floo apps disconnect --app <name>        # remove GitHub connection

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -210,6 +210,11 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_org(&self, org_id: &str) -> Result<OrgResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/orgs/{org_id}"))?;
+        self.handle_response(resp)
+    }
+
     pub fn list_members(&self, org_id: &str) -> Result<ListMembersResponse, FlooApiError> {
         let resp = self.get(&format!("/v1/orgs/{org_id}/members"))?;
         self.handle_response(resp)

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -36,9 +36,17 @@ pub struct ProfileResponse {
 pub struct OrgResponse {
     pub id: String,
     pub name: Option<String>,
+    pub slug: Option<String>,
     pub spend_cap: Option<u64>,
     pub current_period_spend_cents: Option<u64>,
     pub spend_cap_exceeded: Option<bool>,
+}
+
+impl OrgResponse {
+    /// Human-readable display name: prefers slug, falls back to name.
+    pub fn display_name(&self) -> Option<&str> {
+        self.slug.as_deref().or(self.name.as_deref())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +74,7 @@ pub struct MemberRoleResponse {
 pub struct App {
     pub id: String,
     pub name: String,
+    pub org_id: Option<String>,
     pub status: Option<String>,
     pub url: Option<String>,
     pub runtime: Option<String>,

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -37,13 +37,29 @@ pub fn list(page: u32, per_page: u32) {
         return;
     }
 
+    // Resolve org display name once for the table (human mode only).
+    // All listed apps belong to the caller's org, so one lookup suffices.
+    let org_display: Option<String> = if !output::is_json_mode() {
+        client
+            .get_org_me()
+            .ok()
+            .and_then(|o| o.display_name().map(String::from))
+    } else {
+        None
+    };
+
     let rows: Vec<Vec<String>> = result
         .apps
         .iter()
         .map(|a| {
+            let org = org_display
+                .as_deref()
+                .or(a.org_id.as_deref())
+                .unwrap_or("\u{2014}");
             vec![
                 a.name.clone(),
                 a.status.as_deref().unwrap_or("-").to_string(),
+                org.to_string(),
                 a.url.as_deref().unwrap_or("\u{2014}").to_string(),
                 a.runtime.as_deref().unwrap_or("\u{2014}").to_string(),
                 a.created_at.as_deref().unwrap_or("-").to_string(),
@@ -52,7 +68,7 @@ pub fn list(page: u32, per_page: u32) {
         .collect();
 
     output::table(
-        &["Name", "Status", "URL", "Runtime", "Created"],
+        &["Name", "Status", "Org", "URL", "Runtime", "Created"],
         &rows,
         Some(
             serde_json::json!({"apps": output::to_value(&result.apps), "total": total, "page": page, "per_page": per_page}),
@@ -81,6 +97,7 @@ pub fn status(app_name: &str) {
     if output::is_json_mode() {
         output::success(&format!("App {}", app.name), Some(output::to_value(&app)));
     } else {
+        let org_display = resolve_org_display(&client, app.org_id.as_deref());
         output::info(&app.name, None);
         output::info(
             &format!("  Status:   {}", app.status.as_deref().unwrap_or("-")),
@@ -97,11 +114,25 @@ pub fn status(app_name: &str) {
             ),
             None,
         );
+        output::info(&format!("  Org:      {org_display}"), None);
         output::info(&format!("  ID:       {}", app.id), None);
         output::info(
             &format!("  Created:  {}", app.created_at.as_deref().unwrap_or("-")),
             None,
         );
+    }
+}
+
+fn resolve_org_display(client: &crate::api_client::FlooClient, org_id: Option<&str>) -> String {
+    let Some(org_id) = org_id else {
+        return "\u{2014}".to_string();
+    };
+    match client.get_org(org_id) {
+        Ok(org) => org
+            .display_name()
+            .map(String::from)
+            .unwrap_or_else(|| org_id.to_string()),
+        Err(_) => org_id.to_string(),
     }
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -152,6 +152,7 @@ mod tests {
         App {
             id: id.to_string(),
             name: name.to_string(),
+            org_id: None,
             status: None,
             url: None,
             runtime: None,

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -6,6 +6,7 @@ use tempfile::TempDir;
 
 const TEST_APP_ID: &str = "app-uuid-1234";
 const TEST_APP_NAME: &str = "my-app";
+const TEST_ORG_ID: &str = "org-uuid-5678";
 
 fn floo() -> Command {
     Command::cargo_bin("floo").unwrap()
@@ -30,8 +31,25 @@ fn setup_config(server: &Server) -> TempDir {
 /// App JSON fixture used across resolve_app and list mocks.
 fn app_json() -> String {
     format!(
-        r#"{{"id":"{TEST_APP_ID}","name":"{TEST_APP_NAME}","status":"live","url":"https://test.floo.app","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z"}}"#
+        r#"{{"id":"{TEST_APP_ID}","name":"{TEST_APP_NAME}","org_id":"{TEST_ORG_ID}","status":"live","url":"https://test.floo.app","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z"}}"#
     )
+}
+
+/// Org JSON fixture for org lookup mocks.
+fn org_json() -> String {
+    format!(
+        r#"{{"id":"{TEST_ORG_ID}","name":"Test Org","slug":"test-org","spend_cap":null,"current_period_spend_cents":0,"spend_cap_exceeded":false}}"#
+    )
+}
+
+/// Mock GET /v1/orgs/me for human-mode list.
+fn mock_org_me(server: &mut Server) -> Mock {
+    server
+        .mock("GET", "/v1/orgs/me")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(org_json())
+        .create()
 }
 
 fn update_asset_name() -> Option<String> {
@@ -145,7 +163,8 @@ fn test_apps_list_json() {
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains(r#""apps":[{"#))
-        .stdout(predicate::str::contains(TEST_APP_NAME));
+        .stdout(predicate::str::contains(TEST_APP_NAME))
+        .stdout(predicate::str::contains(TEST_ORG_ID));
 }
 
 #[test]
@@ -164,6 +183,8 @@ fn test_apps_list_human() {
         .with_body(format!(r#"{{"apps":[{app}]}}"#, app = app_json()))
         .create();
 
+    let _m_org = mock_org_me(&mut server);
+
     floo()
         .args(["apps", "list"])
         .env("HOME", home.path())
@@ -171,7 +192,8 @@ fn test_apps_list_human() {
         .success()
         .stderr(predicate::str::contains(TEST_APP_NAME))
         .stderr(predicate::str::contains("Name"))
-        .stderr(predicate::str::contains("Status"));
+        .stderr(predicate::str::contains("Status"))
+        .stderr(predicate::str::contains("Org"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `org_id` to `App` struct and `slug` to `OrgResponse` so the CLI shows which org owns each app
- `floo apps status` displays an `Org:` line with the org slug in human mode
- `floo apps list` includes an `Org` column in human mode
- JSON output for both commands includes `org_id` per app

Closes #23

## Changes
| File | Change |
|------|--------|
| `src/api_types.rs` | Add `org_id` to `App`, `slug` to `OrgResponse`, `display_name()` method |
| `src/api_client.rs` | Add `get_org(org_id)` client method |
| `src/commands/apps.rs` | Add org display in `status()` and `list()`, `resolve_org_display()` helper |
| `src/resolve.rs` | Add `org_id: None` to test helper |
| `tests/mock_api_tests.rs` | Update fixtures with `org_id`, add org mock helpers and assertions |
| `skills/floo.md` | Document new output |

## Dependencies
- Requires API endpoint `GET /v1/orgs/{org_id}` — see getfloo/floo#280

## Test plan
- [x] `cargo test` — 267 tests pass (150 unit + 71 CLI + 46 mock API)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] JSON mode includes `org_id` in apps list and status output
- [x] Human mode shows `Org` column in list and `Org:` line in status
- [x] Graceful fallback to raw UUID when org lookup fails

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)