### PR TITLE
[Fix] Remove directory dependencies from CLI commands when --app provided

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -851,6 +851,22 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn rebuild_app(
+        &self,
+        app_id: &str,
+        runtime: &str,
+        services: Option<&[String]>,
+    ) -> Result<Deploy, FlooApiError> {
+        let mut body = serde_json::json!({
+            "runtime": runtime,
+        });
+        if let Some(svcs) = services {
+            body["services_filter"] = serde_json::to_value(svcs).unwrap_or_default();
+        }
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/deploys"), &body)?;
+        self.handle_response(resp)
+    }
+
     pub fn list_releases(
         &self,
         app_id: &str,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,19 +81,18 @@ Examples:
         services: Vec<String>,
     },
 
-    /// Force a redeploy (after env var changes, config updates, or to restart).
+    /// Force a redeploy (after env var changes, config updates, or to rebuild).
     #[command(after_help = "\
 Examples:
-  floo redeploy                            Redeploy current directory
-  floo redeploy --app my-app               Redeploy a specific app
-  floo redeploy --restart                  Restart containers without rebuilding
-  floo redeploy --sync-env                 Re-sync env vars before redeploying
+  floo redeploy --app my-app               Redeploy with fresh env vars (no rebuild)
+  floo redeploy --app my-app --rebuild     Force a full rebuild from latest commit
+  floo redeploy                            Redeploy from current project directory
   floo redeploy --services api             Redeploy specific services only
 
-Note: The primary way to deploy is `git push`. Use `floo redeploy` only
-when you need to trigger a build without a code change.")]
+Note: The primary way to deploy is `git push`. Use `floo redeploy` when you
+need to apply env var changes or force a rebuild without a code change.")]
     Redeploy {
-        /// Project directory.
+        /// Project directory (only needed when --app is not provided).
         #[arg(default_value = ".")]
         path: PathBuf,
 
@@ -105,9 +104,9 @@ when you need to trigger a build without a code change.")]
         #[arg(short, long = "services")]
         services: Vec<String>,
 
-        /// Restart the app without rebuilding (redeploy existing images with fresh env vars).
+        /// Force a full rebuild from the latest commit (re-download source and run Cloud Build).
         #[arg(long)]
-        restart: bool,
+        rebuild: bool,
 
         /// Re-sync env vars from configured env_file before deploying.
         #[arg(long)]
@@ -900,9 +899,9 @@ pub fn run() {
             path,
             app,
             services,
-            restart,
+            rebuild,
             sync_env,
-        } => commands::deploy::deploy(path, app, services, restart, sync_env),
+        } => commands::deploy::deploy(path, app, services, rebuild, sync_env),
 
         Commands::Deploys(sub) => match sub {
             DeploysSubcommands::List { app } => commands::deploys::list(app.as_deref()),

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -31,8 +31,8 @@ fn command_tree() -> Vec<CommandInfo> {
         },
         CommandInfo {
             name: "redeploy",
-            description: "Force a redeploy (after env var changes, config updates, or to restart). The primary deploy path is git push.",
-            usage: "floo redeploy [PATH] [--app <name>] [--restart] [--sync-env] [--services <name>]",
+            description: "Force a redeploy (after env var changes, config updates, or to rebuild). The primary deploy path is git push.",
+            usage: "floo redeploy [PATH] [--app <name>] [--rebuild] [--sync-env] [--services <name>]",
             requires_auth: true,
             subcommands: vec![],
         },

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -186,11 +186,24 @@ pub fn deploy(
     path: PathBuf,
     app: Option<String>,
     services_filter: Vec<String>,
-    restart: bool,
+    rebuild: bool,
     sync_env: bool,
 ) {
-    // --- Restart path: skip detection, needs auth upfront ---
-    if restart {
+    // --- Path 1 & 2: --app flag provided — no local directory needed ---
+    if let Some(ref app_name) = app {
+        // Dry-run exits early — no auth or API calls needed
+        if output::is_dry_run_mode() {
+            let action = if rebuild { "rebuild" } else { "restart" };
+            let service_names: Vec<&str> =
+                services_filter.iter().map(|s| s.as_str()).collect();
+            output::dry_run_success(serde_json::json!({
+                "action": action,
+                "app": app_name,
+                "services": service_names,
+            }));
+            return;
+        }
+
         let config = load_config();
         if config.api_key.is_none() {
             output::error(
@@ -201,44 +214,13 @@ pub fn deploy(
             process::exit(1);
         }
 
-        let app_ident = match app.as_deref() {
-            Some(a) => a.to_string(),
-            None => {
-                let cwd = std::env::current_dir().unwrap_or_else(|e| {
-                    output::error(
-                        &format!("Failed to read current directory: {e}"),
-                        &ErrorCode::FileError,
-                        None,
-                    );
-                    process::exit(1);
-                });
-                match project_config::resolve_app_context(&cwd, None) {
-                    Ok(r) => r.app_name,
-                    Err(e) => {
-                        output::error(&e.message, &e.code, e.suggestion.as_deref());
-                        process::exit(1);
-                    }
-                }
-            }
-        };
-
-        if output::is_dry_run_mode() {
-            let service_names: Vec<&str> = services_filter.iter().map(|s| s.as_str()).collect();
-            output::dry_run_success(serde_json::json!({
-                "action": "restart",
-                "app": app_ident,
-                "services": service_names,
-            }));
-            return;
-        }
-
         let client = super::init_client(Some(config));
-        let app_data = match resolve_app(&client, &app_ident) {
+        let app_data = match resolve_app(&client, app_name) {
             Ok(a) => a,
             Err(e) => {
                 if e.code == "APP_NOT_FOUND" {
                     output::error(
-                        &format!("App '{app_ident}' not found."),
+                        &format!("App '{app_name}' not found."),
                         &ErrorCode::AppNotFound,
                         Some("Check the app name or ID and try again."),
                     );
@@ -248,63 +230,16 @@ pub fn deploy(
                 process::exit(1);
             }
         };
-        let app_id = app_data.id.clone();
 
-        let svcs = if services_filter.is_empty() {
-            None
+        if rebuild {
+            deploy_rebuild(&client, &app_data, &services_filter);
         } else {
-            Some(services_filter.as_slice())
-        };
-
-        let spinner = output::Spinner::new("Restarting...");
-        let deploy_data = match client.restart_app(&app_id, svcs) {
-            Ok(d) => {
-                spinner.finish();
-                d
-            }
-            Err(e) => {
-                spinner.finish();
-                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-                process::exit(1);
-            }
-        };
-
-        let final_status = deploy_data
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let url = deploy_data
-            .get("url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(no URL)");
-
-        if final_status == "failed" {
-            output::error_with_data(
-                "Restart failed.",
-                &ErrorCode::RestartFailed,
-                Some("Run `floo logs` for details."),
-                Some(serde_json::json!({
-                    "app": output::to_value(&app_data),
-                    "deploy": deploy_data,
-                })),
-            );
-            process::exit(1);
+            deploy_restart(&client, &app_data, &services_filter);
         }
-
-        let env_display = deploy_data
-            .get("environment_name")
-            .and_then(|v| v.as_str())
-            .map(|e| format!("{e} \u{2192} "))
-            .unwrap_or_default();
-        output::success(
-            &format!("Restarted {env_display}{url}"),
-            Some(serde_json::json!({
-                "app": output::to_value(&app_data),
-                "deploy": deploy_data,
-            })),
-        );
         return;
     }
+
+    // --- Path 3: No --app flag — full preflight from local project directory ---
 
     // ===== Deploy preflight (no auth required) =====
 
@@ -713,6 +648,185 @@ pub fn deploy(
             "deploy": output::to_value(&deploy_data),
             "detection": detection.to_value(),
             "services": service_names,
+        })),
+    );
+}
+
+/// Redeploy existing images with fresh env vars (no build). Used when `--app` is
+/// provided without `--rebuild`.
+fn deploy_restart(
+    client: &FlooClient,
+    app_data: &crate::api_types::App,
+    services_filter: &[String],
+) {
+    let app_id = &app_data.id;
+
+    if output::is_dry_run_mode() {
+        let service_names: Vec<&str> = services_filter.iter().map(|s| s.as_str()).collect();
+        output::dry_run_success(serde_json::json!({
+            "action": "restart",
+            "app": app_data.name,
+            "services": service_names,
+        }));
+        return;
+    }
+
+    let svcs: Option<&[String]> = if services_filter.is_empty() {
+        None
+    } else {
+        Some(services_filter)
+    };
+
+    let spinner = output::Spinner::new("Restarting...");
+    let deploy_data = match client.restart_app(app_id, svcs) {
+        Ok(d) => {
+            spinner.finish();
+            d
+        }
+        Err(e) => {
+            spinner.finish();
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let final_status = deploy_data
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let url = deploy_data
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(no URL)");
+
+    if final_status == "failed" {
+        output::error_with_data(
+            "Restart failed.",
+            &ErrorCode::RestartFailed,
+            Some("Run `floo logs` for details."),
+            Some(serde_json::json!({
+                "app": output::to_value(app_data),
+                "deploy": deploy_data,
+            })),
+        );
+        process::exit(1);
+    }
+
+    let env_display = deploy_data
+        .get("environment_name")
+        .and_then(|v| v.as_str())
+        .map(|e| format!("{e} \u{2192} "))
+        .unwrap_or_default();
+    output::success(
+        &format!("Restarted {env_display}{url}"),
+        Some(serde_json::json!({
+            "app": output::to_value(app_data),
+            "deploy": deploy_data,
+        })),
+    );
+}
+
+/// Force a full rebuild from the latest commit. Used when `--app --rebuild` is
+/// provided — no local project directory needed.
+fn deploy_rebuild(
+    client: &FlooClient,
+    app_data: &crate::api_types::App,
+    services_filter: &[String],
+) {
+    let app_id = &app_data.id;
+    let runtime = app_data.runtime.as_deref().unwrap_or("unknown");
+
+    if output::is_dry_run_mode() {
+        let service_names: Vec<&str> = services_filter.iter().map(|s| s.as_str()).collect();
+        output::dry_run_success(serde_json::json!({
+            "action": "rebuild",
+            "app": app_data.name,
+            "runtime": runtime,
+            "services": service_names,
+        }));
+        return;
+    }
+
+    let svcs: Option<&[String]> = if services_filter.is_empty() {
+        None
+    } else {
+        Some(services_filter)
+    };
+
+    let spinner = output::Spinner::new("Rebuilding...");
+    let mut deploy_data = match client.rebuild_app(app_id, runtime, svcs) {
+        Ok(d) => {
+            spinner.finish();
+            d
+        }
+        Err(e) => {
+            spinner.finish();
+            let suggestion = match e.code.as_str() {
+                "PLAN_FEATURE_PASSWORD" | "PLAN_FEATURE_ACCOUNTS" | "PLAN_FEATURE_SSO" => {
+                    Some("Upgrade your plan at https://app.getfloo.com/settings/billing")
+                }
+                _ => None,
+            };
+            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
+            process::exit(1);
+        }
+    };
+
+    // Wait for deploy to complete via SSE streaming or polling
+    let initial_status = deploy_data.status.as_deref().unwrap_or("");
+
+    if TERMINAL_STATUSES.contains(&initial_status) {
+        // Already complete
+    } else if !output::is_json_mode() {
+        let deploy_id = deploy_data.id.clone();
+        match stream_deploy(client, app_id, &deploy_id) {
+            Ok(final_data) => deploy_data = final_data,
+            Err(e) => {
+                eprintln!(
+                    "Stream unavailable ({}), falling back to polling...",
+                    e.code
+                );
+                deploy_data = poll_deploy(client, app_id, &deploy_data);
+            }
+        }
+    } else {
+        let deploy_id = deploy_data.id.clone();
+        match stream_deploy_json(client, app_id, &deploy_id) {
+            Ok(final_data) => deploy_data = final_data,
+            Err(_) => deploy_data = poll_deploy(client, app_id, &deploy_data),
+        }
+    }
+
+    let final_status = deploy_data.status.as_deref().unwrap_or("");
+
+    if final_status == "failed" {
+        let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
+        if !output::is_json_mode() && !build_logs.is_empty() && build_logs != "[no message content]"
+        {
+            output::bold_line("Build Logs");
+            for line in build_logs.lines() {
+                output::dim_line(line);
+            }
+        }
+        output::error_with_data(
+            "Rebuild failed.",
+            &ErrorCode::DeployFailed,
+            Some("Check build output above, or run `floo logs` for details."),
+            Some(serde_json::json!({
+                "app": output::to_value(app_data),
+                "deploy": output::to_value(&deploy_data),
+                "build_logs": build_logs,
+            })),
+        );
+        process::exit(1);
+    }
+
+    let url = deploy_data.url.as_deref().unwrap_or("");
+    output::success(
+        &format!("Rebuilt and deployed {url}"),
+        Some(serde_json::json!({
+            "app": output::to_value(app_data),
+            "deploy": output::to_value(&deploy_data),
         })),
     );
 }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -363,10 +363,10 @@ Floo Deploy Flow
 
 ## Redeploy Options
 
-  floo redeploy [path]             — force redeploy from directory (default: current)
-  floo redeploy --app <name>       — redeploy a specific app
+  floo redeploy --app <name>       — redeploy with fresh env vars (no rebuild)
+  floo redeploy --app <name> --rebuild  — force a full rebuild from latest commit
+  floo redeploy [path]             — full redeploy from local project directory
   floo redeploy --services <name>  — redeploy specific services only
-  floo redeploy --restart          — restart without rebuilding
   floo redeploy --sync-env         — re-sync env vars from env_file before redeploying
 
 ## Deploy History
@@ -580,7 +580,7 @@ Floo — Golden Path
   floo redeploy --app my-app
 
   Use this after updating env vars or changing config.
-  To restart without rebuilding: floo redeploy --restart --app my-app
+  To force a full rebuild: floo redeploy --app my-app --rebuild
 
 ## How to Add Env Vars
 
@@ -639,7 +639,7 @@ Floo — Golden Path
   Ship a code change                    | git push origin main
   Validate my config                    | floo preflight (local only, no auth)
   Redeploy after env var change         | floo redeploy --app my-app
-  Restart without rebuilding            | floo redeploy --restart --app my-app
+  Force rebuild without code change      | floo redeploy --app my-app --rebuild
   Watch a deploy in progress            | floo deploys watch --app my-app
   See deploy history                    | floo deploys list --app my-app
   Roll back to a previous version       | floo deploys rollback my-app <id>

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -430,15 +430,19 @@ pub fn import_vars(file_flag: Option<&Path>, app_flag: Option<&str>, service_nam
         process::exit(1);
     });
 
-    // Resolve config once — used for both env_file default and app resolution.
-    // NO_CONFIG_FOUND is acceptable when determining env_file path (fall back to .env),
-    // but all other errors (LEGACY_CONFIG, INVALID_PROJECT_CONFIG) must surface.
+    // Resolve config — used for env_file default path. Missing config is OK.
+    // When --app is provided, config errors in the current dir are irrelevant
+    // (agent may be in an unrelated directory).
     let resolved = match project_config::resolve_app_context(&cwd, app_flag) {
         Ok(r) => Some(r),
         Err(e) if e.code == ErrorCode::NoConfigFound => None,
         Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
+            if app_flag.is_some() {
+                None
+            } else {
+                output::error(&e.message, &e.code, e.suggestion.as_deref());
+                process::exit(1);
+            }
         }
     };
 

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -16,7 +16,6 @@ pub fn connect(
     super::require_auth();
     let client = super::init_client(None);
 
-    // Resolve app name from config files or --app flag
     let cwd = std::env::current_dir().unwrap_or_else(|e| {
         output::error(
             &format!("Failed to read current directory: {e}"),
@@ -25,43 +24,78 @@ pub fn connect(
         );
         process::exit(1);
     });
-    let resolved_ctx = match project_config::resolve_app_context(&cwd, app) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-    let app_name = resolved_ctx.app_name.clone();
 
-    // Resolve existing app or auto-create if it doesn't exist yet
-    let app_data = match crate::resolve::resolve_app(&client, &app_name) {
-        Ok(a) => a,
-        Err(e) if e.code == "APP_NOT_FOUND" => {
-            let detection = detect(&cwd);
-            let spinner = output::Spinner::new(&format!("Creating app {app_name}..."));
-            match client.create_app(&app_name, Some(&detection.runtime)) {
-                Ok(a) => {
-                    spinner.finish();
-                    a
-                }
-                Err(e) => {
-                    spinner.finish();
-                    output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-                    process::exit(1);
+    // Resolve app — skip config file reads when --app is provided
+    let (app_data, resolved) = if let Some(app_flag) = app {
+        // --app provided: look up directly, no local config needed
+        let app_data = match crate::resolve::resolve_app(&client, app_flag) {
+            Ok(a) => a,
+            Err(e) if e.code == "APP_NOT_FOUND" => {
+                // Create new app — try local detection for runtime, fall back to "unknown"
+                let runtime = detect(&cwd).runtime;
+                let spinner = output::Spinner::new(&format!("Creating app {app_flag}..."));
+                match client.create_app(app_flag, Some(&runtime)) {
+                    Ok(a) => {
+                        spinner.finish();
+                        a
+                    }
+                    Err(e) => {
+                        spinner.finish();
+                        output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                        process::exit(1);
+                    }
                 }
             }
-        }
-        Err(e) => {
-            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-            process::exit(1);
-        }
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        };
+        // Try to load local config for env var import (optional — not required)
+        let resolved =
+            project_config::resolve_app_context(&cwd, Some(&app_data.name)).ok();
+        (app_data, resolved)
+    } else {
+        // No --app: must resolve from local config
+        let resolved_ctx = match project_config::resolve_app_context(&cwd, None) {
+            Ok(r) => r,
+            Err(e) => {
+                output::error(&e.message, &e.code, e.suggestion.as_deref());
+                process::exit(1);
+            }
+        };
+        let app_name = resolved_ctx.app_name.clone();
+
+        let app_data = match crate::resolve::resolve_app(&client, &app_name) {
+            Ok(a) => a,
+            Err(e) if e.code == "APP_NOT_FOUND" => {
+                let detection = detect(&cwd);
+                let spinner = output::Spinner::new(&format!("Creating app {app_name}..."));
+                match client.create_app(&app_name, Some(&detection.runtime)) {
+                    Ok(a) => {
+                        spinner.finish();
+                        a
+                    }
+                    Err(e) => {
+                        spinner.finish();
+                        output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                        process::exit(1);
+                    }
+                }
+            }
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        };
+
+        let resolved =
+            project_config::resolve_app_context(&cwd, Some(&app_data.name)).ok();
+        (app_data, resolved)
     };
+
     let app_id = app_data.id.clone();
     let name = app_data.name.clone();
-
-    // Re-resolve config for env var import. Missing config is fine.
-    let resolved = project_config::resolve_app_context(&cwd, Some(&name)).ok();
 
     // Phase 1: Import env vars from local env_file before connecting
     if let Some(ref r) = resolved {

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -220,42 +220,64 @@ pub fn logs(args: LogsArgs) {
     super::require_auth();
     let client = super::init_client(None);
 
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::FileError,
-            None,
-        );
-        process::exit(1);
-    });
-
-    let resolved = match project_config::resolve_app_context(&cwd, args.app_flag.as_deref()) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &e.code, e.suggestion.as_deref());
-            process::exit(1);
-        }
-    };
-
-    let app_name = &resolved.app_name;
-    let src_label = source_label(&resolved.source, &resolved.config_dir);
-
-    let app_data = match resolve_app(&client, app_name) {
-        Ok(a) => a,
-        Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
-                output::error(
-                    &format!("App '{app_name}' not found."),
-                    &ErrorCode::AppNotFound,
-                    Some("Check the app name or ID and try again."),
-                );
-            } else {
-                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+    let (app_data, src_label) = if let Some(ref app_flag) = args.app_flag {
+        // --app provided: skip disk reads entirely
+        let app = match resolve_app(&client, app_flag) {
+            Ok(a) => a,
+            Err(e) => {
+                if e.code == "APP_NOT_FOUND" {
+                    output::error(
+                        &format!("App '{app_flag}' not found."),
+                        &ErrorCode::AppNotFound,
+                        Some("Check the app name or ID and try again."),
+                    );
+                } else {
+                    output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                }
+                process::exit(1);
             }
+        };
+        let label = format!("(--app {})", app.name);
+        (app, label)
+    } else {
+        // No --app: resolve from local config files
+        let cwd = std::env::current_dir().unwrap_or_else(|e| {
+            output::error(
+                &format!("Failed to read current directory: {e}"),
+                &ErrorCode::FileError,
+                None,
+            );
             process::exit(1);
-        }
+        });
+
+        let resolved = match project_config::resolve_app_context(&cwd, None) {
+            Ok(r) => r,
+            Err(e) => {
+                output::error(&e.message, &e.code, e.suggestion.as_deref());
+                process::exit(1);
+            }
+        };
+
+        let label = source_label(&resolved.source, &resolved.config_dir);
+        let app = match resolve_app(&client, &resolved.app_name) {
+            Ok(a) => a,
+            Err(e) => {
+                if e.code == "APP_NOT_FOUND" {
+                    output::error(
+                        &format!("App '{}' not found.", resolved.app_name),
+                        &ErrorCode::AppNotFound,
+                        Some("Check the app name or ID and try again."),
+                    );
+                } else {
+                    output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                }
+                process::exit(1);
+            }
+        };
+        (app, label)
     };
 
+    let app_name = &app_data.name;
     let app_id = &app_data.id;
     let show_service_prefix = args.services.len() != 1;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,6 +80,12 @@ pub(crate) fn resolve_app_from_config(
     client: &FlooClient,
     app_flag: Option<&str>,
 ) -> (String, String) {
+    // Short-circuit: --app flag means we don't need local config
+    if let Some(app_name) = app_flag {
+        let app = resolve_app_or_exit(client, app_name);
+        return (app.id.clone(), app.name.clone());
+    }
+
     let cwd = std::env::current_dir().unwrap_or_else(|e| {
         output::error(
             &format!("Failed to read current directory: {e}"),
@@ -88,7 +94,7 @@ pub(crate) fn resolve_app_from_config(
         );
         process::exit(1);
     });
-    let resolved = match crate::project_config::resolve_app_context(&cwd, app_flag) {
+    let resolved = match crate::project_config::resolve_app_context(&cwd, None) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &e.code, e.suggestion.as_deref());

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1094,6 +1094,33 @@ fn test_dry_run_rollback() {
 }
 
 #[test]
+fn test_dry_run_redeploy_restart() {
+    floo()
+        .args(["--json", "--dry-run", "redeploy", "--app", "test-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"restart"#));
+}
+
+#[test]
+fn test_dry_run_redeploy_rebuild() {
+    floo()
+        .args([
+            "--json",
+            "--dry-run",
+            "redeploy",
+            "--app",
+            "test-app",
+            "--rebuild",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"rebuild"#));
+}
+
+#[test]
 fn test_dry_run_unsupported_init() {
     floo()
         .args(["--json", "--dry-run", "init", "my-app"])


### PR DESCRIPTION
## Summary
- **`resolve_app_from_config`** short-circuits to API lookup when `--app` is set, skipping all local toml/config reads (~20 commands fixed at once)
- **`floo redeploy`** defaults to restart (env-only) when `--app` provided; new `--rebuild` flag for force-rebuilding server-side. Replaces `--restart`
- **`floo logs`**, **`github connect`**, **`env import`** all skip local disk reads when `--app` is provided

## Context
User feedback: `floo redeploy --app growth-pipeline` fails when run outside a project directory because the non-restart path requires local toml files, service discovery, and runtime detection. AI agents always pass `--app` but are never in the right directory.

## Changes
- `src/commands/mod.rs` — `resolve_app_from_config()` short-circuits when `--app` provided
- `src/commands/deploy.rs` — Three-path restructure: `--app` restart, `--app --rebuild`, local preflight
- `src/cli.rs` — Replace `--restart` with `--rebuild` flag
- `src/api_client.rs` — Add `rebuild_app()` method
- `src/commands/logs.rs` — Skip `resolve_app_context` with `--app`
- `src/commands/github.rs` — Skip config reads with `--app`
- `src/commands/env.rs` — Tolerate config errors with `--app`
- `src/commands/docs.rs` + `command_tree.rs` — Updated help text
- `tests/cli_tests.rs` — Two new dry-run integration tests

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo test` — 79 passed, 5 pre-existing failures (stale `services add` tests)
- [x] `cargo clippy -- -D warnings` — no new warnings (3 pre-existing)
- [x] Dry-run tests verify `--app` restart and `--app --rebuild` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)