### PR TITLE
[Fix] Sync embedded skills + show already-latest on update

### DIFF
--- a/plugin/skills/floo-security/SKILL.md
+++ b/plugin/skills/floo-security/SKILL.md
@@ -74,7 +74,9 @@ except Exception:
 
 ## Authentication & Sessions
 
-**Rules:**
+**Floo managed auth:** If the app uses `access_mode = "accounts"`, floo handles authentication via hosted OAuth — no custom password hashing or auth implementation is needed. Use floo's JWT tokens (verified via JWKS) for session management.
+
+**Rules (for apps implementing their own auth outside floo):**
 - Set `HttpOnly`, `Secure`, `SameSite=Lax` on all authentication cookies
 - NEVER store auth tokens in `localStorage` — use `HttpOnly` cookies
 - Validate JWTs on the server side — never trust client-side token claims

--- a/plugin/skills/floo-services/SKILL.md
+++ b/plugin/skills/floo-services/SKILL.md
@@ -10,9 +10,22 @@ description: >
 
 Floo provisions and manages Postgres, Redis, and Storage as platform services. All credentials are delivered as environment variables — never hardcode them.
 
+## How to Provision
+
+Managed services are declared in `floo.app.toml` and auto-provisioned on the first deploy.
+
+**There is no CLI command to imperatively provision a managed service.** `floo services add <name> <path>` adds a *user-managed* service (web/api/worker) to config — it does NOT provision databases.
+
 ## Postgres (Managed)
 
-**Provision:** `floo services add postgres --app my-app` (optionally `--tier basic|standard|performance`)
+**Declare in `floo.app.toml`:**
+
+```toml
+[postgres]
+tier = "basic"    # optional, defaults to basic
+```
+
+Then deploy — Floo auto-provisions on first deploy.
 
 **What happens:**
 - Floo creates a dedicated schema and role on the managed Postgres instance
@@ -51,7 +64,13 @@ let database_url = std::env::var("DATABASE_URL")?;
 
 ## Redis (Managed)
 
-**Provision:** `floo services add redis --app my-app`
+**Declare in `floo.app.toml`:**
+
+```toml
+[redis]
+```
+
+Then deploy — Floo auto-provisions on first deploy.
 
 **What happens:**
 - Floo provisions a dedicated Redis instance via Upstash (serverless Redis)
@@ -79,15 +98,74 @@ const redisUrl = process.env.REDIS_URL;
 
 ## Storage (Managed)
 
-**Provision:** `floo services add storage --app my-app`
+**Declare in `floo.app.toml`:**
+
+```toml
+[storage]
+```
+
+Then deploy — Floo auto-provisions on first deploy.
 
 **What happens:**
-- Floo creates a GCS bucket scoped to your app
+- Floo creates a storage bucket scoped to your app
 - Access is via signed URLs — no direct bucket credentials in your app
 
-**Env vars created:** `STORAGE_BUCKET` — the bucket name.
+**Env vars created:**
+- `STORAGE_BUCKET` — the bucket name
+- `STORAGE_URL` — the signed URL API endpoint for uploads/downloads
 
-**How to upload/download:** Use Floo's signed URL API endpoint, not direct GCS access. The signed URL is time-limited and scoped to a specific object path.
+**How to upload/download:** Use `STORAGE_URL` to request signed URLs. Do NOT access the bucket directly.
+
+**Signed URL endpoint** (value of `STORAGE_URL`):
+
+```
+POST {STORAGE_URL}
+```
+
+Request body:
+```json
+{
+  "method": "PUT",
+  "object_path": "uploads/photo.jpg",
+  "expiration_seconds": 3600,
+  "content_type": "image/jpeg"
+}
+```
+
+Response:
+```json
+{
+  "url": "https://storage.googleapis.com/...",
+  "method": "PUT",
+  "expires_in_seconds": 3600,
+  "object_path": "uploads/photo.jpg",
+  "bucket": "floo-app-..."
+}
+```
+
+Upload example (using STORAGE_URL env var):
+```bash
+# 1. Get a signed upload URL
+curl -X POST "$STORAGE_URL" \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"method": "PUT", "object_path": "uploads/photo.jpg", "expiration_seconds": 3600}'
+
+# 2. Upload directly to the signed URL
+curl -X PUT "<signed_url>" -H "Content-Type: image/jpeg" --data-binary @photo.jpg
+```
+
+Download example:
+```bash
+# 1. Get a signed download URL
+curl -X POST "$STORAGE_URL" \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"method": "GET", "object_path": "uploads/photo.jpg", "expiration_seconds": 3600}'
+
+# 2. Download from the signed URL
+curl "<signed_url>" -o photo.jpg
+```
 
 **Rules:**
 - NEVER store GCP service account keys in your application

--- a/plugin/skills/floo/SKILL.md
+++ b/plugin/skills/floo/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: floo
-description: >
-  Floo deployment platform CLI. Use when working in a project with
-  floo.app.toml or floo.service.toml, or when the user mentions Floo,
-  deploying with Floo, or using floo commands.
+description: Floo CLI command reference and patterns. Use when running floo commands, writing CLI integrations, debugging CLI behavior, or when the user mentions floo deploy, floo init, floo logs, floo env, or any floo subcommand.
+user-invocable: false
 ---
 
 # Floo CLI
@@ -12,10 +10,20 @@ Floo deploys web apps from the terminal. All management happens through `floo` c
 
 ## Getting Started
 
-1. `floo auth login --api-key <key>` — authenticate (use `--api-key` for non-interactive/CI; omit for browser flow)
-2. `floo init <app-name>` — scaffold config files in the current directory
-3. `floo deploy` — detect runtime, build, deploy
+1. `floo auth login` — authenticate (or `--api-key <key>` for CI)
+2. `floo init <app-name>` — scaffold config files (local only, no API call)
+3. `floo apps github connect owner/repo` — connect to GitHub and trigger first deploy
 4. `floo apps status <name>` — see your app's URL and status
+
+After the first deploy, use `floo deploy` for subsequent deploys. All source comes from GitHub — the CLI never uploads code.
+
+## How Deploys Work
+
+`floo deploy` sends metadata to the API. The API pulls source from GitHub, builds a container via Cloud Build, and deploys to Cloud Run. GitHub must be connected first (`floo apps github connect`).
+
+- `floo init` creates local config files only — no app is registered on the platform
+- `floo deploy` auto-creates the app if it doesn't exist, but requires GitHub to be connected
+- `floo apps github connect` connects GitHub and triggers the first deploy by default (use `--no-deploy` to skip)
 
 ## Config Files
 
@@ -88,18 +96,7 @@ floo env set DB_URL=... --app my-app --restart         # set and restart
 floo env list --app my-app --json                      # list all vars
 floo env import .env --app my-app                      # import from file
 floo env remove SECRET --app my-app                    # remove a var
-floo env set KEY=VAL --app my-app --services backend   # target a specific service
-```
-
-### Deploy Management
-
-```bash
-floo deploy list --app my-app                      # deploy history
-floo deploy logs <deploy-id> --app my-app          # build logs
-floo deploy watch --app my-app                     # stream progress
-floo deploy rollback my-app <deploy-id>            # rollback
-floo deploy --restart --app my-app                 # restart without rebuild
-floo deploy --services api --app my-app            # deploy specific service
+floo env set KEY=VAL --app my-app --services backend   # target a specific service (multi-service apps)
 ```
 
 ### Logs and Debugging
@@ -111,23 +108,21 @@ floo logs --app my-app --live                      # stream real-time
 floo logs --app my-app --search "panic" --json     # search + JSON
 ```
 
+### Deploy Management
+
+```bash
+floo deploy list --app my-app                      # deploy history
+floo deploy logs <deploy-id> --app my-app          # build logs
+floo deploy watch --app my-app                     # stream progress
+floo deploy rollback my-app <deploy-id>            # rollback
+floo deploy --restart --app my-app                 # restart without re-upload
+floo deploy --services api --app my-app            # deploy specific service
+```
+
 ### Custom Domains
 
 ```bash
 floo domains add app.example.com --app my-app                       # single-service app
-floo domains add app.example.com --app my-app --services frontend   # target a specific service
+floo domains add app.example.com --app my-app --services frontend   # target a specific service (multi-service)
 floo domains list --app my-app
 ```
-
-### Managed Services
-
-```bash
-floo services add postgres --app my-app            # add managed Postgres
-floo services add redis --app my-app               # add managed Redis
-floo services add storage --app my-app             # add managed Storage
-floo services list --app my-app                    # list services + status
-floo services info <service-id> --app my-app       # service details
-floo services rm <service-id> --app my-app         # remove a service
-```
-
-See the `floo-services` skill for detailed managed service usage and the `floo-security` skill for security rules.

--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -1,13 +1,29 @@
+---
+name: floo
+description: Floo CLI command reference and patterns. Use when running floo commands, writing CLI integrations, debugging CLI behavior, or when the user mentions floo deploy, floo init, floo logs, floo env, or any floo subcommand.
+user-invocable: false
+---
+
 # Floo CLI
 
 Floo deploys web apps from the terminal. All management happens through `floo` commands.
 
 ## Getting Started
 
-1. `floo auth login --api-key <key>` — authenticate (use `--api-key` for non-interactive/CI; omit for browser flow)
-2. `floo init <app-name>` — scaffold config files in the current directory
-3. `floo deploy` — detect runtime, archive source, build, deploy
+1. `floo auth login` — authenticate (or `--api-key <key>` for CI)
+2. `floo init <app-name>` — scaffold config files (local only, no API call)
+3. `floo apps github connect owner/repo` — connect to GitHub and trigger first deploy
 4. `floo apps status <name>` — see your app's URL and status
+
+After the first deploy, use `floo deploy` for subsequent deploys. All source comes from GitHub — the CLI never uploads code.
+
+## How Deploys Work
+
+`floo deploy` sends metadata to the API. The API pulls source from GitHub, builds a container via Cloud Build, and deploys to Cloud Run. GitHub must be connected first (`floo apps github connect`).
+
+- `floo init` creates local config files only — no app is registered on the platform
+- `floo deploy` auto-creates the app if it doesn't exist, but requires GitHub to be connected
+- `floo apps github connect` connects GitHub and triggers the first deploy by default (use `--no-deploy` to skip)
 
 ## Config Files
 
@@ -110,13 +126,3 @@ floo domains add app.example.com --app my-app                       # single-ser
 floo domains add app.example.com --app my-app --services frontend   # target a specific service (multi-service)
 floo domains list --app my-app
 ```
-
-## Full Plugin
-
-For comprehensive managed services documentation and security rules, install the Floo plugin:
-
-```bash
-claude plugin install getfloo/floo-cli/plugin
-```
-
-The plugin includes three skills: platform CLI usage, managed services (Postgres, Redis, Storage), and security patterns for deployed applications.

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -36,6 +36,22 @@ pub fn update(version: Option<&str>) {
                 })),
             );
         }
+        Err(err) if err.code == crate::errors::ErrorCode::AlreadyUpToDate => {
+            let refreshed = super::skills::refresh_skill_files();
+            if !output::is_json_mode() {
+                for path in &refreshed {
+                    eprintln!("  Refreshed agent skill at {path}");
+                }
+            }
+            output::success(
+                &err.message,
+                Some(serde_json::json!({
+                    "version": crate::constants::VERSION,
+                    "already_latest": true,
+                    "refreshed_skills": refreshed,
+                })),
+            );
+        }
         Err(err) => {
             output::error(&err.message, &err.code, err.suggestion.as_deref());
             process::exit(1);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ErrorCode {
+    AlreadyUpToDate,
     AppNameMismatch,
     AppNotFound,
     ChecksumMismatch,
@@ -71,6 +72,7 @@ pub enum ErrorCode {
 impl ErrorCode {
     pub fn as_str(&self) -> &str {
         match self {
+            ErrorCode::AlreadyUpToDate => "ALREADY_UP_TO_DATE",
             ErrorCode::AppNameMismatch => "APP_NAME_MISMATCH",
             ErrorCode::AppNotFound => "APP_NOT_FOUND",
             ErrorCode::ChecksumMismatch => "CHECKSUM_MISMATCH",
@@ -142,6 +144,7 @@ impl ErrorCode {
     /// Unknown codes become Other(s.to_string()).
     pub fn from_api(s: &str) -> Self {
         match s {
+            "ALREADY_UP_TO_DATE" => ErrorCode::AlreadyUpToDate,
             "APP_NAME_MISMATCH" => ErrorCode::AppNameMismatch,
             "APP_NOT_FOUND" => ErrorCode::AppNotFound,
             "CHECKSUM_MISMATCH" => ErrorCode::ChecksumMismatch,
@@ -309,6 +312,7 @@ mod tests {
     #[test]
     fn test_from_api_roundtrip_all_variants() {
         let variants = [
+            ErrorCode::AlreadyUpToDate,
             ErrorCode::AppNameMismatch,
             ErrorCode::AppNotFound,
             ErrorCode::ChecksumMismatch,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -329,6 +329,16 @@ fn run_update_with(
     let release_json = fetch_release_json(client, api_base, version)?;
     let release_asset = release_asset_from_json(&release_json, &asset_name)?;
 
+    // Skip download if already on this version (unless a specific version was requested)
+    let current = crate::constants::VERSION;
+    let remote = release_asset.version.strip_prefix('v').unwrap_or(&release_asset.version);
+    if version.is_none() && remote == current {
+        return Err(FlooError::new(
+            ErrorCode::AlreadyUpToDate,
+            format!("floo {current} is already the latest version."),
+        ));
+    }
+
     let binary_bytes = download_bytes(client, &release_asset.binary_url)?;
     let checksum_bytes = download_bytes(client, &release_asset.checksum_url)?;
     let expected_checksum = parse_checksum(&String::from_utf8_lossy(&checksum_bytes))?;


### PR DESCRIPTION
## Summary
- Sync all 4 SKILL.md files from monorepo (fixes stale agent docs that have persisted through v0.1.5-v0.1.9)
- Add `AlreadyUpToDate` check: skip re-download when already on latest version
- Show "floo X.Y.Z is already the latest version" instead of silently re-installing

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verified in compiled binary: "github connect" present, "archive source" absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)