### PR TITLE
feat: add `floo images list` command and update contact email

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -744,6 +744,13 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    // --- Images ---
+
+    pub fn list_base_images(&self) -> Result<BaseImagesResponse, FlooApiError> {
+        let resp = self.get("/v1/images")?;
+        self.handle_response(resp)
+    }
+
     // --- Analytics ---
 
     pub fn get_app_analytics(

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -255,6 +255,21 @@ pub struct DatabaseInfo {
     pub schema_name: Option<String>,
 }
 
+// --- Images ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseImage {
+    pub short_name: String,
+    pub full_uri: String,
+    pub name: String,
+    pub tag: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseImagesResponse {
+    pub images: Vec<BaseImage>,
+}
+
 // --- Analytics ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,6 +105,10 @@ Examples:
     #[command(subcommand)]
     Domains(DomainsCommands),
 
+    /// List available Floo base Docker images.
+    #[command(subcommand)]
+    Images(ImagesCommands),
+
     /// Manage releases and promote to prod.
     #[command(subcommand)]
     Releases(ReleasesCommands),
@@ -475,6 +479,12 @@ pub enum ServicesCommands {
 }
 
 #[derive(Subcommand)]
+pub enum ImagesCommands {
+    /// List available Floo base Docker images.
+    List,
+}
+
+#[derive(Subcommand)]
 pub enum DomainsCommands {
     /// Add a custom domain to an app.
     Add {
@@ -832,6 +842,10 @@ pub fn run() {
                 name,
                 delete_config,
             } => commands::service_mgmt::rm(&name, delete_config),
+        },
+
+        Commands::Images(sub) => match sub {
+            ImagesCommands::List => commands::images::list(),
         },
 
         Commands::Domains(sub) => match sub {

--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -30,12 +30,12 @@ pub fn contact() {
         output::success(
             "",
             Some(serde_json::json!({
-                "email": "solutions@getfloo.com",
+                "email": "sales@getfloo.com",
                 "subject": "Enterprise inquiry",
             })),
         );
     } else {
-        eprintln!("  Enterprise & custom plans: solutions@getfloo.com");
+        eprintln!("  Enterprise & custom plans: sales@getfloo.com");
         eprintln!("  Subject: Enterprise inquiry");
     }
 }

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -232,6 +232,19 @@ fn command_tree() -> Vec<CommandInfo> {
             ],
         },
         CommandInfo {
+            name: "images",
+            description: "List available Floo base Docker images",
+            usage: "floo images list",
+            requires_auth: true,
+            subcommands: vec![CommandInfo {
+                name: "list",
+                description: "List available Floo base Docker images",
+                usage: "floo images list",
+                requires_auth: true,
+                subcommands: vec![],
+            }],
+        },
+        CommandInfo {
             name: "logs",
             description: "View runtime logs for an app",
             usage: "floo logs --app <name> [OPTIONS]",
@@ -479,6 +492,7 @@ mod tests {
             "docs",
             "domains",
             "env",
+            "images",
             "init",
             "logs",
             "orgs",

--- a/src/commands/images.rs
+++ b/src/commands/images.rs
@@ -1,0 +1,37 @@
+use std::process;
+
+use crate::errors::ErrorCode;
+use crate::output;
+
+pub fn list() {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let result = match client.list_base_images() {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success("Base images", Some(output::to_value(&result)));
+        return;
+    }
+
+    let rows: Vec<Vec<String>> = result
+        .images
+        .iter()
+        .map(|img| {
+            vec![
+                img.name.clone(),
+                img.tag.clone(),
+                img.short_name.clone(),
+                img.full_uri.clone(),
+            ]
+        })
+        .collect();
+
+    output::table(&["Name", "Tag", "Short Form", "Full URI"], &rows, None);
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod docs;
 pub mod domains;
 pub mod env;
 pub mod github;
+pub mod images;
 pub mod init;
 pub mod logs;
 pub mod orgs;


### PR DESCRIPTION
## Summary
- Add new `floo images list` subcommand that lists available Floo base Docker images via `GET /v1/images`, with JSON mode support
- Update enterprise contact email from `solutions@getfloo.com` to `sales@getfloo.com` in billing contact output

## Test plan
- [ ] Run `cargo build` to verify compilation
- [ ] Run `cargo test` to verify command_tree test passes with new `images` entry
- [ ] Run `cargo clippy -- -D warnings` for lint checks
- [ ] Verify `floo images list` returns expected output
- [ ] Verify `floo images list --json` returns structured JSON
- [ ] Verify `floo billing contact` shows updated email

🤖 Generated with [Claude Code](https://claude.com/claude-code)