### PR TITLE
[Feature] [#304] Resource limits + inline config model

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -18,140 +18,136 @@ pub fn check(path: PathBuf) {
         }
     };
 
-    let mut errors: Vec<serde_json::Value> = Vec::new();
-    let mut warnings: Vec<serde_json::Value> = Vec::new();
-    let mut services_info: Vec<serde_json::Value> = Vec::new();
-
-    // 1. Check floo.app.toml exists and parses
-    let app_config = match project_config::load_app_config(&project_path) {
-        Ok(Some(cfg)) => cfg,
-        Ok(None) => {
-            output::error(
-                &format!("{} not found.", project_config::APP_CONFIG_FILE),
-                &ErrorCode::ConfigInvalid,
-                Some("Run `floo init` to create config files."),
-            );
-            process::exit(1);
-        }
+    // Resolve config context
+    let resolved = match project_config::resolve_app_context(&project_path, None) {
+        Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, e.suggestion.as_deref());
             process::exit(1);
         }
     };
 
-    let app_name = &app_config.app.name;
+    let app_name = &resolved.app_name;
 
-    // 2. Check root floo.service.toml if present
-    let root_service = match project_config::load_service_config(&project_path) {
-        Ok(svc) => svc,
+    let mut errors: Vec<serde_json::Value> = Vec::new();
+    let mut warnings: Vec<serde_json::Value> = Vec::new();
+
+    // Discover services using the same logic as deploy
+    let services = match project_config::discover_services(&resolved) {
+        Ok(svcs) => svcs,
         Err(e) => {
-            errors.push(serde_json::json!({
-                "path": ".",
-                "message": e.message,
-            }));
-            None
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
         }
     };
 
-    // Track seen names for duplicate detection
+    // Validate each discovered service
     let mut seen_names: Vec<String> = Vec::new();
+    let mut services_info: Vec<serde_json::Value> = Vec::new();
 
-    if let Some(ref svc) = root_service {
-        // Validate app name match
-        if svc.app.name != *app_name {
+    for svc in &services {
+        // Validate service name
+        if let Err(msg) = validate_service_name(&svc.name) {
             errors.push(serde_json::json!({
-                "path": ".",
-                "message": format!(
-                    "Root {} declares app name '{}', but {} declares '{}'.",
-                    project_config::SERVICE_CONFIG_FILE,
-                    svc.app.name,
-                    project_config::APP_CONFIG_FILE,
-                    app_name,
-                ),
+                "path": svc.path,
+                "message": msg,
             }));
         }
 
-        validate_service(
-            &svc.service,
-            ".",
-            &project_path,
-            &mut errors,
-            &mut warnings,
-            &mut services_info,
-            &mut seen_names,
-        );
-    }
-
-    // 3. Check each service declared in app.toml with a path
-    for (svc_name, entry) in &app_config.services {
-        let Some(ref path_str) = entry.path else {
-            continue;
-        };
-
-        let normalized = path_str.strip_prefix("./").unwrap_or(path_str);
-        let normalized = normalized.strip_suffix('/').unwrap_or(normalized);
-
-        if normalized.is_empty() || normalized == "." {
-            continue; // root service, already checked
-        }
-
-        let svc_dir = project_path.join(normalized);
-
-        // Check directory exists
-        if !svc_dir.is_dir() {
+        // Check for duplicate names
+        if seen_names.contains(&svc.name) {
             errors.push(serde_json::json!({
-                "path": normalized,
-                "message": format!("Service '{svc_name}' path '{normalized}/' does not exist."),
+                "path": svc.path,
+                "message": format!("Duplicate service name '{}'.", svc.name),
             }));
-            continue;
+        } else {
+            seen_names.push(svc.name.clone());
         }
 
-        // Check floo.service.toml exists
-        let svc_config = match project_config::load_service_config(&svc_dir) {
-            Ok(Some(cfg)) => cfg,
-            Ok(None) => {
-                errors.push(serde_json::json!({
-                    "path": normalized,
-                    "message": format!(
-                        "No {} found at '{normalized}/' (declared as service '{svc_name}' in {}).",
-                        project_config::SERVICE_CONFIG_FILE,
-                        project_config::APP_CONFIG_FILE,
-                    ),
-                }));
-                continue;
+        // Validate port
+        if svc.port == 0 {
+            errors.push(serde_json::json!({
+                "path": svc.path,
+                "message": format!("Service '{}' has invalid port 0. Ports must be 1-65535.", svc.name),
+            }));
+        }
+
+        let svc_dir = project_path.join(&svc.path);
+
+        // Check env_file exists (for inline services, look at app config entry)
+        if let Some(ref app_cfg) = resolved.app_config {
+            if let Some(entry) = app_cfg.services.get(&svc.name) {
+                if let Some(ref env_file) = entry.env_file {
+                    let env_path = svc_dir.join(env_file);
+                    if !env_path.exists() {
+                        warnings.push(serde_json::json!({
+                            "path": svc.path,
+                            "message": format!("Service '{}' env_file '{env_file}' not found on disk.", svc.name),
+                        }));
+                    }
+                }
             }
-            Err(e) => {
-                errors.push(serde_json::json!({
-                    "path": normalized,
-                    "message": e.message,
-                }));
-                continue;
-            }
-        };
-
-        // Check app name match
-        if svc_config.app.name != *app_name {
-            errors.push(serde_json::json!({
-                "path": normalized,
-                "message": format!(
-                    "Service '{svc_name}' at '{normalized}/{}' declares app name '{}', but {} declares '{}'.",
-                    project_config::SERVICE_CONFIG_FILE,
-                    svc_config.app.name,
-                    project_config::APP_CONFIG_FILE,
-                    app_name,
-                ),
-            }));
         }
 
-        validate_service(
-            &svc_config.service,
-            normalized,
-            &project_path,
-            &mut errors,
-            &mut warnings,
-            &mut services_info,
-            &mut seen_names,
-        );
+        // Check Dockerfile EXPOSE matches port (best-effort)
+        let dockerfile = svc_dir.join("Dockerfile");
+        if dockerfile.exists() {
+            match std::fs::read_to_string(&dockerfile) {
+                Ok(content) => {
+                    for line in content.lines() {
+                        let trimmed = line.trim();
+                        if let Some(expose_val) = trimmed.strip_prefix("EXPOSE ") {
+                            let expose_val = expose_val.trim();
+                            let port_str = expose_val.split('/').next().unwrap_or(expose_val);
+                            if let Ok(exposed_port) = port_str.parse::<u16>() {
+                                if exposed_port != svc.port {
+                                    warnings.push(serde_json::json!({
+                                        "path": svc.path,
+                                        "message": format!(
+                                            "Service '{}' Dockerfile EXPOSE {exposed_port} does not match configured port {}.",
+                                            svc.name, svc.port
+                                        ),
+                                    }));
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    warnings.push(serde_json::json!({
+                        "path": svc.path,
+                        "message": format!(
+                            "Service '{}' Dockerfile exists but could not be read: {e}. Port check skipped.",
+                            svc.name
+                        ),
+                    }));
+                }
+            }
+        }
+
+        let mut svc_json = serde_json::json!({
+            "name": svc.name,
+            "path": svc.path,
+            "port": svc.port,
+            "type": svc.service_type.to_string(),
+            "ingress": svc.ingress.to_string(),
+        });
+
+        // Include resource fields when set
+        if let Some(ref cpu) = svc.cpu {
+            svc_json["cpu"] = serde_json::json!(cpu);
+        }
+        if let Some(ref memory) = svc.memory {
+            svc_json["memory"] = serde_json::json!(memory);
+        }
+        if let Some(max) = svc.max_instances {
+            svc_json["max_instances"] = serde_json::json!(max);
+        }
+        if let Some(ref domain) = svc.domain {
+            svc_json["domain"] = serde_json::json!(domain);
+        }
+
+        services_info.push(svc_json);
     }
 
     // Output results
@@ -166,6 +162,58 @@ pub fn check(path: PathBuf) {
             "warnings": warnings,
         }));
     } else {
+        // Architecture display
+        eprintln!();
+        eprintln!("  App: {app_name} ({} service{})", services.len(), if services.len() == 1 { "" } else { "s" });
+        eprintln!();
+
+        for svc in &services {
+            let path_label = if svc.path == "." {
+                String::new()
+            } else {
+                format!(" (./{path})", path = svc.path)
+            };
+            eprintln!("  {}{path_label}", svc.name);
+
+            let mut details = format!(
+                "    type: {}, port: {}, ingress: {}",
+                svc.service_type, svc.port, svc.ingress
+            );
+            if let Some(ref cpu) = svc.cpu {
+                details.push_str(&format!(", cpu: {cpu}"));
+            }
+            if let Some(ref memory) = svc.memory {
+                details.push_str(&format!(", memory: {memory}"));
+            }
+            if let Some(max) = svc.max_instances {
+                details.push_str(&format!(", max_instances: {max}"));
+            }
+            eprintln!("{details}");
+            eprintln!();
+        }
+
+        // Show global [resources] if present
+        if let Some(ref app_cfg) = resolved.app_config {
+            if let Some(ref res) = app_cfg.resources {
+                let has_any = res.cpu.is_some() || res.memory.is_some() || res.max_instances.is_some();
+                if has_any {
+                    eprintln!("  [resources] (global defaults)");
+                    let mut parts = Vec::new();
+                    if let Some(ref cpu) = res.cpu {
+                        parts.push(format!("cpu: {cpu}"));
+                    }
+                    if let Some(ref memory) = res.memory {
+                        parts.push(format!("memory: {memory}"));
+                    }
+                    if let Some(max) = res.max_instances {
+                        parts.push(format!("max_instances: {max}"));
+                    }
+                    eprintln!("    {}", parts.join(", "));
+                    eprintln!();
+                }
+            }
+        }
+
         if !warnings.is_empty() {
             for w in &warnings {
                 let msg = w.get("message").and_then(|v| v.as_str()).unwrap_or("");
@@ -197,99 +245,4 @@ pub fn check(path: PathBuf) {
     if !valid {
         process::exit(1);
     }
-}
-
-fn validate_service(
-    service: &project_config::ServiceSection,
-    path: &str,
-    project_path: &std::path::Path,
-    errors: &mut Vec<serde_json::Value>,
-    warnings: &mut Vec<serde_json::Value>,
-    services_info: &mut Vec<serde_json::Value>,
-    seen_names: &mut Vec<String>,
-) {
-    let name = &service.name;
-
-    // Validate service name
-    if let Err(msg) = validate_service_name(name) {
-        errors.push(serde_json::json!({
-            "path": path,
-            "message": msg,
-        }));
-    }
-
-    // Check for duplicate names
-    if seen_names.contains(name) {
-        errors.push(serde_json::json!({
-            "path": path,
-            "message": format!("Duplicate service name '{name}'."),
-        }));
-    } else {
-        seen_names.push(name.clone());
-    }
-
-    // Validate port
-    if service.port == 0 {
-        errors.push(serde_json::json!({
-            "path": path,
-            "message": format!("Service '{name}' has invalid port 0. Ports must be 1-65535."),
-        }));
-    }
-
-    // Check env_file exists
-    if let Some(ref env_file) = service.env_file {
-        let svc_dir = project_path.join(path);
-        let env_path = svc_dir.join(env_file);
-        if !env_path.exists() {
-            warnings.push(serde_json::json!({
-                "path": path,
-                "message": format!("Service '{name}' env_file '{env_file}' not found on disk."),
-            }));
-        }
-    }
-
-    // Check Dockerfile EXPOSE matches port (best-effort)
-    let svc_dir = project_path.join(path);
-    let dockerfile = svc_dir.join("Dockerfile");
-    if dockerfile.exists() {
-        match std::fs::read_to_string(&dockerfile) {
-            Ok(content) => {
-                for line in content.lines() {
-                    let trimmed = line.trim();
-                    if let Some(expose_val) = trimmed.strip_prefix("EXPOSE ") {
-                        let expose_val = expose_val.trim();
-                        // Handle EXPOSE port/protocol format
-                        let port_str = expose_val.split('/').next().unwrap_or(expose_val);
-                        if let Ok(exposed_port) = port_str.parse::<u16>() {
-                            if exposed_port != service.port {
-                                warnings.push(serde_json::json!({
-                                    "path": path,
-                                    "message": format!(
-                                        "Service '{name}' Dockerfile EXPOSE {exposed_port} does not match configured port {}.",
-                                        service.port
-                                    ),
-                                }));
-                            }
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                warnings.push(serde_json::json!({
-                    "path": path,
-                    "message": format!(
-                        "Service '{name}' Dockerfile exists but could not be read: {e}. Port check skipped."
-                    ),
-                }));
-            }
-        }
-    }
-
-    services_info.push(serde_json::json!({
-        "name": name,
-        "path": path,
-        "port": service.port,
-        "type": service.service_type.to_string(),
-        "ingress": service.resolved_ingress().to_string(),
-    }));
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -578,6 +578,9 @@ fn prompt_first_deploy(detection: &crate::detection::DetectionResult) -> FirstDe
             port,
             ingress: ServiceIngress::Public,
             domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
         },
     }
 }
@@ -598,6 +601,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
             env_file,
             domain: service.domain.clone(),
         },
+        resources: None,
     };
 
     let app_file = AppFileConfig {
@@ -605,6 +609,7 @@ fn write_first_deploy_configs(project_path: &Path, app_name: &str, service: &Ser
             name: app_name.to_string(),
             access_mode: None,
         },
+        resources: None,
         services: HashMap::new(),
         environments: HashMap::new(),
     };

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -93,6 +93,7 @@ fn init_non_interactive(
             env_file,
             domain: None,
         },
+        resources: None,
     };
 
     let app_file = AppFileConfig {
@@ -100,6 +101,7 @@ fn init_non_interactive(
             name: app_name.clone(),
             access_mode: None,
         },
+        resources: None,
         services: HashMap::new(),
         environments: HashMap::new(),
     };
@@ -216,66 +218,28 @@ fn init_interactive(
                 ServiceType::Web => AppServiceType::Web,
             };
 
-            // Only add to app.toml services map if path != "."
-            if svc_path != "." {
-                services_map.insert(
-                    svc_name.clone(),
-                    AppServiceEntry {
-                        service_type: app_service_type,
-                        path: Some(format!("./{svc_path}")),
-                        repo: None,
-                        version: None,
-                        plan: None,
-                        ingress: None,
-                        domain: None,
+            // Add inline service entry to app.toml
+            services_map.insert(
+                svc_name.clone(),
+                AppServiceEntry {
+                    service_type: app_service_type,
+                    path: if svc_path == "." {
+                        Some(".".to_string())
+                    } else {
+                        Some(format!("./{svc_path}"))
                     },
-                );
-            }
-
-            // Write floo.service.toml for first service (or root service)
-            if first_service_file.is_none() && svc_path == "." {
-                first_service_file = Some(ServiceFileConfig {
-                    app: ServiceFileAppSection {
-                        name: app_name.clone(),
-                        access_mode: None,
-                    },
-                    service: ServiceSection {
-                        name: svc_name.clone(),
-                        service_type,
-                        port,
-                        ingress: Some(ServiceIngress::Public),
-                        env_file: env_file.clone(),
-                        domain: None,
-                    },
-                });
-            } else {
-                // Write floo.service.toml in subdirectory
-                let svc_dir = project_path.join(&svc_path);
-                if svc_dir.is_dir() {
-                    let svc_file = ServiceFileConfig {
-                        app: ServiceFileAppSection {
-                            name: app_name.clone(),
-                            access_mode: None,
-                        },
-                        service: ServiceSection {
-                            name: svc_name.clone(),
-                            service_type,
-                            port,
-                            ingress: Some(ServiceIngress::Public),
-                            env_file: env_file.clone(),
-                            domain: None,
-                        },
-                    };
-                    if let Err(e) = project_config::write_service_config(&svc_dir, &svc_file) {
-                        output::error(&e.message, &e.code, None);
-                        process::exit(1);
-                    }
-                    output::info(
-                        &format!("Wrote {svc_path}/{}", project_config::SERVICE_CONFIG_FILE),
-                        None,
-                    );
-                }
-            }
+                    repo: None,
+                    version: None,
+                    plan: None,
+                    port: Some(port),
+                    ingress: Some(ServiceIngress::Public),
+                    env_file: env_file.clone(),
+                    domain: None,
+                    cpu: None,
+                    memory: None,
+                    max_instances: None,
+                },
+            );
 
             if !output::confirm("Add another service?") {
                 break;
@@ -302,6 +266,7 @@ fn init_interactive(
                 env_file,
                 domain: None,
             },
+            resources: None,
         });
     }
 
@@ -311,6 +276,7 @@ fn init_interactive(
             name: app_name.clone(),
             access_mode: None,
         },
+        resources: None,
         services: services_map,
         environments: HashMap::new(),
     };

--- a/src/commands/service_mgmt.rs
+++ b/src/commands/service_mgmt.rs
@@ -3,8 +3,7 @@ use std::process;
 use crate::errors::ErrorCode;
 use crate::output;
 use crate::project_config::{
-    self, validate_service_name, AppServiceEntry, AppServiceType, ServiceFileAppSection,
-    ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
+    self, validate_service_name, AppServiceEntry, AppServiceType, ServiceIngress, ServiceType,
 };
 
 pub fn add(
@@ -153,73 +152,38 @@ pub fn add(
 
     let env_file_val = env_file.map(|s| s.to_string());
 
-    let app_name = app_config.app.name.clone();
+    // Add inline service entry to floo.app.toml
+    let path_str = if path == "." {
+        ".".to_string()
+    } else if path.starts_with("./") {
+        path.to_string()
+    } else {
+        format!("./{path}")
+    };
 
-    // Add to floo.app.toml services map (only for non-root paths)
-    let normalized_path = if path == "." { None } else { Some(path) };
-
-    if let Some(p) = normalized_path {
-        let path_str = if p.starts_with("./") {
-            p.to_string()
-        } else {
-            format!("./{p}")
-        };
-        app_config.services.insert(
-            name.to_string(),
-            AppServiceEntry {
-                service_type: app_svc_type,
-                path: Some(path_str),
-                repo: None,
-                version: None,
-                plan: None,
-                ingress: None,
-                domain: None,
-            },
-        );
-    }
+    app_config.services.insert(
+        name.to_string(),
+        AppServiceEntry {
+            service_type: app_svc_type,
+            path: Some(path_str),
+            repo: None,
+            version: None,
+            plan: None,
+            port: Some(resolved_port),
+            ingress: Some(svc_ingress),
+            env_file: env_file_val.clone(),
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+        },
+    );
 
     // Write updated app config
     if let Err(e) = project_config::write_app_config(&cwd, &app_config) {
         output::error(&e.message, &e.code, None);
         process::exit(1);
     }
-
-    // Write floo.service.toml in the service's directory
-    let svc_dir = cwd.join(path);
-    if let Err(e) = std::fs::create_dir_all(&svc_dir) {
-        output::error(
-            &format!("Failed to create directory '{}': {e}", path),
-            &ErrorCode::FileError,
-            None,
-        );
-        process::exit(1);
-    }
-
-    let svc_file = ServiceFileConfig {
-        app: ServiceFileAppSection {
-            name: app_name,
-            access_mode: None,
-        },
-        service: ServiceSection {
-            name: name.to_string(),
-            service_type: svc_type,
-            port: resolved_port,
-            ingress: Some(svc_ingress),
-            env_file: env_file_val.clone(),
-            domain: None,
-        },
-    };
-
-    if let Err(e) = project_config::write_service_config(&svc_dir, &svc_file) {
-        output::error(&e.message, &e.code, None);
-        process::exit(1);
-    }
-
-    let svc_toml_path = if path == "." {
-        project_config::SERVICE_CONFIG_FILE.to_string()
-    } else {
-        format!("{path}/{}", project_config::SERVICE_CONFIG_FILE)
-    };
 
     output::success(
         &format!("Added service '{name}'."),
@@ -232,7 +196,6 @@ pub fn add(
             "env_file": env_file_val,
             "files_written": [
                 project_config::APP_CONFIG_FILE,
-                svc_toml_path,
             ],
         })),
     );

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -5,13 +5,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{ErrorCode, FlooError};
 
-use super::service_config::ServiceIngress;
+use super::service_config::{ResourceConfig, ServiceIngress};
 use super::SCHEMA_URL;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppFileConfig {
     pub app: AppFileAppSection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourceConfig>,
     #[serde(default)]
     pub services: HashMap<String, AppServiceEntry>,
     #[serde(default)]
@@ -65,9 +67,19 @@ pub struct AppServiceEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ingress: Option<ServiceIngress>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_instances: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -78,6 +90,12 @@ pub enum AppServiceType {
     Worker,
     Postgres,
     Redis,
+}
+
+impl AppServiceType {
+    pub fn is_user_managed(&self) -> bool {
+        matches!(self, Self::Web | Self::Api | Self::Worker)
+    }
 }
 
 pub fn load_app_config(dir: &Path) -> Result<Option<AppFileConfig>, FlooError> {
@@ -108,6 +126,9 @@ pub fn load_app_config(dir: &Path) -> Result<Option<AppFileConfig>, FlooError> {
 }
 
 fn validate_app_config(config: &AppFileConfig) -> Result<(), FlooError> {
+    // Detect inline mode: any user-managed service has `port` set
+    let has_inline = config.services.values().any(|e| e.port.is_some());
+
     for (name, entry) in &config.services {
         if entry.path.is_some() && entry.repo.is_some() {
             return Err(FlooError::with_suggestion(
@@ -118,6 +139,32 @@ fn validate_app_config(config: &AppFileConfig) -> Result<(), FlooError> {
                 ),
                 "Use 'path' for monorepo services or 'repo' for multi-repo services, not both.",
             ));
+        }
+
+        let is_user_managed = entry.service_type.is_user_managed();
+
+        // In inline mode, user-managed services require port and path
+        if has_inline && is_user_managed {
+            if entry.port.is_none() {
+                return Err(FlooError::with_suggestion(
+                    ErrorCode::InvalidProjectConfig,
+                    format!(
+                        "Service '{name}' in {} is missing 'port'. All user-managed services must declare a port in inline mode.",
+                        super::APP_CONFIG_FILE
+                    ),
+                    format!("Add port = <number> to [services.{name}]."),
+                ));
+            }
+            if entry.path.is_none() {
+                return Err(FlooError::with_suggestion(
+                    ErrorCode::InvalidProjectConfig,
+                    format!(
+                        "Service '{name}' in {} is missing 'path'. All user-managed services must declare a path in inline mode.",
+                        super::APP_CONFIG_FILE
+                    ),
+                    format!("Add path = \"./subdir\" to [services.{name}]."),
+                ));
+            }
         }
     }
     Ok(())
@@ -306,6 +353,7 @@ type = "mysql"
                 name: "roundtrip-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: HashMap::new(),
             environments: HashMap::new(),
         };
@@ -463,5 +511,81 @@ access_mode = "private"
 
         let err = load_app_config(dir.path()).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+    }
+
+    #[test]
+    fn test_load_app_config_inline_services_with_port() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[resources]
+cpu = "1"
+memory = "2Gi"
+
+[services.api]
+type = "api"
+path = "./backend"
+port = 8000
+ingress = "public"
+env_file = ".env"
+cpu = "2"
+max_instances = 5
+
+[services.web]
+type = "web"
+path = "./frontend"
+port = 3000
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.services.len(), 2);
+
+        let api = &config.services["api"];
+        assert_eq!(api.port, Some(8000));
+        assert_eq!(api.env_file.as_deref(), Some(".env"));
+        assert_eq!(api.cpu.as_deref(), Some("2"));
+        assert_eq!(api.max_instances, Some(5));
+
+        let web = &config.services["web"];
+        assert_eq!(web.port, Some(3000));
+        assert!(web.cpu.is_none());
+
+        let res = config.resources.unwrap();
+        assert_eq!(res.cpu.as_deref(), Some("1"));
+        assert_eq!(res.memory.as_deref(), Some("2Gi"));
+    }
+
+    #[test]
+    fn test_load_app_config_inline_requires_port_for_all_user_managed() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.api]
+type = "api"
+path = "./backend"
+port = 8000
+
+[services.web]
+type = "web"
+path = "./frontend"
+"#,
+        )
+        .unwrap();
+
+        // api has port, web doesn't — error
+        let err = load_app_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("web"));
+        assert!(err.message.contains("port"));
     }
 }

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -2,80 +2,94 @@ use std::collections::HashSet;
 
 use crate::errors::{ErrorCode, FlooError};
 
-use super::app_config::AppServiceType;
+use super::app_config::{AppServiceEntry, AppServiceType};
 use super::resolve::ResolvedApp;
-use super::service_config::{load_service_config, ServiceConfig, ServiceIngress};
+use super::service_config::{
+    load_service_config, ResourceConfig, ServiceConfig, ServiceIngress, ServiceType,
+};
 
 /// Discover all deployable services from resolved config files.
 ///
 /// Three branches:
-/// 1. `floo.app.toml` has user-managed services with `path` entries -> read each sub-service's
-///    `floo.service.toml` and include root service if present
-/// 2. Single `floo.service.toml` only (no app_config path entries) -> single service at "."
-/// 3. `floo.app.toml` only with no deployable services -> error
+/// 1. Inline mode: `floo.app.toml` has user-managed services with `port` fields —
+///    build ServiceConfig directly from app.toml entries (no floo.service.toml in subdirs)
+/// 2. Delegated mode (legacy): `floo.app.toml` has user-managed services with `path` but no `port` —
+///    read each sub-service's `floo.service.toml`
+/// 3. Single `floo.service.toml` only (no app_config user-managed entries) -> single service at "."
+/// 4. `floo.app.toml` only with no deployable services -> error
 pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, FlooError> {
-    let path_entries = user_managed_path_entries(resolved);
+    let inline_entries = inline_service_entries(resolved);
 
-    let services = if !path_entries.is_empty() {
-        // Branch 1: app.toml has user-managed services with path fields
-        let mut services = Vec::new();
-        let mut seen_names = HashSet::new();
-
-        // Include root floo.service.toml if present
-        if let Some(ref svc_file) = resolved.service_config {
-            let svc = svc_file.service.to_api_service_config(".");
-            seen_names.insert(svc.name.clone());
-            services.push(svc);
-        }
-
-        for (name, normalized_path) in &path_entries {
+    let services = if !inline_entries.is_empty() {
+        // Branch 1: Inline mode — build ServiceConfig directly from app.toml
+        // Error if floo.service.toml files exist in subdirs (enforce either/or)
+        for (name, normalized_path, _) in &inline_entries {
             let sub_dir = resolved.config_dir.join(normalized_path);
-            let svc_file = load_service_config(&sub_dir)?.ok_or_else(|| {
-                FlooError::with_suggestion(
-                    ErrorCode::ServiceConfigMissing,
-                    format!(
-                        "No {} found at '{normalized_path}/' (declared as service '{name}' in {}).",
-                        super::SERVICE_CONFIG_FILE,
-                        super::APP_CONFIG_FILE,
-                    ),
-                    format!(
-                        "Create {normalized_path}/{} with [app] and [service] sections.",
-                        super::SERVICE_CONFIG_FILE,
-                    ),
-                )
-            })?;
-
-            if svc_file.app.name != resolved.app_name {
+            if sub_dir.join(super::SERVICE_CONFIG_FILE).exists() {
                 return Err(FlooError::with_suggestion(
-                    ErrorCode::AppNameMismatch,
+                    ErrorCode::InvalidProjectConfig,
                     format!(
-                        "Service '{name}' at '{normalized_path}/{}' declares app name '{}', but {} declares '{}'.",
-                        super::SERVICE_CONFIG_FILE,
-                        svc_file.app.name,
+                        "Service '{name}' is defined inline in {} but '{normalized_path}/{}' also exists.",
                         super::APP_CONFIG_FILE,
-                        resolved.app_name,
+                        super::SERVICE_CONFIG_FILE,
                     ),
                     format!(
-                        "Set [app].name = \"{}\" in {normalized_path}/{}.",
-                        resolved.app_name,
+                        "Remove {normalized_path}/{} — inline services in {} don't use separate service files.",
                         super::SERVICE_CONFIG_FILE,
+                        super::APP_CONFIG_FILE,
                     ),
                 ));
             }
+        }
 
-            let mut svc = svc_file.service.to_api_service_config(normalized_path);
+        let global_resources = resolved
+            .app_config
+            .as_ref()
+            .and_then(|c| c.resources.as_ref());
 
-            // Let floo.app.toml override floo.service.toml values
-            if let Some(ref app_cfg) = resolved.app_config {
-                if let Some(entry) = app_cfg.services.get(name) {
-                    if let Some(override_ingress) = entry.ingress {
-                        svc.ingress = override_ingress;
-                    }
-                    if entry.domain.is_some() {
-                        svc.domain = entry.domain.clone();
-                    }
-                }
-            }
+        let mut services = Vec::new();
+        let mut seen_names = HashSet::new();
+
+        for (name, normalized_path, entry) in &inline_entries {
+            let service_type = match entry.service_type {
+                AppServiceType::Api => ServiceType::Api,
+                AppServiceType::Web => ServiceType::Web,
+                AppServiceType::Worker => ServiceType::Worker,
+                _ => continue,
+            };
+
+            let ingress = entry.ingress.unwrap_or(match service_type {
+                ServiceType::Worker => ServiceIngress::Internal,
+                _ => ServiceIngress::Public,
+            });
+
+            // port is guaranteed by validation
+            let port = entry.port.unwrap();
+
+            // Merge resources: per-service > global
+            let cpu = entry
+                .cpu
+                .clone()
+                .or_else(|| global_resources.and_then(|r| r.cpu.clone()));
+            let memory = entry
+                .memory
+                .clone()
+                .or_else(|| global_resources.and_then(|r| r.memory.clone()));
+            let max_instances = entry
+                .max_instances
+                .or_else(|| global_resources.and_then(|r| r.max_instances));
+
+            let svc = ServiceConfig {
+                name: name.clone(),
+                service_type,
+                path: normalized_path.clone(),
+                port,
+                ingress,
+                domain: entry.domain.clone(),
+                cpu,
+                memory,
+                max_instances,
+            };
 
             if !seen_names.insert(svc.name.clone()) {
                 return Err(FlooError::new(
@@ -91,22 +105,111 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
         }
 
         services
-    } else if let Some(ref svc_file) = resolved.service_config {
-        // Branch 2: single floo.service.toml only
-        vec![svc_file.service.to_api_service_config(".")]
     } else {
-        // Branch 3: app.toml only with no deployable services
-        return Err(FlooError::with_suggestion(
-            ErrorCode::NoDeployableServices,
-            format!(
-                "{} has no deployable services (only Floo-managed services like postgres/redis).",
-                super::APP_CONFIG_FILE,
-            ),
-            format!(
-                "Add a user-managed service with a 'path' field, or create a {} in your project root.",
-                super::SERVICE_CONFIG_FILE,
-            ),
-        ));
+        let delegated_entries = delegated_path_entries(resolved);
+        if !delegated_entries.is_empty() {
+            // Branch 2: Delegated mode (legacy) — read floo.service.toml from subdirs
+            let mut services = Vec::new();
+            let mut seen_names = HashSet::new();
+
+            // Include root floo.service.toml if present
+            if let Some(ref svc_file) = resolved.service_config {
+                let mut svc = svc_file.service.to_api_service_config(".");
+                apply_service_file_resources(&mut svc, &svc_file.resources, None);
+                seen_names.insert(svc.name.clone());
+                services.push(svc);
+            }
+
+            for (name, normalized_path) in &delegated_entries {
+                let sub_dir = resolved.config_dir.join(normalized_path);
+                let svc_file = load_service_config(&sub_dir)?.ok_or_else(|| {
+                    FlooError::with_suggestion(
+                        ErrorCode::ServiceConfigMissing,
+                        format!(
+                            "No {} found at '{normalized_path}/' (declared as service '{name}' in {}).",
+                            super::SERVICE_CONFIG_FILE,
+                            super::APP_CONFIG_FILE,
+                        ),
+                        format!(
+                            "Create {normalized_path}/{} with [app] and [service] sections, or add port/type fields inline in {}.",
+                            super::SERVICE_CONFIG_FILE,
+                            super::APP_CONFIG_FILE,
+                        ),
+                    )
+                })?;
+
+                if svc_file.app.name != resolved.app_name {
+                    return Err(FlooError::with_suggestion(
+                        ErrorCode::AppNameMismatch,
+                        format!(
+                            "Service '{name}' at '{normalized_path}/{}' declares app name '{}', but {} declares '{}'.",
+                            super::SERVICE_CONFIG_FILE,
+                            svc_file.app.name,
+                            super::APP_CONFIG_FILE,
+                            resolved.app_name,
+                        ),
+                        format!(
+                            "Set [app].name = \"{}\" in {normalized_path}/{}.",
+                            resolved.app_name,
+                            super::SERVICE_CONFIG_FILE,
+                        ),
+                    ));
+                }
+
+                let mut svc = svc_file.service.to_api_service_config(normalized_path);
+
+                // Let floo.app.toml override floo.service.toml values
+                if let Some(ref app_cfg) = resolved.app_config {
+                    if let Some(entry) = app_cfg.services.get(name) {
+                        if let Some(override_ingress) = entry.ingress {
+                            svc.ingress = override_ingress;
+                        }
+                        if entry.domain.is_some() {
+                            svc.domain = entry.domain.clone();
+                        }
+                    }
+                }
+
+                // Apply resources from floo.service.toml [resources]
+                let global_resources = resolved
+                    .app_config
+                    .as_ref()
+                    .and_then(|c| c.resources.as_ref());
+                apply_service_file_resources(&mut svc, &svc_file.resources, global_resources);
+
+                if !seen_names.insert(svc.name.clone()) {
+                    return Err(FlooError::new(
+                        ErrorCode::DuplicateServiceNames,
+                        format!(
+                            "Multiple services named '{}'. Service names must be unique.",
+                            svc.name,
+                        ),
+                    ));
+                }
+
+                services.push(svc);
+            }
+
+            services
+        } else if let Some(ref svc_file) = resolved.service_config {
+            // Branch 3: single floo.service.toml only
+            let mut svc = svc_file.service.to_api_service_config(".");
+            apply_service_file_resources(&mut svc, &svc_file.resources, None);
+            vec![svc]
+        } else {
+            // Branch 4: app.toml only with no deployable services
+            return Err(FlooError::with_suggestion(
+                ErrorCode::NoDeployableServices,
+                format!(
+                    "{} has no deployable services (only Floo-managed services like postgres/redis).",
+                    super::APP_CONFIG_FILE,
+                ),
+                format!(
+                    "Add a user-managed service with port/type/path fields, or create a {} in your project root.",
+                    super::SERVICE_CONFIG_FILE,
+                ),
+            ));
+        }
     };
 
     // Multi-service apps must have at least one public service
@@ -114,11 +217,36 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
         return Err(FlooError::with_suggestion(
             ErrorCode::NoPublicServices,
             "At least one service must have ingress 'public'. All services are currently set to 'internal'.",
-            "Set ingress = \"public\" on at least one service in its floo.service.toml, or override it in floo.app.toml.",
+            "Set ingress = \"public\" on at least one service in floo.app.toml or floo.service.toml.",
         ));
     }
 
     Ok(services)
+}
+
+/// Apply resources from floo.service.toml [resources], with optional global fallback.
+fn apply_service_file_resources(
+    svc: &mut ServiceConfig,
+    svc_resources: &Option<ResourceConfig>,
+    global_resources: Option<&ResourceConfig>,
+) {
+    if let Some(res) = svc_resources {
+        svc.cpu = res.cpu.clone();
+        svc.memory = res.memory.clone();
+        svc.max_instances = res.max_instances;
+    }
+    // Fall back to global for any fields still None
+    if let Some(global) = global_resources {
+        if svc.cpu.is_none() {
+            svc.cpu = global.cpu.clone();
+        }
+        if svc.memory.is_none() {
+            svc.memory = global.memory.clone();
+        }
+        if svc.max_instances.is_none() {
+            svc.max_instances = global.max_instances;
+        }
+    }
 }
 
 /// Filter services by name. Empty filter returns all.
@@ -149,9 +277,9 @@ pub fn filter_services(
         .collect())
 }
 
-/// Extract user-managed service entries with `path` fields from app_config, returning
-/// (service_name, normalized_path) pairs.
-fn user_managed_path_entries(resolved: &ResolvedApp) -> Vec<(String, String)> {
+/// Extract user-managed inline service entries (have `port` set) from app_config.
+/// Returns (service_name, normalized_path, &AppServiceEntry) triples.
+fn inline_service_entries(resolved: &ResolvedApp) -> Vec<(String, String, &AppServiceEntry)> {
     let Some(ref app_cfg) = resolved.app_config else {
         return Vec::new();
     };
@@ -160,11 +288,40 @@ fn user_managed_path_entries(resolved: &ResolvedApp) -> Vec<(String, String)> {
         .services
         .iter()
         .filter_map(|(name, entry)| {
+            // Inline mode: user-managed + has port
+            if !entry.service_type.is_user_managed() {
+                return None;
+            }
+            entry.port?; // must have port for inline mode
+            let raw = entry.path.as_deref().unwrap_or(".");
+            let normalized = normalize_path(raw);
+            let path = if normalized.is_empty() { ".".to_string() } else { normalized };
+            Some((name.clone(), path, entry))
+        })
+        .collect()
+}
+
+/// Extract user-managed service entries with `path` but no `port` (delegated/legacy mode).
+fn delegated_path_entries(resolved: &ResolvedApp) -> Vec<(String, String)> {
+    let Some(ref app_cfg) = resolved.app_config else {
+        return Vec::new();
+    };
+
+    // If any entry has port (inline mode), don't use delegated mode
+    let has_inline = app_cfg
+        .services
+        .values()
+        .any(|e| e.port.is_some() && e.service_type.is_user_managed());
+    if has_inline {
+        return Vec::new();
+    }
+
+    app_cfg
+        .services
+        .iter()
+        .filter_map(|(name, entry)| {
             let raw = entry.path.as_deref()?;
-            if !matches!(
-                entry.service_type,
-                AppServiceType::Web | AppServiceType::Api | AppServiceType::Worker
-            ) {
+            if !entry.service_type.is_user_managed() {
                 return None;
             }
             let normalized = normalize_path(raw);
@@ -240,6 +397,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
             },
+            resources: None,
         };
         let resolved = make_resolved(
             dir.path(),
@@ -285,8 +443,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
         services_map.insert(
@@ -297,8 +460,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -307,6 +475,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -353,6 +522,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
             },
+            resources: None,
         };
 
         // Sub-service
@@ -373,8 +543,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -383,6 +558,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -424,6 +600,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
             },
+            resources: None,
         };
 
         let mut services_map = HashMap::new();
@@ -435,8 +612,13 @@ ingress = "public"
                 repo: None,
                 version: Some("16".to_string()),
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
         services_map.insert(
@@ -447,8 +629,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -457,6 +644,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -492,8 +680,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -502,6 +695,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -540,8 +734,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -550,6 +749,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -586,6 +786,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
             },
+            resources: None,
         };
 
         // Sub-service also named "api"
@@ -606,8 +807,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -616,6 +822,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -646,8 +853,13 @@ ingress = "public"
                 repo: None,
                 version: Some("16".to_string()),
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -656,6 +868,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -693,8 +906,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -703,6 +921,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -730,6 +949,9 @@ ingress = "public"
                 port: 3000,
                 ingress: ServiceIngress::Public,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
             ServiceConfig {
                 name: "api".to_string(),
@@ -738,6 +960,9 @@ ingress = "public"
                 port: 8000,
                 ingress: ServiceIngress::Public,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         ];
 
@@ -755,6 +980,9 @@ ingress = "public"
                 port: 3000,
                 ingress: ServiceIngress::Public,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
             ServiceConfig {
                 name: "api".to_string(),
@@ -763,6 +991,9 @@ ingress = "public"
                 port: 8000,
                 ingress: ServiceIngress::Public,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         ];
 
@@ -781,6 +1012,9 @@ ingress = "public"
                 port: 3000,
                 ingress: ServiceIngress::Public,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
             ServiceConfig {
                 name: "api".to_string(),
@@ -789,6 +1023,9 @@ ingress = "public"
                 port: 8000,
                 ingress: ServiceIngress::Public,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         ];
 
@@ -826,6 +1063,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
             },
+            resources: None,
         };
 
         let mut services_map = HashMap::new();
@@ -837,8 +1075,13 @@ ingress = "public"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: Some(ServiceIngress::Internal),
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -847,6 +1090,7 @@ ingress = "public"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -910,8 +1154,13 @@ ingress = "internal"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
         services_map.insert(
@@ -922,8 +1171,13 @@ ingress = "internal"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -932,6 +1186,7 @@ ingress = "internal"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -979,8 +1234,13 @@ domain = "svc.example.com"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: Some("app.example.com".to_string()),
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -989,6 +1249,7 @@ domain = "svc.example.com"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -1037,8 +1298,13 @@ domain = "svc.example.com"
                 repo: None,
                 version: None,
                 plan: None,
+                port: None,
                 ingress: None,
+                env_file: None,
                 domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
             },
         );
 
@@ -1047,6 +1313,7 @@ domain = "svc.example.com"
                 name: "my-app".to_string(),
                 access_mode: None,
             },
+            resources: None,
             services: services_map,
             environments: HashMap::new(),
         };
@@ -1063,5 +1330,306 @@ domain = "svc.example.com"
         let api = services.iter().find(|s| s.name == "api").unwrap();
         // Domain from floo.service.toml should be preserved
         assert_eq!(api.domain.as_deref(), Some("svc.example.com"));
+    }
+
+    // --- Inline mode tests ---
+
+    #[test]
+    fn test_discover_inline_services_from_app_config() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        let frontend = dir.path().join("frontend");
+        fs::create_dir(&backend).unwrap();
+        fs::create_dir(&frontend).unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                port: Some(8000),
+                ingress: Some(ServiceIngress::Public),
+                env_file: None,
+                domain: None,
+                cpu: Some("2".to_string()),
+                memory: Some("4Gi".to_string()),
+                max_instances: Some(5),
+            },
+        );
+        services_map.insert(
+            "web".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Web,
+                path: Some("./frontend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                port: Some(3000),
+                ingress: None,
+                env_file: None,
+                domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            resources: None,
+            services: services_map,
+            environments: HashMap::new(),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 2);
+
+        let api = services.iter().find(|s| s.name == "api").unwrap();
+        assert_eq!(api.path, "backend");
+        assert_eq!(api.port, 8000);
+        assert_eq!(api.cpu.as_deref(), Some("2"));
+        assert_eq!(api.memory.as_deref(), Some("4Gi"));
+        assert_eq!(api.max_instances, Some(5));
+
+        let web = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.path, "frontend");
+        assert_eq!(web.port, 3000);
+        assert!(web.cpu.is_none());
+    }
+
+    #[test]
+    fn test_discover_inline_with_global_resources() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                port: Some(8000),
+                ingress: None,
+                env_file: None,
+                domain: None,
+                cpu: Some("4".to_string()), // per-service override
+                memory: None,               // will inherit global
+                max_instances: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            resources: Some(super::super::service_config::ResourceConfig {
+                cpu: Some("1".to_string()),
+                memory: Some("2Gi".to_string()),
+                max_instances: Some(3),
+            }),
+            services: services_map,
+            environments: HashMap::new(),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        let api = &services[0];
+        assert_eq!(api.cpu.as_deref(), Some("4"));       // per-service wins
+        assert_eq!(api.memory.as_deref(), Some("2Gi"));   // global fallback
+        assert_eq!(api.max_instances, Some(3));            // global fallback
+    }
+
+    #[test]
+    fn test_discover_inline_errors_when_service_toml_exists() {
+        let dir = TempDir::new().unwrap();
+
+        let backend = dir.path().join("backend");
+        fs::create_dir(&backend).unwrap();
+        // Create conflicting floo.service.toml in subdir
+        fs::write(
+            backend.join("floo.service.toml"),
+            make_service_toml("api", "my-app", "api", 8000),
+        )
+        .unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "api".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Api,
+                path: Some("./backend".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                port: Some(8000),
+                ingress: None,
+                env_file: None,
+                domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            resources: None,
+            services: services_map,
+            environments: HashMap::new(),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let err = discover_services(&resolved).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("inline"));
+    }
+
+    #[test]
+    fn test_discover_inline_worker_defaults_internal() {
+        let dir = TempDir::new().unwrap();
+
+        let worker_dir = dir.path().join("worker");
+        let web_dir = dir.path().join("web");
+        fs::create_dir(&worker_dir).unwrap();
+        fs::create_dir(&web_dir).unwrap();
+
+        let mut services_map = HashMap::new();
+        services_map.insert(
+            "bg".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Worker,
+                path: Some("./worker".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                port: Some(9000),
+                ingress: None, // should default to internal for workers
+                env_file: None,
+                domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
+            },
+        );
+        services_map.insert(
+            "web".to_string(),
+            AppServiceEntry {
+                service_type: AppServiceType::Web,
+                path: Some("./web".to_string()),
+                repo: None,
+                version: None,
+                plan: None,
+                port: Some(3000),
+                ingress: None, // should default to public
+                env_file: None,
+                domain: None,
+                cpu: None,
+                memory: None,
+                max_instances: None,
+            },
+        );
+
+        let app_config = AppFileConfig {
+            app: AppFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            resources: None,
+            services: services_map,
+            environments: HashMap::new(),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            None,
+            Some(app_config),
+            AppSource::AppFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        let worker = services.iter().find(|s| s.name == "bg").unwrap();
+        assert_eq!(worker.ingress, ServiceIngress::Internal);
+
+        let web = services.iter().find(|s| s.name == "web").unwrap();
+        assert_eq!(web.ingress, ServiceIngress::Public);
+    }
+
+    #[test]
+    fn test_single_service_with_resources() {
+        let dir = TempDir::new().unwrap();
+
+        let svc_file = ServiceFileConfig {
+            app: ServiceFileAppSection {
+                name: "my-app".to_string(),
+                access_mode: None,
+            },
+            service: ServiceSection {
+                name: "api".to_string(),
+                service_type: ServiceType::Api,
+                port: 8000,
+                ingress: Some(ServiceIngress::Public),
+                env_file: None,
+                domain: None,
+            },
+            resources: Some(super::super::service_config::ResourceConfig {
+                cpu: Some("2".to_string()),
+                memory: Some("4Gi".to_string()),
+                max_instances: Some(5),
+            }),
+        };
+
+        let resolved = make_resolved(
+            dir.path(),
+            "my-app",
+            Some(svc_file),
+            None,
+            AppSource::ServiceFile,
+        );
+
+        let services = discover_services(&resolved).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].cpu.as_deref(), Some("2"));
+        assert_eq!(services[0].memory.as_deref(), Some("4Gi"));
+        assert_eq!(services[0].max_instances, Some(5));
     }
 }

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -8,6 +8,19 @@ use crate::errors::{ErrorCode, FlooError};
 use super::app_config::AppAccessMode;
 use super::SCHEMA_URL;
 
+// --- Resource limits ---
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_instances: Option<u32>,
+}
+
 // --- API wire format (sent to the API as JSON) ---
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -21,6 +34,12 @@ pub struct ServiceConfig {
     pub ingress: ServiceIngress,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_instances: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
@@ -64,6 +83,8 @@ impl fmt::Display for ServiceIngress {
 pub struct ServiceFileConfig {
     pub app: ServiceFileAppSection,
     pub service: ServiceSection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourceConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -107,6 +128,9 @@ impl ServiceSection {
             port: self.port,
             ingress: self.resolved_ingress(),
             domain: self.domain.clone(),
+            cpu: None,
+            memory: None,
+            max_instances: None,
         }
     }
 }
@@ -277,6 +301,7 @@ ingress = "internal"
                 env_file: None,
                 domain: None,
             },
+            resources: None,
         };
 
         write_service_config(dir.path(), &config).unwrap();
@@ -314,6 +339,9 @@ ingress = "internal"
             port: 8000,
             ingress: ServiceIngress::Internal,
             domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["name"], "api");
@@ -507,6 +535,9 @@ port = 8000
             port: 8000,
             ingress: ServiceIngress::Public,
             domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(json.get("domain").is_none());
@@ -521,6 +552,9 @@ port = 8000
             port: 3000,
             ingress: ServiceIngress::Public,
             domain: Some("getfloo.com".to_string()),
+            cpu: None,
+            memory: None,
+            max_instances: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["domain"], "getfloo.com");
@@ -542,10 +576,99 @@ port = 8000
                 env_file: None,
                 domain: Some("getfloo.com".to_string()),
             },
+            resources: None,
         };
 
         write_service_config(dir.path(), &config).unwrap();
         let loaded = load_service_config(dir.path()).unwrap().unwrap();
         assert_eq!(loaded.service.domain.as_deref(), Some("getfloo.com"));
+    }
+
+    #[test]
+    fn test_load_service_config_with_resources() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+
+[resources]
+cpu = "2"
+memory = "4Gi"
+max_instances = 5
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        let res = config.resources.unwrap();
+        assert_eq!(res.cpu.as_deref(), Some("2"));
+        assert_eq!(res.memory.as_deref(), Some("4Gi"));
+        assert_eq!(res.max_instances, Some(5));
+    }
+
+    #[test]
+    fn test_load_service_config_without_resources() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert!(config.resources.is_none());
+    }
+
+    #[test]
+    fn test_service_config_json_resources_omitted_when_none() {
+        let config = ServiceConfig {
+            name: "api".to_string(),
+            service_type: ServiceType::Api,
+            path: ".".to_string(),
+            port: 8000,
+            ingress: ServiceIngress::Public,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(json.get("cpu").is_none());
+        assert!(json.get("memory").is_none());
+        assert!(json.get("max_instances").is_none());
+    }
+
+    #[test]
+    fn test_service_config_json_resources_included_when_set() {
+        let config = ServiceConfig {
+            name: "api".to_string(),
+            service_type: ServiceType::Api,
+            path: ".".to_string(),
+            port: 8000,
+            ingress: ServiceIngress::Public,
+            domain: None,
+            cpu: Some("2".to_string()),
+            memory: Some("4Gi".to_string()),
+            max_instances: Some(5),
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["cpu"], "2");
+        assert_eq!(json["memory"], "4Gi");
+        assert_eq!(json["max_instances"], 5);
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -831,8 +831,11 @@ fn test_service_add_creates_files() {
         .success()
         .stdout(predicate::str::contains(r#""name":"api"#));
 
-    // Verify service toml was created
-    assert!(project.path().join("api/floo.service.toml").exists());
+    // Verify inline service was added to app.toml (no floo.service.toml in subdirs)
+    assert!(!project.path().join("api/floo.service.toml").exists());
+    let app_toml = std::fs::read_to_string(project.path().join("floo.app.toml")).unwrap();
+    assert!(app_toml.contains("[services.api]"));
+    assert!(app_toml.contains("port = 8000"));
 }
 
 #[test]
@@ -938,7 +941,7 @@ path = "./api"
         .args(["--json", "check", project.path().to_str().unwrap()])
         .assert()
         .failure()
-        .stdout(predicate::str::contains(r#""valid":false"#));
+        .stdout(predicate::str::contains(r#""code":"SERVICE_CONFIG_MISSING""#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add CPU, memory, and max_instances resource configuration to CLI config model and wire format
- Support inline service definitions in `floo.app.toml` for monorepos — no more `floo.service.toml` in subdirs
- Enhanced `floo check` with architecture display showing service topology and resource values

Closes getfloo/floo#304
Closes getfloo/floo#305

## Changes

| File | What |
|------|------|
| `service_config.rs` | `ResourceConfig` struct, resource fields on `ServiceConfig` (API wire format) |
| `app_config.rs` | Inline fields (`port`, `env_file`, `cpu`, `memory`, `max_instances`), `is_user_managed()`, global `[resources]` |
| `discover.rs` | Inline discovery branch, lazy delegated fallback, `apply_service_file_resources()` |
| `check.rs` | Architecture display with type/port/ingress/resources per service, JSON mode |
| `init.rs` | Generates inline `[services.X]` in `floo.app.toml` for multi-service apps |
| `service_mgmt.rs` | `add()` creates inline entry instead of `floo.service.toml` in subdirs |
| `deploy.rs` | Resource field construction sites |
| `cli_tests.rs` | Updated assertions for inline mode |

### Config Model

Three valid configurations:
1. **Monorepo**: `floo.app.toml` with inline `[services.X]` (port, type, path, resources) — NO `floo.service.toml` in subdirs
2. **Multi-repo**: `floo.service.toml` per repo (legacy delegated mode preserved)
3. **Single-service**: Just `floo.service.toml` at root

Resource precedence: per-service fields > global `[resources]` > API defaults

## Test plan
- [x] 168 unit tests passing
- [x] 75 mock API tests passing
- [x] 46 integration tests passing (289 total)
- [x] 0 clippy warnings
- [x] Inline discovery, global resource merge, conflict detection, worker ingress defaults tested
- [x] `/simplify` review completed — all actionable findings fixed

## Discovered issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)