### PR TITLE
feat(db): add --env flag to floo db migrate

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -958,10 +958,10 @@ impl FlooClient {
         self.handle_response_value(resp)
     }
 
-    pub fn db_migrate(&self, app_id: &str) -> Result<Value, FlooApiError> {
+    pub fn db_migrate(&self, app_id: &str, environment: &str) -> Result<Value, FlooApiError> {
         let resp = self.post_json(
             &format!("/v1/apps/{app_id}/db/migrate"),
-            &serde_json::json!({}),
+            &serde_json::json!({ "environment": environment }),
         )?;
         self.handle_response_value(resp)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -837,10 +837,18 @@ Examples:
     },
 
     /// Run database migrations for an app.
+    #[command(after_help = "\
+Examples:
+  floo db migrate --app my-app              Run migrations against dev (default)
+  floo db migrate --app my-app --env prod   Run migrations against prod")]
     Migrate {
         /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
         app: Option<String>,
+
+        /// Environment to migrate: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
     },
 }
 
@@ -1185,7 +1193,7 @@ pub fn run() {
                 limit,
             } => commands::db::query(app.as_deref(), &sql, &env, limit),
             DbCommands::Schema { app } => commands::db::schema(app.as_deref()),
-            DbCommands::Migrate { app } => commands::db::migrate(app.as_deref()),
+            DbCommands::Migrate { app, env } => commands::db::migrate(app.as_deref(), &env),
         },
 
         Commands::Cron(sub) => match sub {

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -463,7 +463,7 @@ fn command_tree() -> Vec<CommandInfo> {
                 CommandInfo {
                     name: "migrate",
                     description: "Run database migrations for an app",
-                    usage: "floo db migrate --app <name>",
+                    usage: "floo db migrate --app <name> [--env dev|prod]",
                     requires_auth: true,
                     subcommands: vec![],
                 },

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -139,16 +139,19 @@ pub fn schema(app_flag: Option<&str>) {
     }
 }
 
-pub fn migrate(app_flag: Option<&str>) {
+pub fn migrate(app_flag: Option<&str>, env: &str) {
     super::require_auth();
     let client = super::init_client(None);
     let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
 
     if !output::is_json_mode() {
-        output::info(&format!("Running migrations for {app_name}..."), None);
+        output::info(
+            &format!("Running migrations for {app_name} ({env})..."),
+            None,
+        );
     }
 
-    let result = match client.db_migrate(&app_id) {
+    let result = match client.db_migrate(&app_id, env) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);


### PR DESCRIPTION
## Summary
- Adds `--env` flag to `floo db migrate` so migrations can target a specific environment explicitly.

## Test plan
- [ ] `cargo test`
- [ ] `floo db migrate --env dev` targets the dev DB
- [ ] `floo db migrate` (no flag) preserves prior default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)