### PR TITLE
[Feature] Expose public base image URIs in the CLI

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -259,10 +259,10 @@ pub struct DatabaseInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseImage {
-    pub short_name: String,
-    pub full_uri: String,
     pub name: String,
     pub tag: String,
+    pub public_uri: String,
+    pub mirror_uri: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/commands/images.rs
+++ b/src/commands/images.rs
@@ -27,11 +27,15 @@ pub fn list() {
             vec![
                 img.name.clone(),
                 img.tag.clone(),
-                img.short_name.clone(),
-                img.full_uri.clone(),
+                img.public_uri.clone(),
+                img.mirror_uri.clone().unwrap_or_else(|| "-".to_owned()),
             ]
         })
         .collect();
 
-    output::table(&["Name", "Tag", "Short Form", "Full URI"], &rows, None);
+    output::table(
+        &["Name", "Tag", "Public URI", "Deploy Mirror URI"],
+        &rows,
+        None,
+    );
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -25,7 +25,7 @@ fn test_version() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("floo 0.1.0"));
+        .stdout(predicate::str::contains("floo 0.1.1"));
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn test_version_command_human() {
         .arg("version")
         .assert()
         .success()
-        .stderr(predicate::str::contains("floo 0.1.0"));
+        .stderr(predicate::str::contains("floo 0.1.1"));
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn test_version_command_json() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
-        .stdout(predicate::str::contains(r#""version":"0.1.0""#));
+        .stdout(predicate::str::contains(r#""version":"0.1.1""#));
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -257,6 +257,65 @@ fn test_apps_list_api_error() {
         .stdout(predicate::str::contains("INTERNAL_ERROR"));
 }
 
+// ───────────────────────── Images ─────────────────────────
+
+#[test]
+fn test_images_list_json() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m = server
+        .mock("GET", "/v1/images")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"images":[{"name":"floo-base-node","tag":"22","public_uri":"ghcr.io/getfloo/floo-base-node:22","mirror_uri":"us-central1-docker.pkg.dev/floo-prod/floo/floo-base-node:22"}]}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "images", "list"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""public_uri":"ghcr.io/getfloo/floo-base-node:22""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""mirror_uri":"us-central1-docker.pkg.dev/floo-prod/floo/floo-base-node:22""#,
+        ));
+}
+
+#[test]
+fn test_images_list_human() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m = server
+        .mock("GET", "/v1/images")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"images":[{"name":"floo-base-node","tag":"22","public_uri":"ghcr.io/getfloo/floo-base-node:22","mirror_uri":"us-central1-docker.pkg.dev/floo-prod/floo/floo-base-node:22"}]}"#,
+        )
+        .create();
+
+    floo()
+        .args(["images", "list"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Public URI"))
+        .stderr(predicate::str::contains("Deploy Mirror URI"))
+        .stderr(predicate::str::contains(
+            "ghcr.io/getfloo/floo-base-node:22",
+        ))
+        .stderr(predicate::str::contains(
+            "us-central1-docker.pkg.dev/floo-prod/floo/floo-base-node:22",
+        ));
+}
+
 // ───────────────────────── Env ─────────────────────────
 
 const TEST_SERVICE_ID: &str = "svc-uuid-1234";
@@ -801,7 +860,7 @@ ingress = "public"
 
 #[test]
 fn test_logs_no_config_no_app_errors() {
-    let mut server = Server::new();
+    let server = Server::new();
     let home = setup_config(&server);
 
     let project = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- align the CLI base-image types with the new `public_uri` and `mirror_uri` API contract
- update `floo images list` to show the public Dockerfile URI and deploy mirror URI
- add mock API coverage for the images command and refresh stale version assertions

## Testing
- `cargo fmt --check`
- `cargo test`