### PR TITLE
feat(config): add [env] contract for required/optional env vars

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -649,6 +649,7 @@ mod tests {
             min_instances: None,
             dev_command: dev_command.map(String::from),
             migrate_command: None,
+            env: None,
         }
     }
 

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{ErrorCode, FlooError};
 
-use super::service_config::{ResourceConfig, ServiceIngress};
+use super::service_config::{ResourceConfig, ServiceEnvContract, ServiceIngress};
 use super::SCHEMA_URL;
 
 /// A single scheduled cron job declared in `[cron.<name>]`.
@@ -182,6 +182,8 @@ pub struct AppServiceEntry {
     pub dev_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<ServiceEnvContract>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -237,6 +239,7 @@ impl AppServiceEntry {
             min_instances: None,
             dev_command: None,
             migrate_command: None,
+            env: None,
         }
     }
 }
@@ -296,6 +299,9 @@ fn validate_app_config(config: &AppFileConfig) -> Result<(), FlooError> {
                     format!("Add path = \"./subdir\" to [services.{name}]."),
                 ));
             }
+        }
+        if let Some(ref env) = entry.env {
+            env.validate(&format!("[services.{name}.env]"))?;
         }
     }
     Ok(())
@@ -903,5 +909,59 @@ bad_field = true
 
         let err = load_app_config(dir.path()).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+    }
+
+    #[test]
+    fn test_load_app_config_inline_service_with_env_contract() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.api]
+type = "api"
+path = "./backend"
+port = 8000
+
+[services.api.env]
+required = ["STRIPE_SECRET_KEY", "JWT_SECRET"]
+optional = ["SENTRY_DSN"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        let api = config.services.get("api").expect("api service present");
+        let env = api.env.as_ref().expect("env contract present");
+        assert_eq!(env.required, vec!["STRIPE_SECRET_KEY", "JWT_SECRET"]);
+        assert_eq!(env.optional, vec!["SENTRY_DSN"]);
+    }
+
+    #[test]
+    fn test_load_app_config_inline_service_env_contract_rejects_invalid_name() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.api]
+type = "api"
+path = "./backend"
+port = 8000
+
+[services.api.env]
+required = ["BAD-NAME"]
+"#,
+        )
+        .unwrap();
+
+        let err = load_app_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("[services.api.env]"));
+        assert!(err.message.contains("'BAD-NAME'"));
     }
 }

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -440,6 +440,7 @@ ingress = "public"
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
         let resolved = make_resolved(
             dir.path(),
@@ -495,6 +496,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
         services_map.insert(
@@ -515,6 +517,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -582,6 +585,7 @@ ingress = "public"
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
 
         // Sub-service
@@ -612,6 +616,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -674,6 +679,7 @@ ingress = "public"
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
 
         use crate::project_config::app_config::ManagedServiceSection;
@@ -736,6 +742,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -801,6 +808,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -858,6 +866,7 @@ ingress = "public"
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
 
         // Sub-service also named "api"
@@ -888,6 +897,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -988,6 +998,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1162,6 +1173,7 @@ ingress = "public"
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
 
         let mut services_map = HashMap::new();
@@ -1183,6 +1195,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1273,6 +1286,7 @@ ingress = "internal"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
         services_map.insert(
@@ -1293,6 +1307,7 @@ ingress = "internal"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1367,6 +1382,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1442,6 +1458,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1507,6 +1524,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
         services_map.insert(
@@ -1527,6 +1545,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1598,6 +1617,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1671,6 +1691,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1733,6 +1754,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
         services_map.insert(
@@ -1753,6 +1775,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                env: None,
             },
         );
 
@@ -1816,6 +1839,7 @@ domain = "svc.example.com"
                 max_instances: Some(5),
                 min_instances: None,
             }),
+            env: None,
         };
 
         let resolved = make_resolved(
@@ -1874,6 +1898,7 @@ domain = "svc.example.com"
                         min_instances: None,
                         dev_command: None,
                         migrate_command: None,
+                        env: None,
                     },
                 );
                 m
@@ -1934,6 +1959,7 @@ domain = "svc.example.com"
                         min_instances: None,
                         dev_command: None,
                         migrate_command: None,
+                        env: None,
                     },
                 );
                 m

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt;
 use std::path::Path;
 
@@ -21,6 +22,67 @@ pub struct ResourceConfig {
     pub max_instances: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_instances: Option<u32>,
+}
+
+// --- Env var contract ---
+
+/// Per-service declaration of which env vars the service requires.
+///
+/// Declares names and kinds only — values always live in `.env` (local) or
+/// encrypted EnvVar rows (server-side). The server-side deploy pipeline
+/// gates on `required`: if any named key is missing or empty in the target
+/// environment, the deploy fails with `MISSING_REQUIRED_ENV_VAR`. `optional`
+/// is purely documentary.
+///
+/// Attached under `[services.<name>.env]` in `floo.app.toml` (inline mode)
+/// or `[env]` at the top level of `floo.service.toml` (delegated mode).
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ServiceEnvContract {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub optional: Vec<String>,
+}
+
+impl ServiceEnvContract {
+    /// Validate that names are well-formed, non-duplicated, and non-overlapping.
+    ///
+    /// `where_` is a human-readable location string used in error messages
+    /// (e.g. `"[services.api.env]"` or `"[env] in floo.service.toml"`).
+    pub fn validate(&self, where_: &str) -> Result<(), FlooError> {
+        let mut seen = HashSet::new();
+        for (bucket, names) in [("required", &self.required), ("optional", &self.optional)] {
+            for name in names {
+                if !is_valid_env_name(name) {
+                    return Err(FlooError::with_suggestion(
+                        ErrorCode::InvalidProjectConfig,
+                        format!("{where_} {bucket} contains invalid env var name '{name}'.",),
+                        "Env var names must match /^[A-Za-z_][A-Za-z0-9_]*$/.".to_string(),
+                    ));
+                }
+                if !seen.insert(name.clone()) {
+                    return Err(FlooError::with_suggestion(
+                        ErrorCode::InvalidProjectConfig,
+                        format!(
+                            "{where_} declares '{name}' more than once (across required and optional).",
+                        ),
+                        "Each env var name may appear in at most one of required/optional.".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 // --- API wire format (sent to the API as JSON) ---
@@ -91,6 +153,8 @@ pub struct ServiceFileConfig {
     pub service: ServiceSection,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<ResourceConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<ServiceEnvContract>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -170,6 +234,10 @@ pub fn load_service_config(dir: &Path) -> Result<Option<ServiceFileConfig>, Floo
             format!("See {SCHEMA_URL} for the schema reference."),
         )
     })?;
+
+    if let Some(ref env) = config.env {
+        env.validate(&format!("[env] in {}", super::SERVICE_CONFIG_FILE))?;
+    }
 
     Ok(Some(config))
 }
@@ -319,6 +387,7 @@ ingress = "internal"
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
 
         write_service_config(dir.path(), &config).unwrap();
@@ -609,6 +678,7 @@ port = 8000
                 migrate_command: None,
             },
             resources: None,
+            env: None,
         };
 
         write_service_config(dir.path(), &config).unwrap();
@@ -706,5 +776,148 @@ port = 8000
         assert_eq!(json["cpu"], "2");
         assert_eq!(json["memory"], "4Gi");
         assert_eq!(json["max_instances"], 5);
+    }
+
+    #[test]
+    fn test_load_service_config_with_env_contract() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+
+[env]
+required = ["STRIPE_SECRET_KEY", "JWT_SECRET"]
+optional = ["SENTRY_DSN"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        let env = config.env.expect("env contract present");
+        assert_eq!(env.required, vec!["STRIPE_SECRET_KEY", "JWT_SECRET"]);
+        assert_eq!(env.optional, vec!["SENTRY_DSN"]);
+    }
+
+    #[test]
+    fn test_load_service_config_env_contract_absent_is_none() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert!(config.env.is_none());
+    }
+
+    #[test]
+    fn test_load_service_config_env_contract_rejects_invalid_name() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+
+[env]
+required = ["1INVALID"]
+"#,
+        )
+        .unwrap();
+
+        let err = load_service_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("'1INVALID'"));
+    }
+
+    #[test]
+    fn test_load_service_config_env_contract_rejects_duplicate_within_bucket() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+
+[env]
+required = ["JWT_SECRET", "JWT_SECRET"]
+"#,
+        )
+        .unwrap();
+
+        let err = load_service_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("'JWT_SECRET'"));
+    }
+
+    #[test]
+    fn test_load_service_config_env_contract_rejects_overlap_across_buckets() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "api"
+type = "api"
+port = 8000
+
+[env]
+required = ["JWT_SECRET"]
+optional = ["JWT_SECRET"]
+"#,
+        )
+        .unwrap();
+
+        let err = load_service_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("'JWT_SECRET'"));
+    }
+
+    #[test]
+    fn test_env_contract_valid_names_accepted() {
+        let contract = ServiceEnvContract {
+            required: vec!["STRIPE_KEY".into(), "_INTERNAL".into(), "A1_B2".into()],
+            optional: vec![],
+        };
+        contract.validate("[env]").unwrap();
+    }
+
+    #[test]
+    fn test_env_contract_name_with_dash_rejected() {
+        let contract = ServiceEnvContract {
+            required: vec!["MY-KEY".into()],
+            optional: vec![],
+        };
+        let err = contract.validate("[env]").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `[services.<name>.env]` (inline in `floo.app.toml`) and `[env]` (top-level in `floo.service.toml`) blocks declaring `required` and `optional` env var names.
- Names and kinds only — values still live in `.env` locally or encrypted `EnvVar` rows server-side.
- Validates names at parse time: `/^[A-Za-z_][A-Za-z0-9_]*$/`, unique across both buckets, unknown fields rejected.
- Paired with the server-side gate in the monorepo (`api/app/services/pipeline.py` `VALIDATE_CONFIG` → `MISSING_REQUIRED_ENV_VAR`) already shipped in [floo#533](https://github.com/getfloo/floo/pull/533).

## Out of scope (intentional)

- No `secret` flag — every user env var is already encrypted at rest.
- No managed-service keys (`DATABASE_URL`, `REDIS_URL`, `FLOO_APP_ID`, …) — auto-provided when `[postgres]`/`[redis]`/`[storage]` are declared.
- No build-time-ness — inferred from `VITE_`/`NEXT_PUBLIC_`/`REACT_APP_` prefix server-side.

## Test plan

- [x] `cargo test` — 275 + 79 + 51 pass; 9 new unit tests cover parsing for both modes, invalid names, within-bucket duplicates, and cross-bucket overlap.
- [ ] Declare `[services.X.env] required = [...]` in a sample app, push to `main`, watch webhook deploy fail with `MISSING_REQUIRED_ENV_VAR` until `floo env set` populates the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)