### PR TITLE
fix: make --json flag global so it works in any position

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use crate::output;
 )]
 pub struct Cli {
     /// Output JSON to stdout (for agents).
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub json: bool,
 
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- Add `global = true` to the `--json` clap arg attribute so the flag propagates to all subcommands
- Enables the intuitive `floo apps list --json` position (after subcommand args) in addition to the existing `floo --json apps list` position
- Fully backward compatible — all existing tests pass without modification

## Changes
- `src/cli.rs` — added `global = true` to `#[arg(long)]` on the `json` field

## Test plan
- [x] `cargo test` — all 280 tests pass (161 unit + 73 CLI + 46 mock API)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)