### PR TITLE
feat(init+preflight): agent-first UX — inline config, docs pointer, preflight catches

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -849,6 +849,7 @@ fn validate_preflight(
         if let Err(msg) = validate_service_name(&svc.name) {
             errors.push(serde_json::json!({
                 "path": svc.path,
+                "code": "INVALID_SERVICE_NAME",
                 "message": msg,
             }));
         }
@@ -857,6 +858,7 @@ fn validate_preflight(
         if seen_names.contains(&svc.name) {
             errors.push(serde_json::json!({
                 "path": svc.path,
+                "code": "DUPLICATE_SERVICE_NAME",
                 "message": format!("Duplicate service name '{}'.", svc.name),
             }));
         } else {
@@ -867,6 +869,7 @@ fn validate_preflight(
         if svc.port == 0 {
             errors.push(serde_json::json!({
                 "path": svc.path,
+                "code": "INVALID_PORT",
                 "message": format!("Service '{}' has invalid port 0. Ports must be 1-65535.", svc.name),
             }));
         }
@@ -881,6 +884,7 @@ fn validate_preflight(
                     if !env_path.exists() {
                         warnings.push(serde_json::json!({
                             "path": svc.path,
+                            "code": "ENV_FILE_NOT_FOUND",
                             "message": format!("Service '{}' env_file '{env_file}' not found on disk.", svc.name),
                         }));
                     }
@@ -888,13 +892,23 @@ fn validate_preflight(
             }
         }
 
-        // Check Dockerfile EXPOSE matches port
+        // Check Dockerfile for common issues
         let dockerfile = svc_dir.join("Dockerfile");
         if dockerfile.exists() {
             match std::fs::read_to_string(&dockerfile) {
                 Ok(content) => {
+                    let no_lockfile = !svc_dir.join("package-lock.json").exists();
+                    let mut npm_ci_flagged = false;
+
                     for line in content.lines() {
                         let trimmed = line.trim();
+
+                        // Skip comments — don't match Dockerfile comment lines
+                        if trimmed.starts_with('#') {
+                            continue;
+                        }
+
+                        // EXPOSE mismatch
                         if let Some(expose_val) = trimmed.strip_prefix("EXPOSE ") {
                             let expose_val = expose_val.trim();
                             let port_str = expose_val.split('/').next().unwrap_or(expose_val);
@@ -902,6 +916,7 @@ fn validate_preflight(
                                 if exposed_port != svc.port {
                                     warnings.push(serde_json::json!({
                                         "path": svc.path,
+                                        "code": "EXPOSE_PORT_MISMATCH",
                                         "message": format!(
                                             "Service '{}' Dockerfile EXPOSE {exposed_port} does not match configured port {}.",
                                             svc.name, svc.port
@@ -910,13 +925,45 @@ fn validate_preflight(
                                 }
                             }
                         }
+
+                        // CMD exec form with $PORT or ${PORT} — variables don't expand in exec form.
+                        // Emitted as a warning (not error) because heredoc content could produce
+                        // false positives; the runtime failure makes it obvious quickly.
+                        if trimmed.starts_with("CMD [")
+                            && (trimmed.contains("$PORT") || trimmed.contains("${PORT}"))
+                        {
+                            warnings.push(serde_json::json!({
+                                "path": svc.path,
+                                "code": "CMD_EXEC_FORM_PORT",
+                                "message": format!(
+                                    "Service '{}' Dockerfile CMD uses exec form with $PORT — $PORT won't expand at runtime.",
+                                    svc.name
+                                ),
+                                "hint": "Use shell form: CMD [\"sh\", \"-c\", \"your-command $PORT\"]",
+                            }));
+                        }
+
+                        // npm ci without package-lock.json — report once per service
+                        if !npm_ci_flagged && no_lockfile && trimmed.contains("npm ci") {
+                            errors.push(serde_json::json!({
+                                "path": svc.path,
+                                "code": "NPM_CI_NO_LOCKFILE",
+                                "message": format!(
+                                    "Service '{}' Dockerfile uses 'npm ci' but package-lock.json was not found.",
+                                    svc.name
+                                ),
+                                "hint": "Commit package-lock.json or change 'npm ci' to 'npm install' in your Dockerfile",
+                            }));
+                            npm_ci_flagged = true;
+                        }
                     }
                 }
                 Err(e) => {
                     warnings.push(serde_json::json!({
                         "path": svc.path,
+                        "code": "DOCKERFILE_READ_ERROR",
                         "message": format!(
-                            "Service '{}' Dockerfile exists but could not be read: {e}. Port check skipped.",
+                            "Service '{}' Dockerfile exists but could not be read: {e}. Checks skipped.",
                             svc.name
                         ),
                     }));

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -149,8 +149,8 @@ An app contains one or more services. Each service is independently deployable.
   api     — HTTP server for backend APIs
   worker  — background process (no incoming HTTP traffic)
 
-  These are deployed from source via git push. Each has its own
-  `floo.service.toml` with port, runtime, and ingress settings.
+  Declare services inline in floo.app.toml with type, port, and path.
+  See: floo docs config
 
 ## Platform Services (provisioned by Floo)
 
@@ -242,34 +242,23 @@ All services share the same origin, so cookies and auth work without CORS.
 const CONFIG: &str = "\
 Floo Config Files
 
-## floo.service.toml — Single-Service Apps
+## floo.app.toml — Primary Config Format
+
+  All apps use floo.app.toml. Services are declared inline with type, port, and path:
 
   [app]
   name = \"my-app\"
 
-  [service]
-  name = \"web\"
-  port = 3000
+  [services.web]
   type = \"web\"
+  path = \".\"
+  port = 3000
   ingress = \"public\"                   # public = internet-facing, internal = only other services
   env_file = \".env\"
   dev_command = \"npm run dev\"          # command to run for `floo dev`
   migrate_command = \"npx prisma migrate deploy\"  # optional, runs after deploy
 
-## floo.app.toml — Multi-Service Apps
-
-  [app]
-  name = \"my-app\"
-
-  [services.api]
-  path = \"./api\"
-
-  [services.web]
-  path = \"./web\"
-
-  Each service directory has its own floo.service.toml.
-
-## Inline Multi-Service App (in floo.app.toml)
+  Multi-service app (each service in its own subdirectory):
 
   [app]
   name = \"my-app\"
@@ -286,9 +275,23 @@ Floo Config Files
   port = 3000
   ingress = \"public\"
 
-  When type and port are set inline, no per-service floo.service.toml is needed.
+## floo.service.toml — Legacy Single-Service Format
 
-## Service Fields (floo.service.toml)
+  Still supported for backward compatibility. Single-service apps may use:
+
+  [app]
+  name = \"my-app\"
+
+  [service]
+  name = \"web\"
+  port = 3000
+  type = \"web\"
+  ingress = \"public\"
+
+  Prefer floo.app.toml for new apps — it supports managed services (postgres,
+  redis, storage), cron jobs, and multi-service apps in one file.
+
+## Service Fields (floo.app.toml inline or floo.service.toml)
 
   dev_command      — command to run locally for `floo dev`
                      e.g., \"npm run dev\", \"uvicorn app.main:app --reload\"
@@ -919,6 +922,7 @@ const TOPICS: &[(&str, &str)] = &[
     ("golden-path", HOWTO),
     ("services", SERVICES),
     ("config", CONFIG),
+    ("app-toml", CONFIG), // alias — agents can run `floo docs app-toml` after `floo init`
     ("deploy", DEPLOY),
     ("auth", AUTH),
     ("feedback", FEEDBACK),

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -8,8 +8,7 @@ use crate::errors::ErrorCode;
 use crate::names::generate_name;
 use crate::output;
 use crate::project_config::{
-    self, AppFileAppSection, AppFileConfig, AppServiceEntry, AppServiceType, ServiceFileAppSection,
-    ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
+    self, AppFileAppSection, AppFileConfig, AppServiceEntry, ServiceType,
 };
 
 pub fn init(name: Option<String>, path: PathBuf) {
@@ -136,31 +135,19 @@ fn init_non_interactive(
     };
 
     let env_file = super::detect_env_file(project_path);
-
     let service_name = default_type.to_string();
     let port = detection.default_port();
 
     // Generate Dockerfile if none exists
     let dockerfile_generated = generate_dockerfile_if_needed(project_path, detection);
 
-    let service_file = ServiceFileConfig {
-        app: ServiceFileAppSection {
-            name: app_name.clone(),
-            access_mode: None,
-        },
-        service: ServiceSection {
-            name: service_name.clone(),
-            service_type,
-            port,
-            ingress: Some(ServiceIngress::Public),
-            env_file,
-            domain: None,
-            min_instances: None,
-            dev_command: None,
-            migrate_command: None,
-        },
-        resources: None,
-    };
+    // Write a single floo.app.toml with the service inline.
+    // Agents read 'floo docs config' to understand the schema and customize it.
+    let mut services = HashMap::new();
+    services.insert(
+        service_name.clone(),
+        AppServiceEntry::scaffold(service_type.into(), ".", port, env_file),
+    );
 
     let app_file = AppFileConfig {
         app: AppFileAppSection {
@@ -176,7 +163,7 @@ fn init_non_interactive(
         resources: None,
         reparo: None,
         cron: HashMap::new(),
-        services: HashMap::new(),
+        services,
         environments: HashMap::new(),
     };
 
@@ -187,12 +174,6 @@ fn init_non_interactive(
         process::exit(1);
     }
     files_written.push(project_config::APP_CONFIG_FILE);
-
-    if let Err(e) = project_config::write_service_config(project_path, &service_file) {
-        output::error(&e.message, &e.code, None);
-        process::exit(1);
-    }
-    files_written.push(project_config::SERVICE_CONFIG_FILE);
 
     if dockerfile_generated {
         files_written.push("Dockerfile");
@@ -208,6 +189,7 @@ fn init_non_interactive(
             "port": port,
         },
         "dockerfile_generated": dockerfile_generated,
+        "hint": "Edit floo.app.toml to configure your services — run 'floo docs config' for the schema",
     });
 
     // Add suggestion when Dockerfile was not generated due to low confidence
@@ -217,6 +199,10 @@ fn init_non_interactive(
         );
     }
 
+    if !output::is_json_mode() {
+        eprintln!("  Edit floo.app.toml to configure your services, then run 'floo preflight'.");
+        eprintln!("  See 'floo docs config' for the full schema.");
+    }
     output::success(&format!("Initialized app '{app_name}'."), Some(json_data));
 }
 
@@ -248,7 +234,6 @@ fn init_interactive(
     let app_name = output::prompt_with_default("App name", &default_name);
 
     let mut services_map: HashMap<String, AppServiceEntry> = HashMap::new();
-    let mut first_service_file: Option<ServiceFileConfig> = None;
 
     // First service prompt
     if output::confirm("Add a service?") {
@@ -291,45 +276,19 @@ fn init_interactive(
                 Some(name) => {
                     let use_it =
                         output::confirm(&format!("  {name} detected. Use it for cloud deploy?"));
-                    if use_it {
-                        Some(name)
-                    } else {
-                        None
-                    }
+                    if use_it { Some(name) } else { None }
                 }
                 None => None,
             };
 
-            let app_service_type = match service_type {
-                ServiceType::Api => AppServiceType::Api,
-                ServiceType::Worker => AppServiceType::Worker,
-                ServiceType::Web => AppServiceType::Web,
+            let path_str = if svc_path == "." {
+                ".".to_string()
+            } else {
+                format!("./{svc_path}")
             };
-
-            // Add inline service entry to app.toml
             services_map.insert(
                 svc_name.clone(),
-                AppServiceEntry {
-                    service_type: app_service_type,
-                    path: if svc_path == "." {
-                        Some(".".to_string())
-                    } else {
-                        Some(format!("./{svc_path}"))
-                    },
-                    repo: None,
-                    version: None,
-                    plan: None,
-                    port: Some(port),
-                    ingress: Some(ServiceIngress::Public),
-                    env_file: env_file.clone(),
-                    domain: None,
-                    cpu: None,
-                    memory: None,
-                    max_instances: None,
-                    min_instances: None,
-                    dev_command: None,
-                    migrate_command: None,
-                },
+                AppServiceEntry::scaffold(service_type.into(), path_str, port, env_file),
             );
 
             if !output::confirm("Add another service?") {
@@ -337,31 +296,18 @@ fn init_interactive(
             }
         }
     } else {
-        // No explicit service — create a default one
+        // No explicit service — add a default inline entry so floo.app.toml is valid.
+        // The agent edits it after reading 'floo docs config'.
         let default_type = detection.default_service_type();
         let service_type = match default_type {
             "api" => ServiceType::Api,
             _ => ServiceType::Web,
         };
         let env_file = super::detect_env_file(project_path);
-        first_service_file = Some(ServiceFileConfig {
-            app: ServiceFileAppSection {
-                name: app_name.clone(),
-                access_mode: None,
-            },
-            service: ServiceSection {
-                name: default_type.to_string(),
-                service_type,
-                port: detection.default_port(),
-                ingress: Some(ServiceIngress::Public),
-                env_file,
-                domain: None,
-                min_instances: None,
-                dev_command: None,
-                migrate_command: None,
-            },
-            resources: None,
-        });
+        services_map.insert(
+            default_type.to_string(),
+            AppServiceEntry::scaffold(service_type.into(), ".", detection.default_port(), env_file),
+        );
     }
 
     // Write app config
@@ -389,17 +335,7 @@ fn init_interactive(
     }
     output::info(&format!("Wrote {}", project_config::APP_CONFIG_FILE), None);
 
-    // Write root service config
-    if let Some(svc_file) = first_service_file {
-        if let Err(e) = project_config::write_service_config(project_path, &svc_file) {
-            output::error(&e.message, &e.code, None);
-            process::exit(1);
-        }
-        output::info(
-            &format!("Wrote {}", project_config::SERVICE_CONFIG_FILE),
-            None,
-        );
-    }
-
+    eprintln!("  Edit floo.app.toml to configure your services, then run 'floo preflight'.");
+    eprintln!("  See 'floo docs config' for the full schema.");
     output::success(&format!("Initialized app '{app_name}'."), None);
 }

--- a/src/dockerfile.rs
+++ b/src/dockerfile.rs
@@ -216,7 +216,7 @@ WORKDIR /app
 RUN npm install -g serve
 COPY --from=build /app/dist ./dist
 EXPOSE $PORT
-CMD ["serve", "-s", "dist", "-l", "$PORT"]
+CMD ["sh", "-c", "serve -s dist -l $PORT"]
 "#,
         copy = pm.copy_line(),
         install = pm.install_cmd(),
@@ -262,7 +262,7 @@ COPY --from=deps /usr/local/lib/python{py_version}/site-packages /usr/local/lib/
 COPY --from=deps /usr/local/bin /usr/local/bin
 COPY . .
 EXPOSE $PORT
-CMD ["uvicorn", "{entry}", "--host", "0.0.0.0", "--port", "$PORT"]
+CMD ["sh", "-c", "uvicorn {entry} --host 0.0.0.0 --port $PORT"]
 "#,
     )
 }
@@ -285,7 +285,7 @@ COPY --from=deps /usr/local/lib/python{py_version}/site-packages /usr/local/lib/
 COPY --from=deps /usr/local/bin /usr/local/bin
 COPY . .
 EXPOSE $PORT
-CMD ["gunicorn", "{gunicorn_entry}", "--bind", "0.0.0.0:$PORT"]
+CMD ["sh", "-c", "gunicorn {gunicorn_entry} --bind 0.0.0.0:$PORT"]
 "#,
     )
 }
@@ -308,7 +308,7 @@ COPY --from=deps /usr/local/lib/python{py_version}/site-packages /usr/local/lib/
 COPY --from=deps /usr/local/bin /usr/local/bin
 COPY . .
 EXPOSE $PORT
-CMD ["gunicorn", "{wsgi_module}", "--bind", "0.0.0.0:$PORT"]
+CMD ["sh", "-c", "gunicorn {wsgi_module} --bind 0.0.0.0:$PORT"]
 "#,
     )
 }
@@ -386,7 +386,7 @@ WORKDIR /app
 RUN npm install -g serve
 COPY . .
 EXPOSE $PORT
-CMD ["serve", "-s", ".", "-l", "$PORT"]
+CMD ["sh", "-c", "serve -s . -l $PORT"]
 "#
     .to_string()
 }

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -202,6 +202,45 @@ impl fmt::Display for AppServiceType {
     }
 }
 
+impl From<super::service_config::ServiceType> for AppServiceType {
+    fn from(st: super::service_config::ServiceType) -> Self {
+        match st {
+            super::service_config::ServiceType::Web => AppServiceType::Web,
+            super::service_config::ServiceType::Api => AppServiceType::Api,
+            super::service_config::ServiceType::Worker => AppServiceType::Worker,
+        }
+    }
+}
+
+impl AppServiceEntry {
+    /// Construct a scaffolded inline service entry for `floo init`.
+    /// All optional fields default to `None` except `path`, `port`, and `ingress` (public).
+    pub fn scaffold(
+        service_type: AppServiceType,
+        path: impl Into<String>,
+        port: u16,
+        env_file: Option<String>,
+    ) -> Self {
+        Self {
+            service_type,
+            path: Some(path.into()),
+            repo: None,
+            version: None,
+            plan: None,
+            port: Some(port),
+            ingress: Some(ServiceIngress::Public),
+            env_file,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+            min_instances: None,
+            dev_command: None,
+            migrate_command: None,
+        }
+    }
+}
+
 pub fn load_app_config(dir: &Path) -> Result<Option<AppFileConfig>, FlooError> {
     let config_path = dir.join(super::APP_CONFIG_FILE);
     if !config_path.exists() {

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -210,10 +210,7 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
                     "{} has no deployable services (only Floo-managed services like postgres/redis).",
                     super::APP_CONFIG_FILE,
                 ),
-                format!(
-                    "Add a user-managed service with port/type/path fields, or create a {} in your project root.",
-                    super::SERVICE_CONFIG_FILE,
-                ),
+                "Add a [services.<name>] block with type, port, and path. Run 'floo docs config' for the schema.".to_string(),
             ));
         }
     };

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -18,8 +18,8 @@ pub use discover::{
 };
 pub use resolve::{resolve_app_context, AppSource, ResolvedApp};
 pub use service_config::{
-    load_service_config, write_service_config, ServiceConfig, ServiceFileAppSection,
-    ServiceFileConfig, ServiceIngress, ServiceSection, ServiceType,
+    load_service_config, ServiceConfig, ServiceFileAppSection, ServiceFileConfig, ServiceIngress,
+    ServiceSection, ServiceType,
 };
 
 /// Wire-format representation of a cron job sent to the API.

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -798,9 +798,9 @@ fn test_init_creates_config_json() {
         .stdout(predicate::str::contains(r#""app_name":"myapp"#))
         .stdout(predicate::str::contains(r#""success":true"#));
 
-    // Verify files were created
+    // Service is now inline in floo.app.toml — no separate floo.service.toml
     assert!(project.path().join("floo.app.toml").exists());
-    assert!(project.path().join("floo.service.toml").exists());
+    assert!(!project.path().join("floo.service.toml").exists());
 }
 
 #[test]
@@ -1148,10 +1148,10 @@ fn test_init_detects_floo_env() {
         .assert()
         .success();
 
-    let svc_toml = std::fs::read_to_string(project.path().join("floo.service.toml")).unwrap();
+    let app_toml = std::fs::read_to_string(project.path().join("floo.app.toml")).unwrap();
     assert!(
-        svc_toml.contains(r#"env_file = ".floo.env""#),
-        "Expected env_file = \".floo.env\" in service config, got:\n{svc_toml}"
+        app_toml.contains(r#"env_file = ".floo.env""#),
+        "Expected env_file = \".floo.env\" in floo.app.toml, got:\n{app_toml}"
     );
 }
 
@@ -1172,10 +1172,10 @@ fn test_init_falls_back_to_dot_env() {
         .assert()
         .success();
 
-    let svc_toml = std::fs::read_to_string(project.path().join("floo.service.toml")).unwrap();
+    let app_toml = std::fs::read_to_string(project.path().join("floo.app.toml")).unwrap();
     assert!(
-        svc_toml.contains(r#"env_file = ".env""#),
-        "Expected env_file = \".env\" in service config, got:\n{svc_toml}"
+        app_toml.contains(r#"env_file = ".env""#),
+        "Expected env_file = \".env\" in floo.app.toml, got:\n{app_toml}"
     );
 }
 
@@ -1197,9 +1197,9 @@ fn test_init_prefers_floo_env_over_dot_env() {
         .assert()
         .success();
 
-    let svc_toml = std::fs::read_to_string(project.path().join("floo.service.toml")).unwrap();
+    let app_toml = std::fs::read_to_string(project.path().join("floo.app.toml")).unwrap();
     assert!(
-        svc_toml.contains(r#"env_file = ".floo.env""#),
-        "Expected .floo.env to win over .env, got:\n{svc_toml}"
+        app_toml.contains(r#"env_file = ".floo.env""#),
+        "Expected .floo.env to win over .env, got:\n{app_toml}"
     );
 }


### PR DESCRIPTION
## Summary

- **`floo init`** stops generating `floo.service.toml`. Single `floo.app.toml` with inline `[services.<name>]`. `--json` output includes a `hint` field pointing to `floo docs config`. Root cause of the courtside friction report (#9953a6e4): generated config was rejected at deploy time because `floo.app.toml` had an empty `[services]` section while the actual config lived in a separate `floo.service.toml` that the API parser never reached.
- **`floo docs config`** restructured to lead with inline `floo.app.toml` as primary format; `floo.service.toml` moved to "Legacy" section. `floo docs app-toml` added as alias so agents can run it immediately after `floo init`.
- **`floo preflight`** catches three new failure modes before code reaches Cloud Build:
  - `CMD_EXEC_FORM_PORT`: `CMD ["...", "$PORT"]` exec form doesn't expand env vars at runtime — warns with fix hint
  - `NPM_CI_NO_LOCKFILE`: `npm ci` without `package-lock.json` will fail at install — errors with fix hint
  - All preflight findings now have consistent `{path, code, message}` shape so agents can parse them
- **Dockerfile templates**: all exec-form `CMD` with `$PORT` changed to shell form `CMD ["sh", "-c", "..."]`. Affected: Vite, static, FastAPI, Flask, Django.
- **`AppServiceEntry::scaffold()` + `From<ServiceType> for AppServiceType`**: eliminates 3x 17-field struct literal duplication in `init.rs`.

## Test plan

- [ ] `cargo test` — 51/51 green
- [ ] `floo init myapp --json` → `floo.app.toml` exists, `floo.service.toml` does NOT, JSON includes `hint` field
- [ ] `floo preflight` with a Dockerfile using `CMD ["serve", "-l", "$PORT"]` → `CMD_EXEC_FORM_PORT` warning
- [ ] `floo preflight` with `npm ci` Dockerfile + no `package-lock.json` → `NPM_CI_NO_LOCKFILE` error
- [ ] `floo docs config` and `floo docs app-toml` → same output, leads with inline format

🤖 Generated with [Claude Code](https://claude.com/claude-code)