### PR TITLE
docs: align embedded CLI docs with inline-services + shipped flags

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -74,8 +74,8 @@ Floo Quickstart — End-to-End Walkthrough
   cd my-project
   floo init my-app
 
-  This creates config files (floo.service.toml or floo.app.toml) locally.
-  No app is registered on the platform yet.
+  This writes floo.app.toml (with your service declared inline) and a Dockerfile
+  locally. No app is registered on the platform yet.
 
 ## 3. (Optional) Add Managed Services
 
@@ -127,12 +127,12 @@ Floo Quickstart — End-to-End Walkthrough
   floo dev --app my-app --service web
 
   Runs your service locally with live Cloud SQL access and the same env vars
-  as the deployed version. Requires dev_command set in floo.service.toml.
+  as the deployed version. Requires dev_command set on the service in floo.app.toml.
 
 ## What Creates What
 
   floo init           — local config files only (no API call)
-  floo redeploy       — force a redeploy (auto-creates app if needed)
+  floo redeploy       — force a redeploy of an existing app (no code-change required)
   floo apps github connect — creates app if needed, connects GitHub, triggers first deploy
   Managed services (postgres, redis, storage, cron) are declared in floo.app.toml
   and provisioned automatically on deploy. Edit the config file directly.
@@ -154,9 +154,8 @@ An app contains one or more services. Each service is independently deployable.
 
 ## Platform Services (provisioned by Floo)
 
-  Declared in floo.app.toml (NOT floo.service.toml), auto-provisioned
-  on first deploy. If floo init created floo.service.toml, rename it to
-  floo.app.toml and move [service] to [services.web] (add path = \".\").
+  Declared in floo.app.toml (top-level, not inside [services.*]),
+  auto-provisioned on first deploy.
 
   postgres — managed PostgreSQL database
              Connection string injected as DATABASE_URL env var.
@@ -206,10 +205,13 @@ An app contains one or more services. Each service is independently deployable.
 
 ## Routing
 
-Multi-service apps share a single hostname with path-based routing:
+Multi-service apps share a single hostname with path-based routing. Each
+environment gets its own subdomain (prod has no suffix, dev appends -dev):
 
-  web service  → app-name.on.getfloo.com/
-  api service  → app-name.on.getfloo.com/api/
+  Prod:  app-name.on.getfloo.com/       → web service
+         app-name.on.getfloo.com/api/   → api service
+  Dev:   app-name-dev.on.getfloo.com/   → web (dev)
+         app-name-dev.on.getfloo.com/api/ → api (dev)
 
 This is automatic — no configuration needed. The gateway strips the /api
 prefix before forwarding, so your FastAPI routes stay at the root:
@@ -322,7 +324,10 @@ Floo Config Files
 
   Auto-provisioned on first deploy. Credentials injected as env vars.
 
-## Resource Limits (optional, in floo.service.toml)
+## Resource Limits (optional)
+
+  Place [resources] in floo.app.toml (app-wide defaults) or set per-service
+  fields inside [services.<name>] to override.
 
   [resources]
   cpu = \"1\"             # CPU cores (0.25 to 8)
@@ -493,9 +498,8 @@ The auth endpoints are live as soon as the deploy completes.
 
 ## Quickstart (exact sequence)
 
-  IMPORTANT: Auth config lives in floo.app.toml, NOT floo.service.toml.
-  If `floo init` created a floo.service.toml for your single-service app,
-  rename it to floo.app.toml and move [service] to [services.web] (add path = \".\").
+  IMPORTANT: Auth config lives in floo.app.toml. `floo init` writes a
+  floo.app.toml for every app, so you should already have one.
 
   1. Configure floo.app.toml (see config below)
   2. Deploy so auth endpoints are provisioned:
@@ -544,7 +548,12 @@ Your app integrates with these endpoints (BASE = https://api.getfloo.com):
   3. **Exchange code for tokens** — POST from your backend:
      POST BASE/v1/auth/apps/{app_id}/token
      Body: { \"grant_type\": \"authorization_code\", \"code\": \"<exchange_code>\" }
-     Returns: { \"access_token\": \"<jwt>\", \"refresh_token\": \"<token>\", \"user\": {...} }
+     Returns: {
+       \"access_token\": \"<jwt>\",
+       \"refresh_token\": \"<token>\",
+       \"expires_in\": 3600,
+       \"user\": {...}
+     }
 
   4. **Verify user** — the access_token is an RS256 JWT. Verify locally with:
      GET BASE/v1/auth/apps/{app_id}/.well-known/jwks.json
@@ -768,44 +777,33 @@ Floo Templates — Copy-Paste App Structures
 ### Directory Structure
 
   my-app/
-  ├── floo.app.toml          # app-level config
+  ├── floo.app.toml          # single config file — services declared inline
+  ├── Dockerfile
   ├── web/                   # React frontend
-  │   ├── floo.service.toml
   │   ├── package.json
   │   └── src/
   └── api/                   # FastAPI backend
-      ├── floo.service.toml
       ├── pyproject.toml     # or requirements.txt
       └── app/
           └── main.py
 
-### floo.app.toml (root)
+### floo.app.toml (single file for the whole app)
 
   [app]
   name = \"my-app\"
 
-  [services.web]
-  path = \"./web\"
-
-  [services.api]
-  path = \"./api\"
-
   [postgres]
   tier = \"basic\"
 
-### web/floo.service.toml
-
-  [service]
-  name = \"web\"
+  [services.web]
+  path = \"./web\"
   type = \"web\"
   port = 3000
   ingress = \"public\"
   dev_command = \"npm run dev\"
 
-### api/floo.service.toml
-
-  [service]
-  name = \"api\"
+  [services.api]
+  path = \"./api\"
   type = \"api\"
   port = 8080
   ingress = \"public\"
@@ -880,12 +878,11 @@ Floo Templates — Copy-Paste App Structures
 
 ## Next.js + FastAPI (Multi-Service)
 
-  Same structure as above, but replace web/ with a Next.js app:
+  Same structure as above — declare both services inline in one floo.app.toml.
+  Replace the [services.web] entry with a Next.js service:
 
-### web/floo.service.toml
-
-  [service]
-  name = \"web\"
+  [services.web]
+  path = \"./web\"
   type = \"web\"
   port = 3000
   ingress = \"public\"
@@ -902,19 +899,20 @@ Floo Templates — Copy-Paste App Structures
   For a standalone app (just a web server, no separate API):
 
   my-app/
-  ├── floo.service.toml
+  ├── floo.app.toml
+  ├── Dockerfile
   ├── package.json
   └── src/
 
-  floo.service.toml:
+  floo.app.toml:
 
   [app]
   name = \"my-app\"
 
-  [service]
-  name = \"web\"
-  port = 3000
+  [services.web]
+  path = \".\"
   type = \"web\"
+  port = 3000
   ingress = \"public\"
   dev_command = \"npm run dev\"
 
@@ -1020,7 +1018,8 @@ mod tests {
     fn test_templates_has_react_fastapi() {
         assert!(TEMPLATES.contains("React + FastAPI"));
         assert!(TEMPLATES.contains("floo.app.toml"));
-        assert!(TEMPLATES.contains("floo.service.toml"));
+        assert!(TEMPLATES.contains("[services.web]"));
+        assert!(TEMPLATES.contains("[services.api]"));
         assert!(TEMPLATES.contains("/api/users"));
         assert!(TEMPLATES.contains("VITE_API_URL"));
     }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -433,25 +433,32 @@ Floo Deploy Flow
 
 ## Do I Need a Dockerfile?
 
-  Usually no. Floo auto-detects your runtime and builds your app:
+  Yes — every service deploys from a Dockerfile. Floo does not deploy
+  without one.
 
-  - package.json → Node.js (npm install + npm run build + npm start)
-  - pyproject.toml or requirements.txt → Python (pip install + uvicorn/gunicorn)
-  - go.mod → Go (go build)
-  - index.html → Static site (served with nginx)
+  You usually do not have to write it yourself. `floo init` detects your
+  runtime (Node.js, Python, Go, static) and generates a working Dockerfile
+  that you commit alongside your code. Agents run `floo init --json` to
+  see what was detected and generated.
 
-  Write a Dockerfile ONLY when you need a custom build (e.g., multi-stage
-  builds, system packages, non-standard entrypoints). If a Dockerfile exists,
-  floo uses it instead of auto-detection.
+  Write your own Dockerfile when you need a custom build (multi-stage,
+  system packages, non-standard entrypoints). If a Dockerfile already
+  exists, `floo init` leaves it alone.
 
-## Runtime Detection Priority
+## Runtime Detection (at `floo init`)
 
-  Dockerfile       — highest priority (custom build)
+  `floo init` inspects the project directory to generate a Dockerfile:
+
+  Dockerfile       — already present, init leaves it untouched
   package.json     — Node.js (detects Express, Next.js, etc.)
   pyproject.toml   — Python (detects Django, Flask, FastAPI)
   requirements.txt — Python (fallback)
   go.mod           — Go
   index.html       — Static site (lowest priority)
+
+  If detection is low-confidence, init prompts you (or in `--json` mode,
+  suggests adding a Dockerfile manually). At deploy time, the API requires
+  a Dockerfile in the service path — missing-Dockerfile deploys fail fast.
 
 ## Preflight Validation
 
@@ -1021,7 +1028,8 @@ mod tests {
     #[test]
     fn test_deploy_explains_dockerfiles() {
         assert!(DEPLOY.contains("Do I Need a Dockerfile?"));
-        assert!(DEPLOY.contains("Usually no"));
+        assert!(DEPLOY.contains("every service deploys from a Dockerfile"));
+        assert!(DEPLOY.contains("floo init"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two commits on this branch. Both update `floo docs <topic>` content to match what the CLI and config surface actually ship today.

1. **DEPLOY topic** (first commit): fix the Dockerfile claim — every service deploys from a Dockerfile; `floo init` scaffolds one when needed. Previously implied floo auto-detects runtimes without one.
2. **QUICKSTART / SERVICES / CONFIG / TEMPLATES / AUTH** (second commit):
   - QUICKSTART: describe `floo init` as writing a single `floo.app.toml` with services inline (plus a Dockerfile). Remove "auto-creates app if needed" from the `floo redeploy` description — it doesn't.
   - SERVICES: simplify the managed-services paragraph (no more "rename floo.service.toml"). Document that dev env adds a `-dev` suffix in the routing section so users know how to construct URLs per environment.
   - CONFIG: re-title "Resource Limits" so it covers `floo.app.toml` (not just the legacy `floo.service.toml` path) and clarify per-service overrides.
   - TEMPLATES: rewrite the React+FastAPI and single-service templates to declare services inline in one `floo.app.toml` instead of the old per-service `floo.service.toml` fragments.
   - AUTH: drop the stale "if floo init created a floo.service.toml, rename it" note — `floo init` never produces that file. Include `expires_in: 3600` in the token exchange response shape.
   - Test update: `test_templates_has_react_fastapi` now asserts the inline `[services.web]` / `[services.api]` sections.

Paired with https://github.com/getfloo/floo-docs/pull/6.

## Test plan

- [x] `cargo test --bin floo commands::docs` — 9 passed.
- [ ] `floo docs quickstart | less` reads cleanly end-to-end.
- [ ] `floo docs templates | grep -i "service.toml"` returns nothing in template bodies (historical mentions remain in CONFIG where the delegated layout is still documented).
- [ ] `floo docs auth | grep expires_in` shows the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)