### PR TITLE
fix(dev): skip external-repo services without dev_command instead of failing

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -95,12 +95,22 @@ pub fn dev(app_flag: Option<String>) {
     // --- Collect and validate service info ---
     let mut services: Vec<DevServiceInfo> = Vec::new();
     let mut missing_dev_command: Vec<String> = Vec::new();
+    let mut skipped_external: Vec<String> = Vec::new();
 
     for (name, entry) in &app_config.services {
         let dev_command = match &entry.dev_command {
             Some(cmd) => cmd.clone(),
             None => {
-                missing_dev_command.push(name.clone());
+                // External-repo services (`repo = "owner/repo"`) source their
+                // code from a different GitHub repo and can't realistically
+                // run a local dev command. Warn and skip instead of failing
+                // the entire dev session — the rest of the multi-service app
+                // can still come up locally.
+                if entry.repo.is_some() {
+                    skipped_external.push(name.clone());
+                } else {
+                    missing_dev_command.push(name.clone());
+                }
                 continue;
             }
         };
@@ -146,6 +156,14 @@ pub fn dev(app_flag: Option<String>) {
             Some("Add dev_command = \"<cmd>\" to each [services.<name>] in floo.app.toml."),
         );
         process::exit(1);
+    }
+
+    for name in &skipped_external {
+        output::warn(&format!(
+            "Skipping '{name}' (external repo, no dev_command) — \
+             the service won't run locally. Hit its prod/preview URL or add a \
+             dev_command if you want to run it locally."
+        ));
     }
 
     // Sort by name for deterministic ordering
@@ -607,5 +625,69 @@ fn cleanup_session(client: &crate::api_client::FlooClient, app_id: &str, session
                 e.message
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::project_config::{AppServiceEntry, AppServiceType};
+
+    fn entry_with(repo: Option<&str>, dev_command: Option<&str>) -> AppServiceEntry {
+        AppServiceEntry {
+            service_type: AppServiceType::Web,
+            path: Some(".".into()),
+            repo: repo.map(String::from),
+            version: None,
+            plan: None,
+            port: Some(3000),
+            ingress: None,
+            env_file: None,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+            min_instances: None,
+            dev_command: dev_command.map(String::from),
+            migrate_command: None,
+        }
+    }
+
+    /// Mirror of the partition logic in `dev()` so we can assert the rule
+    /// without spinning up subprocesses. If the dev() loop changes, update
+    /// both this helper and the call sites.
+    fn classify(entry: &AppServiceEntry) -> &'static str {
+        match entry.dev_command {
+            Some(_) => "runnable",
+            None if entry.repo.is_some() => "skipped_external",
+            None => "missing",
+        }
+    }
+
+    #[test]
+    fn external_repo_without_dev_command_is_skipped_not_an_error() {
+        // Regression test for: floo-crm fixture service had `repo = ...` and
+        // no dev_command, which hard-failed `floo dev` for the entire app.
+        let entry = entry_with(Some("getfloo/floo-crm-fixture"), None);
+        assert_eq!(classify(&entry), "skipped_external");
+    }
+
+    #[test]
+    fn local_service_without_dev_command_is_a_hard_error() {
+        let entry = entry_with(None, None);
+        assert_eq!(classify(&entry), "missing");
+    }
+
+    #[test]
+    fn local_service_with_dev_command_is_runnable() {
+        let entry = entry_with(None, Some("npm run dev"));
+        assert_eq!(classify(&entry), "runnable");
+    }
+
+    #[test]
+    fn external_service_with_dev_command_still_runs() {
+        // If the user explicitly opts into running an external-repo service
+        // locally by providing a dev_command, respect it.
+        let entry = entry_with(Some("getfloo/other"), Some("./run.sh"));
+        assert_eq!(classify(&entry), "runnable");
     }
 }


### PR DESCRIPTION
## Summary

Previously, \`floo dev\` hard-failed if any service had no \`dev_command\`, including services with \`repo = \"owner/external\"\` that source code from a different GitHub repo. This blocked dev sessions for multi-service apps where one or more services live in external repos.

## Changes

- \`src/commands/dev.rs\`: classify services into runnable / skipped_external / missing. External-repo services without a \`dev_command\` are warned and skipped; local-repo services still hard-error.
- 4 unit tests covering the partition rules.

## Test plan

- [x] 257 / 257 cli tests pass (4 new)
- [x] cargo build clean
- [x] cargo fmt clean
- [ ] After merge: run \`floo dev\` against floo-crm and verify the fixture service is skipped with a warning instead of blocking

Source: feedback DB \`abfc980e\` — team@getfloo.com on floo-crm, 2026-04-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)