### PR TITLE
[Feature] Add floo deploys command

### DIFF
--- a/skills/floo.md
+++ b/skills/floo.md
@@ -136,6 +136,13 @@ floo services list --app <name> --json               # list all services
 floo services info <service-name> --app <name> --json # service details
 ```
 
+### Deploys
+
+```bash
+floo deploys list --app <name> --json                # list deploy history
+floo deploys logs <deploy-id> --app <name> --json    # show build logs for a deploy
+```
+
 ### Releases & Rollbacks
 
 ```bash

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -98,6 +98,8 @@ pub struct Deploy {
     pub runtime: Option<String>,
     pub created_at: Option<String>,
     pub generated_password: Option<String>,
+    pub triggered_by: Option<String>,
+    pub commit_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,10 @@ pub enum Commands {
     #[command(subcommand)]
     Domains(DomainsCommands),
 
+    /// View deploy history and build logs.
+    #[command(subcommand)]
+    Deploys(DeploysCommands),
+
     /// Manage releases.
     #[command(subcommand)]
     Releases(ReleasesCommands),
@@ -532,6 +536,26 @@ pub enum ReleasesCommands {
 }
 
 #[derive(Subcommand)]
+pub enum DeploysCommands {
+    /// List deploy history for an app.
+    List {
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Show build logs for a specific deploy.
+    Logs {
+        /// Deploy ID.
+        deploy_id: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum RollbacksCommands {
     /// List deploys available for rollback.
     List {
@@ -719,6 +743,13 @@ pub fn run() {
                 app,
                 services,
             } => commands::domains::remove(&hostname, app.as_deref(), services.as_deref()),
+        },
+
+        Commands::Deploys(sub) => match sub {
+            DeploysCommands::List { app } => commands::deploys::list(app.as_deref()),
+            DeploysCommands::Logs { deploy_id, app } => {
+                commands::deploys::logs(&deploy_id, app.as_deref())
+            }
         },
 
         Commands::Releases(sub) => match sub {

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -1,0 +1,102 @@
+use std::process;
+
+use crate::errors::ErrorCode;
+use crate::output;
+
+pub fn list(app: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
+
+    let result = match client.list_deploys(&app_id) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if result.deploys.is_empty() {
+        if output::is_json_mode() {
+            output::success(
+                "No deploys found.",
+                Some(serde_json::json!({"deploys": []})),
+            );
+        } else {
+            output::info("No deploys found.", None);
+        }
+        return;
+    }
+
+    let rows: Vec<Vec<String>> = result
+        .deploys
+        .iter()
+        .map(|d| {
+            let commit = d
+                .commit_sha
+                .as_deref()
+                .map(|s| if s.len() > 7 { &s[..7] } else { s })
+                .unwrap_or("\u{2014}");
+            vec![
+                d.id.clone(),
+                d.status.as_deref().unwrap_or("-").to_string(),
+                d.triggered_by.as_deref().unwrap_or("\u{2014}").to_string(),
+                commit.to_string(),
+                d.created_at.as_deref().unwrap_or("-").to_string(),
+            ]
+        })
+        .collect();
+
+    output::table(
+        &["Deploy ID", "Status", "Triggered By", "Commit", "Created"],
+        &rows,
+        Some(output::to_value(&result)),
+    );
+}
+
+pub fn logs(deploy_id: &str, app: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
+
+    let deploy = match client.get_deploy(&app_id, deploy_id) {
+        Ok(d) => d,
+        Err(e) => {
+            let suggestion = match e.code.as_str() {
+                "DEPLOY_NOT_FOUND" => Some("Check the deploy ID: floo deploys list --app <name>"),
+                _ => None,
+            };
+            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Deploy logs retrieved.",
+            Some(serde_json::json!({
+                "deploy_id": deploy.id,
+                "status": deploy.status,
+                "build_logs": deploy.build_logs,
+            })),
+        );
+        return;
+    }
+
+    match &deploy.build_logs {
+        Some(logs) if !logs.is_empty() => output::info(logs, None),
+        _ => {
+            let status = deploy.status.as_deref().unwrap_or("unknown");
+            let msg = match status {
+                "pending" | "building" => {
+                    "Build logs not yet available (deploy is still in progress)."
+                }
+                "failed" => "No build logs captured for this deploy.",
+                _ => "No build logs available.",
+            };
+            output::info(msg, None);
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod auth;
 pub mod billing;
 pub mod check;
 pub mod deploy;
+pub mod deploys;
 pub mod domains;
 pub mod env;
 pub mod github;


### PR DESCRIPTION
## Summary
- Adds `floo deploys list --app <name>` to view deploy history with columns: Deploy ID, Status, Triggered By, Commit, Created
- Adds `floo deploys logs <deploy-id> --app <name>` to retrieve build logs for a specific deploy
- Status-aware messages when logs are empty (in-progress vs failed vs completed)
- Adds `triggered_by` and `commit_sha` fields to `Deploy` struct
- Updates skill docs with new commands

## Test plan
- [x] `cargo test` passes (46 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean (pre-existing env.rs format issue only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)