### PR TITLE
[Fix] Derive CLI version from git tag at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FLOO_RELEASE_VERSION: ${{ github.ref_name }}
 
 jobs:
   build:

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,11 @@
 fn main() {
-    println!("cargo:rustc-env=FLOO_VERSION={}", env!("CARGO_PKG_VERSION"));
+    // Re-run build.rs if this env var changes (needed for cargo caching).
+    println!("cargo:rerun-if-env-changed=FLOO_RELEASE_VERSION");
+
+    // Prefer FLOO_RELEASE_VERSION (set by CI from the git tag) over Cargo.toml version.
+    // This ensures the compiled binary reports the correct release version.
+    let version = std::env::var("FLOO_RELEASE_VERSION")
+        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+    let version = version.strip_prefix('v').unwrap_or(&version);
+    println!("cargo:rustc-env=FLOO_VERSION={version}");
 }


### PR DESCRIPTION
## Summary
- `build.rs` now reads `FLOO_RELEASE_VERSION` env var (set by CI from the git tag) instead of hardcoded `Cargo.toml` version
- `floo --version` and `floo version` now report the actual release version
- Falls back to `Cargo.toml` for local dev builds

## Test plan
- [x] `FLOO_RELEASE_VERSION=v0.1.7 cargo run -- --version` → `floo 0.1.7`
- [x] `cargo run -- version` (no env var) → `floo 0.1.1` (Cargo.toml fallback)
- [x] All 48 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)