### PR TITLE
feat: floo run — service-scoped one-shot command runner

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -318,7 +318,10 @@ pub struct DatabaseInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DevSessionService {
     pub name: String,
-    pub port: u16,
+    /// Port is required for `floo dev` (used for cross-service discovery vars).
+    /// Omit (None) for `floo run` one-shot mode — the API skips discovery in that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,33 @@ Examples:
         app: Option<String>,
     },
 
+    /// Run a one-shot command with a service's managed env vars injected.
+    ///
+    /// Creates a scoped dev session to fetch the service's env vars (DATABASE_URL,
+    /// REDIS_URL, and any custom vars set via `floo env`), authorizes Postgres for
+    /// direct connections if provisioned, runs the command in the service's directory,
+    /// then tears down the session when the command exits.
+    ///
+    /// Exit code propagates exactly — a failing test suite returns non-zero.
+    #[command(after_help = "\
+Examples:
+  floo run --service api -- pytest tests/unit/        Run tests with api env vars
+  floo run --service worker -- python seed.py         Run a script with worker env vars
+  floo run --service api --json -- pytest             Machine-readable exit code")]
+    Run {
+        /// Service name to inject env vars for (from floo.app.toml).
+        #[arg(long, required = true)]
+        service: String,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// The command to run (everything after --).
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+
     /// Validate project config, detect runtimes, and check readiness.
     #[command(after_help = "\
 Examples:
@@ -969,6 +996,12 @@ pub fn run() {
         Commands::Init { name, path } => commands::init::init(name, path),
 
         Commands::Dev { app } => commands::dev::dev(app),
+
+        Commands::Run {
+            service,
+            app,
+            command,
+        } => commands::run::run(&service, app, command),
 
         Commands::Preflight {
             path,

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -23,6 +23,13 @@ fn command_tree() -> Vec<CommandInfo> {
             subcommands: vec![],
         },
         CommandInfo {
+            name: "run",
+            description: "Run a one-shot command with a service's managed env vars injected",
+            usage: "floo run [--service <name>] [--app <name>] -- <command...>",
+            requires_auth: true,
+            subcommands: vec![],
+        },
+        CommandInfo {
             name: "preflight",
             description: "Validate project config, detect runtimes, and check readiness (no auth required, no side effects)",
             usage: "floo preflight [PATH] [--app <name>] [--services <name>] [--json]",
@@ -620,6 +627,7 @@ mod tests {
             "redeploy",
             "releases",
             "reparo",
+            "run",
             "services",
             "skills",
             "update",

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -193,7 +193,7 @@ pub fn dev(app_flag: Option<String>) {
         .iter()
         .map(|s| crate::api_types::DevSessionService {
             name: s.name.clone(),
-            port: s.port,
+            port: Some(s.port),
         })
         .collect();
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod orgs;
 pub mod releases;
 pub mod reparo;
 pub mod rollbacks;
+pub mod run;
 
 pub mod services;
 pub mod skills;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,291 @@
+use std::collections::HashMap;
+use std::process::{self, Command, Stdio};
+
+use crate::config::load_config;
+use crate::errors::ErrorCode;
+use crate::output;
+use crate::project_config;
+
+pub fn run(service: &str, app_flag: Option<String>, command: Vec<String>) {
+    super::require_auth();
+
+    if command.is_empty() {
+        output::error(
+            "No command provided.",
+            &ErrorCode::InvalidProjectConfig,
+            Some("Usage: floo run --service <name> -- <command...>"),
+        );
+        process::exit(1);
+    }
+
+    let config = load_config();
+    let client = super::init_client(Some(config));
+
+    let cwd = std::env::current_dir().unwrap_or_else(|e| {
+        output::error(
+            &format!("Failed to read current directory: {e}"),
+            &ErrorCode::CwdError,
+            Some("Ensure the current directory exists and you have read permission."),
+        );
+        process::exit(1);
+    });
+
+    let resolved = match project_config::resolve_app_context(&cwd, app_flag.as_deref()) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
+        }
+    };
+
+    let app = super::resolve_app_or_exit(&client, &resolved.app_name);
+    let app_id = app.id.clone();
+
+    // Resolve the working directory: use the service's `path` from floo.app.toml.
+    let working_dir = {
+        let app_config = match project_config::load_app_config(&cwd) {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                output::error(
+                    "No floo.app.toml found in current directory.",
+                    &ErrorCode::NoConfigFound,
+                    Some("Run 'floo init' to create a project config, or cd to your project root."),
+                );
+                process::exit(1);
+            }
+            Err(e) => {
+                output::error(&e.message, &e.code, e.suggestion.as_deref());
+                process::exit(1);
+            }
+        };
+
+        let entry = match app_config.services.get(service) {
+            Some(e) => e,
+            None => {
+                output::error(
+                    &format!("Service '{service}' not found in floo.app.toml."),
+                    &ErrorCode::InvalidProjectConfig,
+                    Some(
+                        "Check the service name or run 'floo services list' to see deployed services.",
+                    ),
+                );
+                process::exit(1);
+            }
+        };
+
+        match &entry.path {
+            Some(p) => {
+                let dir = cwd.join(p);
+                if !dir.exists() {
+                    output::error(
+                        &format!("Service '{service}' path '{p}' does not exist."),
+                        &ErrorCode::InvalidPath,
+                        Some("Check the 'path' value in floo.app.toml."),
+                    );
+                    process::exit(1);
+                }
+                dir
+            }
+            None => cwd.clone(),
+        }
+    };
+
+    // Create a portless dev session: gets env vars + postgres IP auth without
+    // starting a local server. The API skips cross-service discovery for portless entries.
+    let api_services = vec![crate::api_types::DevSessionService {
+        name: service.to_string(),
+        port: None,
+    }];
+
+    let spinner = output::Spinner::new("Fetching env vars...");
+    let session = match client.create_dev_session(&app_id, &api_services) {
+        Ok(s) => {
+            spinner.finish();
+            s
+        }
+        Err(e) => {
+            spinner.finish();
+            output::error(
+                &format!("Failed to create dev session: {}", e.message),
+                &ErrorCode::from_api(&e.code),
+                None,
+            );
+            process::exit(1);
+        }
+    };
+
+    let session_id = session.session_id.clone();
+
+    if !output::is_json_mode() {
+        output::info(&format!("Running with env from '{service}'"), None);
+        if session.postgres_authorized {
+            output::info(
+                "  Postgres: your IP is authorized for direct connections",
+                None,
+            );
+        }
+        eprintln!();
+    }
+
+    // Build env: inherit current env, then overlay platform vars for the service.
+    let mut env_vars: HashMap<String, String> = std::env::vars().collect();
+    if let Some(svc_env) = session.services.get(service) {
+        for (k, v) in svc_env {
+            env_vars.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Run the command, inheriting stdin/stdout/stderr so test output flows through naturally.
+    let (bin, args) = command.split_first().expect("command is non-empty");
+    let status = match Command::new("sh")
+        .arg("-c")
+        .arg(shell_join(bin, args))
+        .current_dir(&working_dir)
+        .envs(&env_vars)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+    {
+        Ok(s) => s,
+        Err(e) => {
+            // Clean up the session before exiting — process::exit() skips destructors.
+            let _ = client.delete_dev_session(&app_id, &session_id);
+            output::error(
+                &format!("Failed to run command: {e}"),
+                &ErrorCode::InternalError,
+                None,
+            );
+            process::exit(1);
+        }
+    };
+
+    let exit_code = status.code().unwrap_or(1);
+
+    if output::is_json_mode() {
+        output::print_json(&serde_json::json!({
+            "success": exit_code == 0,
+            "data": {
+                "exit_code": exit_code,
+                "session_id": session_id,
+                "postgres_authorized": session.postgres_authorized,
+            }
+        }));
+    }
+
+    // Tear down the dev session before exit. process::exit() skips destructors,
+    // so this must be an explicit call — not a Drop impl.
+    let _ = client.delete_dev_session(&app_id, &session_id);
+    process::exit(exit_code);
+}
+
+/// Build a shell command string, quoting any argument that contains whitespace
+/// or shell metacharacters. Both `bin` and `args` are quoted with the same rules.
+fn shell_join(bin: &str, args: &[String]) -> String {
+    let mut parts = vec![shell_quote_if_needed(bin)];
+    for arg in args {
+        parts.push(shell_quote_if_needed(arg));
+    }
+    parts.join(" ")
+}
+
+fn shell_quote_if_needed(s: &str) -> String {
+    let needs_quoting = s.contains(|c: char| {
+        c.is_whitespace()
+            || matches!(
+                c,
+                '"' | '\''
+                    | '\\'
+                    | '$'
+                    | '`'
+                    | '!'
+                    | '#'
+                    | '&'
+                    | '|'
+                    | ';'
+                    | '('
+                    | ')'
+                    | '<'
+                    | '>'
+                    | '*'
+                    | '?'
+                    | '['
+                    | ']'
+                    | '~'
+                    | '{'
+                    | '}'
+            )
+    });
+    if needs_quoting {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_join_plain_args() {
+        assert_eq!(
+            shell_join("pytest", &["tests/unit/".into()]),
+            "pytest tests/unit/"
+        );
+    }
+
+    #[test]
+    fn shell_join_arg_with_spaces() {
+        assert_eq!(
+            shell_join("echo", &["hello world".into()]),
+            "echo 'hello world'"
+        );
+    }
+
+    #[test]
+    fn shell_join_no_args() {
+        assert_eq!(shell_join("pytest", &[]), "pytest");
+    }
+
+    #[test]
+    fn shell_join_flag_args() {
+        assert_eq!(
+            shell_join("pytest", &["-x".into(), "-v".into(), "tests/".into()]),
+            "pytest -x -v tests/"
+        );
+    }
+
+    #[test]
+    fn shell_join_dollar_sign_quoted() {
+        assert_eq!(shell_join("echo", &["$SECRET".into()]), "echo '$SECRET'");
+    }
+
+    #[test]
+    fn shell_join_pipe_quoted() {
+        assert_eq!(shell_join("echo", &["foo|bar".into()]), "echo 'foo|bar'");
+    }
+
+    #[test]
+    fn shell_join_semicolon_quoted() {
+        assert_eq!(
+            shell_join("echo", &["foo;rm -rf /".into()]),
+            "echo 'foo;rm -rf /'"
+        );
+    }
+
+    #[test]
+    fn shell_join_bin_with_spaces_quoted() {
+        // Binary name with spaces is quoted like any other token.
+        assert_eq!(
+            shell_join("/path/to my/script", &["arg".into()]),
+            "'/path/to my/script' arg"
+        );
+    }
+
+    #[test]
+    fn shell_quote_embedded_single_quote() {
+        // Single quote in an argument is escaped correctly.
+        assert_eq!(shell_quote_if_needed("it's"), "'it'\\''s'");
+    }
+}


### PR DESCRIPTION
## Summary
- New `floo run --service <name> -- <command...>` command
- Creates a portless dev session to inject env vars (DATABASE_URL, REDIS_URL, all custom vars) into a one-shot subprocess
- Authorizes Postgres for direct connections if the app has a managed Postgres instance
- Runs the command in the service's path from `floo.app.toml`, inherits stdin/stdout/stderr, propagates exit code exactly
- Session torn down after command exits

Closes #99

## Changes
- `src/commands/run.rs` — new command implementation
- `src/api_types.rs` — `DevSessionService.port: Option<u16>` (portless for run-mode)
- `src/commands/dev.rs` — updated to pass `Some(port)` 
- `src/cli.rs` — `Commands::Run` variant + dispatch
- `src/commands/mod.rs` + `command_tree.rs` — registration + sync test updated

## Test plan
- [x] 9 `shell_join`/`shell_quote_if_needed` unit tests — all passing
- [x] Full 266-test suite passes: `cargo test`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Companion API PR: getfloo/floo#498

## Design notes
- `process::exit()` bypasses Rust destructors, so session cleanup is an explicit `delete_dev_session` call before each exit path (not a RAII Drop impl)
- `shell_quote_if_needed` covers all POSIX shell metacharacters (`;`, `|`, `&`, `` ` ``, `$`, etc.) applied to both the binary and all arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)