### PR TITLE
feat: add FLOO_CONFIG_DIR env var for separate dev/prod configs

### DIFF
--- a/scripts/floo-dev
+++ b/scripts/floo-dev
@@ -12,4 +12,6 @@ if [[ ! -x "$DEV_BIN" ]]; then
     exit 1
 fi
 
+export FLOO_CONFIG_DIR="${FLOO_CONFIG_DIR:-$HOME/.floo-dev}"
+
 exec "$DEV_BIN" "$@"

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,8 +44,17 @@ impl FlooConfig {
     }
 }
 
+/// Returns the Floo config directory. Checks `FLOO_CONFIG_DIR` first,
+/// falls back to `$HOME/.floo`.
+pub(crate) fn config_dir() -> PathBuf {
+    if let Ok(dir) = env::var("FLOO_CONFIG_DIR") {
+        return PathBuf::from(dir);
+    }
+    dirs_home().join(CONFIG_DIR_NAME)
+}
+
 fn config_path() -> PathBuf {
-    dirs_home().join(CONFIG_DIR_NAME).join(CONFIG_FILE_NAME)
+    config_dir().join(CONFIG_FILE_NAME)
 }
 
 pub(crate) fn dirs_home() -> PathBuf {
@@ -185,5 +194,22 @@ mod tests {
         // (actual env manipulation in integration tests)
         let config = FlooConfig::default();
         assert_eq!(config.api_url, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn test_config_dir_env_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom_dir = tmp.path().join("custom-floo");
+        env::set_var("FLOO_CONFIG_DIR", &custom_dir);
+        let result = config_dir();
+        env::remove_var("FLOO_CONFIG_DIR");
+        assert_eq!(result, custom_dir);
+    }
+
+    #[test]
+    fn test_config_dir_fallback() {
+        env::remove_var("FLOO_CONFIG_DIR");
+        let result = config_dir();
+        assert!(result.ends_with(CONFIG_DIR_NAME));
     }
 }

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -8,7 +8,6 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
-use crate::constants::CONFIG_DIR_NAME;
 use crate::updater;
 
 const CACHE_TTL_SECS: u64 = 86_400; // 24 hours
@@ -54,12 +53,12 @@ fn now_secs() -> u64 {
 }
 
 fn floo_dir() -> Option<PathBuf> {
-    let home = config::dirs_home();
-    // dirs_home() falls back to "~" when HOME is unset; that's not a usable path
-    if home.as_os_str() == "~" {
+    let dir = config::config_dir();
+    // config_dir() falls back to "~/.floo" when HOME is unset; "~" is not a usable path
+    if dir.starts_with("~") {
         return None;
     }
-    Some(home.join(CONFIG_DIR_NAME))
+    Some(dir)
 }
 
 fn cache_path() -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

- Add `FLOO_CONFIG_DIR` env var to override the config directory (default `~/.floo`), enabling separate accounts for dev and prod installs on the same machine
- Extract `config_dir()` helper in `config.rs` and reuse it in `version_check.rs` so version cache and staged updates also respect the override
- Default `floo-dev` wrapper to `~/.floo-dev` so dev login doesn't clobber prod config

## Test plan

- [x] `cargo test` — all existing tests pass (3 pre-existing version string failures unrelated)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `floo whoami` uses `~/.floo/` config
- [ ] Manual: `FLOO_CONFIG_DIR=/tmp/floo-test floo whoami` uses `/tmp/floo-test/config.json`
- [ ] Manual: `./scripts/floo-dev login` creates `~/.floo-dev/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)