### PR TITLE
[Feature] Auto-resolve GitHub installation ID on connect

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -47,29 +47,42 @@ impl FlooClient {
     fn handle_error(&self, response: reqwest::blocking::Response) -> FlooApiError {
         let status = response.status().as_u16();
         let text = response.text().unwrap_or_default();
-        let (code, message) = if let Ok(body) = serde_json::from_str::<Value>(&text) {
+        let (code, message, extra) = if let Ok(body) = serde_json::from_str::<Value>(&text) {
             let detail = body.get("detail").unwrap_or(&body);
             if let Some(obj) = detail.as_object() {
-                (
-                    obj.get("code")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("API_ERROR")
-                        .to_string(),
-                    obj.get("message")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(&text)
-                        .to_string(),
-                )
+                let code = obj
+                    .get("code")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("API_ERROR")
+                    .to_string();
+                let message = obj
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&text)
+                    .to_string();
+                // Capture any extra fields beyond code/message
+                let mut extra_obj = obj.clone();
+                extra_obj.remove("code");
+                extra_obj.remove("message");
+                let extra = if extra_obj.is_empty() {
+                    None
+                } else {
+                    Some(Value::Object(extra_obj))
+                };
+                (code, message, extra)
             } else {
                 (
                     "API_ERROR".to_string(),
                     detail.to_string().trim_matches('"').to_string(),
+                    None,
                 )
             }
         } else {
-            ("API_ERROR".to_string(), text)
+            ("API_ERROR".to_string(), text, None)
         };
-        FlooApiError::new(status, code, message)
+        let mut err = FlooApiError::new(status, code, message);
+        err.extra = extra;
+        err
     }
 
     fn handle_response<T: serde::de::DeserializeOwned>(
@@ -636,13 +649,11 @@ impl FlooClient {
 
     // --- GitHub ---
 
-    #[allow(dead_code)]
     pub fn github_setup_begin(&self) -> Result<Value, FlooApiError> {
         let resp = self.post_json("/v1/github/setup/begin", &serde_json::json!({}))?;
         self.handle_response(resp)
     }
 
-    #[allow(dead_code)]
     pub fn github_setup_poll(&self) -> Result<Value, FlooApiError> {
         let resp = self.get("/v1/github/setup/poll")?;
         self.handle_response(resp)
@@ -658,13 +669,11 @@ impl FlooClient {
         &self,
         app_id: &str,
         repo_full_name: &str,
-        installation_id: u64,
         branch: Option<&str>,
         skip_env_var_check: bool,
     ) -> Result<GitHubConnectResponse, FlooApiError> {
         let mut body = serde_json::json!({
             "repo_full_name": repo_full_name,
-            "installation_id": installation_id,
         });
         if let Some(b) = branch {
             body.as_object_mut()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -291,10 +291,6 @@ pub enum AppsCommands {
         #[arg(long)]
         repo: String,
 
-        /// GitHub App installation ID.
-        #[arg(long)]
-        installation_id: u64,
-
         /// App name or ID.
         #[arg(short, long)]
         app: String,
@@ -624,14 +620,12 @@ pub fn run() {
             AppsCommands::Delete { app_name, force } => commands::apps::delete(&app_name, force),
             AppsCommands::Connect {
                 repo,
-                installation_id,
                 app,
                 branch,
                 skip_env_check,
                 no_deploy,
             } => commands::apps::connect(
                 &repo,
-                installation_id,
                 &app,
                 branch.as_deref(),
                 skip_env_check,

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -166,7 +166,6 @@ pub fn delete(app_name: &str, force: bool) {
 
 pub fn connect(
     repo: &str,
-    installation_id: u64,
     app_name: &str,
     branch: Option<&str>,
     skip_env_check: bool,
@@ -198,10 +197,52 @@ pub fn connect(
         import_env_vars_for_connect(&client, &app_id, r);
     }
 
-    // Step 2: Connect to GitHub
-    let result = match client.github_connect(&app_id, repo, installation_id, branch, skip_env_check)
-    {
+    // Step 2: Connect to GitHub (installation_id auto-resolved by the API)
+    let result = match client.github_connect(&app_id, repo, branch, skip_env_check) {
         Ok(r) => r,
+        Err(e) if e.code == "GITHUB_APP_NOT_INSTALLED" => {
+            // App not installed — run browser install flow or exit in JSON mode
+            let install_url = e
+                .extra
+                .as_ref()
+                .and_then(|v| v.get("install_url"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("https://github.com/apps/getfloo/installations/new");
+
+            if output::is_json_mode() {
+                output::error_with_data(
+                    &e.message,
+                    &ErrorCode::from_api(&e.code),
+                    None,
+                    Some(serde_json::json!({
+                        "error": "github_app_not_installed",
+                        "install_url": install_url,
+                    })),
+                );
+                process::exit(1);
+            }
+
+            // Interactive: run browser install flow
+            let owner = repo.split('/').next().unwrap_or(repo);
+            output::warn(&format!(
+                "Floo GitHub App not installed on \"{owner}\""
+            ));
+
+            run_installation_flow(&client, install_url);
+
+            // Retry connect — API will auto-resolve the newly installed ID
+            match client.github_connect(&app_id, repo, branch, skip_env_check) {
+                Ok(r) => r,
+                Err(e2) => {
+                    output::error(
+                        &e2.message,
+                        &ErrorCode::from_api(&e2.code),
+                        None,
+                    );
+                    process::exit(1);
+                }
+            }
+        }
         Err(e) => {
             let suggestion = match e.code.as_str() {
                 "GITHUB_ALREADY_CONNECTED" => {
@@ -233,6 +274,89 @@ pub fn connect(
                 "No project config found. Run `floo deploy` to trigger the first deploy.",
                 None,
             );
+        }
+    }
+}
+
+fn run_installation_flow(
+    client: &crate::api_client::FlooClient,
+    install_url: &str,
+) {
+    // Begin the setup session (stores pending state in Redis)
+    if let Err(e) = client.github_setup_begin() {
+        // Permanent errors (4xx) mean the flow is doomed — abort early
+        if e.status_code > 0 && e.status_code < 500 {
+            output::error(
+                &format!("Failed to start setup session: {}", e.message),
+                &ErrorCode::from_api(&e.code),
+                Some("Check your authentication with: floo auth whoami"),
+            );
+            process::exit(1);
+        }
+        output::warn(&format!(
+            "Setup session may not have been created: {}. Continuing...",
+            e.message
+        ));
+    }
+
+    // Open browser for installation
+    if !output::is_json_mode() {
+        output::info("Opening browser to install...", None);
+    }
+    if let Err(e) = open::that(install_url) {
+        output::warn(&format!("Could not open browser: {e}"));
+        output::warn(&format!("Open this URL manually: {install_url}"));
+    }
+
+    // Poll for installation completion (3s interval, 5 min timeout)
+    let spinner = output::Spinner::new("Waiting for installation...");
+    let poll_interval = std::time::Duration::from_secs(3);
+    let timeout = std::time::Duration::from_secs(300);
+    let start = std::time::Instant::now();
+
+    loop {
+        std::thread::sleep(poll_interval);
+
+        if start.elapsed() > timeout {
+            spinner.finish();
+            output::error(
+                "Timed out waiting for GitHub App installation.",
+                &ErrorCode::Other("SETUP_TIMEOUT".into()),
+                Some("Install the app manually, then re-run: floo apps connect --repo <owner/repo> --app <name>"),
+            );
+            process::exit(1);
+        }
+
+        match client.github_setup_poll() {
+            Ok(resp) => {
+                let status = resp.get("status").and_then(|v| v.as_str()).unwrap_or("none");
+                if status == "ready" {
+                    spinner.finish();
+                    if resp.get("installation_id").and_then(|v| v.as_u64()).is_none() {
+                        output::error(
+                            "GitHub App was installed but the server did not return an installation ID.",
+                            &ErrorCode::InvalidResponse,
+                            Some("Try running the command again — the installation should be detected automatically."),
+                        );
+                        process::exit(1);
+                    }
+                    return;
+                }
+            }
+            Err(e) => {
+                // Only tolerate transient failures (network issues, 5xx).
+                // Permanent errors (4xx) should abort immediately.
+                let is_transient = e.status_code == 0 || e.status_code >= 500;
+                if !is_transient {
+                    spinner.finish();
+                    output::error(
+                        &format!("Poll failed: {}", e.message),
+                        &ErrorCode::from_api(&e.code),
+                        None,
+                    );
+                    process::exit(1);
+                }
+            }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -249,6 +249,7 @@ pub struct FlooApiError {
     pub status_code: u16,
     pub code: String,
     pub message: String,
+    pub extra: Option<serde_json::Value>,
 }
 
 impl FlooApiError {
@@ -257,6 +258,7 @@ impl FlooApiError {
             status_code,
             code: code.into(),
             message: message.into(),
+            extra: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Remove `--installation-id` flag from `floo apps connect` — the API now auto-resolves it
- Add browser-based GitHub App install flow when the app is not installed (setup/begin → open browser → poll → retry)
- Add `extra` field to `FlooApiError` for structured error data from the API

## Changes

- **`src/errors.rs`** — Add `extra: Option<serde_json::Value>` to `FlooApiError`
- **`src/api_client.rs`** — Extract extra fields in `handle_error()`, remove `installation_id` from `github_connect()`
- **`src/cli.rs`** — Remove `--installation-id` from `AppsCommands::Connect`
- **`src/commands/apps.rs`** — Add `run_installation_flow()` with browser open + poll loop, handle `GITHUB_APP_NOT_INSTALLED` error

Companion PR: getfloo/floo (API side)

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 280 tests pass (161 unit + 73 integration + 46 mock API)
- [x] JSON mode outputs structured error with `install_url` for agent use
- [x] Interactive mode opens browser and polls for installation

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)