### PR TITLE
feat: handle WAITLISTED error in CLI auth flow

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -193,6 +193,15 @@ pub fn login(api_key: Option<&str>, force: bool) {
                 );
                 process::exit(1);
             }
+            Err(e) if e.code == "WAITLISTED" => {
+                spinner.finish();
+                output::error(
+                    "You're on the waitlist! We'll email you when your account is ready.",
+                    &ErrorCode::Waitlisted,
+                    None,
+                );
+                process::exit(1);
+            }
             Err(e) if e.status_code == 0 => {
                 // Network error — retry up to 3 times
                 network_retries += 1;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,6 +60,7 @@ pub enum ErrorCode {
     StreamError,
     UnknownService,
     UnsupportedPlatform,
+    Waitlisted,
     UpdateHttpClientError,
     UpdateInstallFailed,
     UpdateInstallPathUnresolved,
@@ -128,6 +129,7 @@ impl ErrorCode {
             ErrorCode::StreamError => "STREAM_ERROR",
             ErrorCode::UnknownService => "UNKNOWN_SERVICE",
             ErrorCode::UnsupportedPlatform => "UNSUPPORTED_PLATFORM",
+            ErrorCode::Waitlisted => "WAITLISTED",
             ErrorCode::UpdateHttpClientError => "UPDATE_HTTP_CLIENT_ERROR",
             ErrorCode::UpdateInstallFailed => "UPDATE_INSTALL_FAILED",
             ErrorCode::UpdateInstallPathUnresolved => "UPDATE_INSTALL_PATH_UNRESOLVED",
@@ -198,6 +200,7 @@ impl ErrorCode {
             "STREAM_ERROR" => ErrorCode::StreamError,
             "UNKNOWN_SERVICE" => ErrorCode::UnknownService,
             "UNSUPPORTED_PLATFORM" => ErrorCode::UnsupportedPlatform,
+            "WAITLISTED" => ErrorCode::Waitlisted,
             "UPDATE_HTTP_CLIENT_ERROR" => ErrorCode::UpdateHttpClientError,
             "UPDATE_INSTALL_FAILED" => ErrorCode::UpdateInstallFailed,
             "UPDATE_INSTALL_PATH_UNRESOLVED" => ErrorCode::UpdateInstallPathUnresolved,
@@ -368,6 +371,7 @@ mod tests {
             ErrorCode::UpdateInstallFailed,
             ErrorCode::UpdateInstallPathUnresolved,
             ErrorCode::UpdatePermissionDenied,
+            ErrorCode::Waitlisted,
         ];
         for variant in &variants {
             assert_eq!(


### PR DESCRIPTION
## Summary
- Add `WAITLISTED` error code to `ErrorCode` enum
- Handle 403 WAITLISTED response in device token polling flow
- Display friendly message and exit cleanly (code 1) in both human and JSON modes

## Test plan
- [ ] `cargo test` passes
- [ ] Manual: attempt `floo auth login` with a waitlisted account → see "You're on the waitlist!" message
- [ ] JSON mode outputs `{"success": false, "error": "WAITLISTED", "message": "..."}`

Depends on getfloo/floo#PR (closed beta waitlist API changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)