### PR TITLE
fix: resolve app config from repo root in dev and run

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -67,16 +67,8 @@ pub fn dev(app_flag: Option<String>) {
     let app_name = app.name.clone();
 
     // --- Read service definitions from floo.app.toml ---
-    let app_config = match project_config::load_app_config(&cwd) {
-        Ok(Some(c)) => c,
-        Ok(None) => {
-            output::error(
-                "No floo.app.toml found in current directory.",
-                &ErrorCode::NoConfigFound,
-                Some("Run 'floo init' to create a project config, or cd to your project root."),
-            );
-            process::exit(1);
-        }
+    let app_config = match super::load_app_config_for_resolved_app(&resolved) {
+        Ok(c) => c,
         Err(e) => {
             output::error(&e.message, &e.code, e.suggestion.as_deref());
             process::exit(1);
@@ -328,7 +320,7 @@ pub fn dev(app_flag: Option<String>) {
     let mut children: Vec<(String, Child)> = Vec::new();
 
     for (idx, svc) in services.iter().enumerate() {
-        let working_dir = cwd.join(&svc.path);
+        let working_dir = resolved.config_dir.join(&svc.path);
 
         if !working_dir.exists() {
             output::error(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,7 +3,7 @@ use std::process;
 use crate::api_client::FlooClient;
 use crate::api_types::App;
 use crate::config::{load_config, FlooConfig};
-use crate::errors::ErrorCode;
+use crate::errors::{ErrorCode, FlooError};
 use crate::output;
 
 pub mod analytics;
@@ -106,6 +106,23 @@ pub(crate) fn resolve_app_from_config(
     (app.id.clone(), app.name.clone())
 }
 
+pub(crate) fn load_app_config_for_resolved_app(
+    resolved: &crate::project_config::ResolvedApp,
+) -> Result<crate::project_config::AppFileConfig, FlooError> {
+    match crate::project_config::load_app_config(&resolved.config_dir)? {
+        Some(config) => Ok(config),
+        None => Err(FlooError::with_suggestion(
+            ErrorCode::NoConfigFound,
+            format!(
+                "No {} found in '{}'.",
+                crate::project_config::APP_CONFIG_FILE,
+                resolved.config_dir.display()
+            ),
+            "Run 'floo init' to create a project config, or cd to your project root.".to_string(),
+        )),
+    }
+}
+
 /// Truncate a commit SHA to 7 characters for display.
 pub(crate) fn short_sha(sha: &str) -> &str {
     if sha.len() > 7 && sha.is_ascii() {
@@ -124,5 +141,63 @@ pub(crate) fn detect_env_file(dir: &std::path::Path) -> Option<String> {
         Some(".env".to_string())
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_app_config_for_resolved_app_uses_resolved_config_dir() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(crate::project_config::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "nested-app"
+
+[services.web]
+type = "web"
+path = "./web"
+port = 3000
+dev_command = "npm run dev"
+"#,
+        )
+        .unwrap();
+        let nested = dir.path().join("apps/web");
+        fs::create_dir_all(&nested).unwrap();
+
+        let resolved = crate::project_config::ResolvedApp {
+            app_name: "nested-app".to_string(),
+            source: crate::project_config::AppSource::AppFile,
+            service_config: None,
+            app_config: None,
+            config_dir: dir.path().to_path_buf(),
+        };
+
+        let config = load_app_config_for_resolved_app(&resolved).unwrap();
+        assert_eq!(
+            config.services["web"].dev_command.as_deref(),
+            Some("npm run dev")
+        );
+    }
+
+    #[test]
+    fn load_app_config_for_resolved_app_reports_resolved_dir_in_error() {
+        let dir = TempDir::new().unwrap();
+        let resolved = crate::project_config::ResolvedApp {
+            app_name: "missing-app".to_string(),
+            source: crate::project_config::AppSource::AppFile,
+            service_config: None,
+            app_config: None,
+            config_dir: dir.path().to_path_buf(),
+        };
+
+        let err = load_app_config_for_resolved_app(&resolved).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoConfigFound);
+        assert!(err.message.contains(&dir.path().display().to_string()));
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -43,16 +43,8 @@ pub fn run(service: &str, app_flag: Option<String>, command: Vec<String>) {
 
     // Resolve the working directory: use the service's `path` from floo.app.toml.
     let working_dir = {
-        let app_config = match project_config::load_app_config(&cwd) {
-            Ok(Some(c)) => c,
-            Ok(None) => {
-                output::error(
-                    "No floo.app.toml found in current directory.",
-                    &ErrorCode::NoConfigFound,
-                    Some("Run 'floo init' to create a project config, or cd to your project root."),
-                );
-                process::exit(1);
-            }
+        let app_config = match super::load_app_config_for_resolved_app(&resolved) {
+            Ok(c) => c,
             Err(e) => {
                 output::error(&e.message, &e.code, e.suggestion.as_deref());
                 process::exit(1);
@@ -75,7 +67,7 @@ pub fn run(service: &str, app_flag: Option<String>, command: Vec<String>) {
 
         match &entry.path {
             Some(p) => {
-                let dir = cwd.join(p);
+                let dir = resolved.config_dir.join(p);
                 if !dir.exists() {
                     output::error(
                         &format!("Service '{service}' path '{p}' does not exist."),

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -9,18 +9,17 @@ pub const LEGACY_CONFIG_FILE: &str = "floo.toml";
 const SCHEMA_URL: &str = "https://getfloo.com/docs/floo-toml";
 const MAX_WALK_UP_LEVELS: usize = 20;
 
+#[cfg(test)]
+pub use app_config::AppServiceType;
 pub use app_config::{
     load_app_config, write_app_config, AppAccessMode, AppAgentMode, AppFileAppSection,
-    AppFileConfig, AppServiceEntry, AppServiceType, GitHubConfig, ReparoConfig,
+    AppFileConfig, AppServiceEntry, GitHubConfig, ReparoConfig,
 };
 pub use discover::{
     discover_managed_services, discover_services, filter_services, ManagedServiceDeclaration,
 };
 pub use resolve::{resolve_app_context, AppSource, ResolvedApp};
-pub use service_config::{
-    load_service_config, ServiceConfig, ServiceFileAppSection, ServiceFileConfig, ServiceIngress,
-    ServiceSection, ServiceType,
-};
+pub use service_config::{load_service_config, ServiceConfig, ServiceIngress, ServiceType};
 
 /// Wire-format representation of a cron job sent to the API.
 ///

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -174,7 +174,8 @@ pub fn load_service_config(dir: &Path) -> Result<Option<ServiceFileConfig>, Floo
     Ok(Some(config))
 }
 
-pub fn write_service_config(dir: &Path, config: &ServiceFileConfig) -> Result<(), FlooError> {
+#[cfg(test)]
+fn write_service_config(dir: &Path, config: &ServiceFileConfig) -> Result<(), FlooError> {
     let config_path = dir.join(super::SERVICE_CONFIG_FILE);
     let content = toml::to_string_pretty(config).map_err(|e| {
         FlooError::new(


### PR DESCRIPTION
## Summary
- load \ from the resolved repo root instead of the raw cwd in \ and \
- resolve service working directories relative to the resolved app config directory so nested repo invocations behave correctly
- add regression tests for resolved-config loading and keep the crate lint-clean

## Testing
- \
- \
- \
running 268 tests
test cli::tests::rewrite_leaves_help_flag_alone ... ok
test cli::tests::rewrite_leaves_bare_invocation_unchanged ... ok
test cli::tests::rewrite_version_with_json_flag ... ok
test cli::tests::rewrite_leaves_version_subcommand_unchanged ... ok
test cli::tests::rewrite_version_long_flag ... ok
test commands::analytics::tests::format_number_with_commas ... ok
test cli::tests::rewrite_version_short_flag ... ok
test commands::analytics::tests::format_period_known ... ok
test commands::analytics::tests::format_number_no_commas ... ok
test cli::tests::rewrite_leaves_subcommand_unchanged ... ok
test commands::analytics::tests::format_period_unknown ... ok
test commands::command_tree::tests::test_all_commands_have_descriptions ... ok
test commands::db::tests::test_value_to_display_bool ... ok
test commands::command_tree::tests::test_command_names_match_cli_enum ... ok
test commands::db::tests::test_value_to_display_null ... ok
test commands::command_tree::tests::test_command_tree_not_empty ... ok
test commands::db::tests::test_value_to_display_string ... ok
test commands::db::tests::test_value_to_display_number ... ok
test commands::deploys::tests::test_colored_status_unknown_passthrough ... ok
test commands::deploys::tests::test_colored_status_values ... ok
test commands::deploys::tests::test_is_real_log_empty ... ok
test commands::deploys::tests::test_is_real_log_placeholder_with_whitespace ... ok
test commands::deploys::tests::test_is_real_log_real_content ... ok
test commands::deploys::tests::test_is_real_log_placeholder ... ok
test commands::deploys::tests::test_is_real_log_whitespace_only ... ok
test commands::deploys::tests::test_relative_time_boundary_59_minutes ... ok
test commands::deploys::tests::test_relative_time_boundary_60_minutes ... ok
test commands::deploys::tests::test_relative_time_days_ago ... ok
test commands::deploys::tests::test_relative_time_hours_ago ... ok
test commands::deploy::tests::test_parse_env_file_soft_missing_file ... ok
test commands::deploys::tests::test_relative_time_invalid_input ... ok
test commands::deploy::tests::test_parse_env_file_soft_empty_file ... ok
test commands::deploys::tests::test_relative_time_minutes_ago ... ok
test commands::deploys::tests::test_relative_time_seconds_ago ... ok
test commands::deploys::tests::test_relative_time_naive_timestamp ... ok
test commands::deploys::tests::test_truncate_id_exactly_eight ... ok
test commands::deploys::tests::test_truncate_id_long ... ok
test commands::deploys::tests::test_truncate_id_non_ascii_not_sliced ... ok
test commands::deploys::tests::test_truncate_id_short ... ok
test commands::dev::tests::external_repo_without_dev_command_is_skipped_not_an_error ... ok
test commands::dev::tests::external_service_with_dev_command_still_runs ... ok
test commands::dev::tests::local_service_with_dev_command_is_runnable ... ok
test commands::deploy::tests::test_parse_env_file_soft_basic ... ok
test commands::dev::tests::local_service_without_dev_command_is_a_hard_error ... ok
test commands::deploy::tests::test_parse_env_file_soft_skips_malformed ... ok
test commands::docs::tests::test_auth_docs_has_key_concepts ... ok
test commands::docs::tests::test_deploy_explains_dockerfiles ... ok
test commands::docs::tests::test_deploy_mentions_github ... ok
test commands::docs::tests::test_docs_content_not_empty ... ok
test commands::docs::tests::test_overview_has_key_concepts ... ok
test commands::docs::tests::test_quickstart_has_full_flow ... ok
test commands::docs::tests::test_services_explains_routing ... ok
test commands::docs::tests::test_services_no_coming_soon ... ok
test commands::docs::tests::test_templates_has_react_fastapi ... ok
test commands::logs::tests::test_format_log_line_with_prefix ... ok
test commands::logs::tests::test_format_log_line_without_prefix ... ok
test commands::logs::tests::test_format_log_line_with_prefix_missing_service_name ... ok
test commands::run::tests::shell_join_arg_with_spaces ... ok
test commands::run::tests::shell_join_bin_with_spaces_quoted ... ok
test commands::run::tests::shell_join_dollar_sign_quoted ... ok
test commands::run::tests::shell_join_flag_args ... ok
test commands::run::tests::shell_join_no_args ... ok
test commands::run::tests::shell_join_pipe_quoted ... ok
test commands::run::tests::shell_join_semicolon_quoted ... ok
test commands::run::tests::shell_join_plain_args ... ok
test commands::run::tests::shell_quote_embedded_single_quote ... ok
test commands::skills::tests::test_plugin_skills_are_embedded ... ok
test commands::skills::tests::test_recommended_permissions_read_only ... ok
test commands::skills::tests::test_recommended_permissions_read_write ... ok
test commands::skills::tests::test_security_skill_has_anti_patterns ... ok
test commands::skills::tests::test_skill_content_has_key_sections ... ok
test commands::skills::tests::test_services_skill_covers_all_services ... ok
test commands::env::tests::test_parse_env_file_basic ... ok
test commands::skills::tests::test_skill_content_is_embedded ... ok
test commands::update::tests::test_floo_no_update_check_env_var_is_install_sh_contract ... ok
test commands::update::tests::test_display_tag_strips_leading_v ... ok
test commands::update::tests::test_version_skip_network_is_stable ... ok
test commands::env::tests::test_parse_env_file_comments_and_blanks ... ok
test config::tests::test_add_skill_path_deduplicates ... ok
test commands::env::tests::test_parse_env_file_uppercase_keys ... ok
test config::tests::test_config_dir_fallback ... ok
test config::tests::test_config_env_override ... ok
test config::tests::test_config_serialization ... ok
test config::tests::test_config_without_skill_paths_deserializes ... ok
test config::tests::test_default_config ... ok
test config::tests::test_skill_paths_omitted_when_empty ... ok
test detection::tests::test_default_port_go ... ok
test detection::tests::test_default_port_nodejs ... ok
test detection::tests::test_default_port_python ... ok
test detection::tests::test_default_service_type_express_is_api ... ok
test detection::tests::test_default_service_type_nextjs_is_web ... ok
test detection::tests::test_default_service_type_no_framework_is_web ... ok
test commands::tests::load_app_config_for_resolved_app_reports_resolved_dir_in_error ... ok
test commands::env::tests::test_parse_env_file_value_with_equals ... ok
test commands::env::tests::test_parse_env_file_export_prefix ... ok
test commands::env::tests::test_parse_env_file_quotes ... ok
test config::tests::test_config_dir_env_override ... ok
test detection::tests::test_detect_dockerfile ... ok
test detection::tests::test_detect_go ... ok
test detection::tests::test_detect_nodejs_nextjs ... ok
test detection::tests::test_detect_nodejs_vite ... ok
test detection::tests::test_detect_nodejs_express ... ok
test detection::tests::test_detection_result_to_value ... ok
test commands::tests::load_app_config_for_resolved_app_uses_resolved_config_dir ... ok
test detection::tests::test_detect_python_django_pyproject ... ok
test detection::tests::test_detect_unknown ... ok
test config::tests::test_corrupted_config_file_returns_default ... ok
test detection::tests::test_detect_static_html ... ok
test detection::tests::test_detect_python_fastapi ... ok
test detection::tests::test_detect_python_flask ... ok
test dockerfile::tests::test_detect_node_entry_default ... ok
test dockerfile::tests::test_detect_package_manager_default_npm ... ok
test detection::tests::test_dockerfile_takes_priority ... ok
test dockerfile::tests::test_detect_package_manager_npm ... ok
test dockerfile::tests::test_detect_package_manager_yarn ... ok
test dockerfile::tests::test_detect_node_entry_from_file_scan ... ok
test dockerfile::tests::test_detect_python_version_default ... ok
test dockerfile::tests::test_detect_python_entry_default ... ok
test dockerfile::tests::test_detect_node_entry_from_main ... ok
test dockerfile::tests::test_detect_python_entry_from_file_scan ... ok
test dockerfile::tests::test_detect_package_manager_pnpm ... ok
test dockerfile::tests::test_detect_python_version_from_pyproject ... ok
test dockerfile::tests::test_express_template ... ok
test dockerfile::tests::test_generic_node_uses_express_template ... ok
test dockerfile::tests::test_django_template ... ok
test dockerfile::tests::test_django_fallback_wsgi ... ok
test dockerfile::tests::test_express_entry_point_fallback ... ok
test dockerfile::tests::test_fastapi_with_version ... ok
test dockerfile::tests::test_fastify_uses_express_template ... ok
test dockerfile::tests::test_fastapi_template ... ok
test dockerfile::tests::test_flask_template ... ok
test dockerfile::tests::test_go_template ... ok
test errors::tests::test_error_code_as_str ... ok
test dockerfile::tests::test_go_version_fallback ... ok
test errors::tests::test_error_code_from_api ... ok
test errors::tests::test_floo_api_error ... ok
test dockerfile::tests::test_returns_none_for_docker_runtime ... ok
test errors::tests::test_floo_error_display ... ok
test dockerfile::tests::test_returns_none_for_unknown_runtime ... ok
test errors::tests::test_floo_error_with_suggestion ... ok
test errors::tests::test_from_api_roundtrip_all_variants ... ok
test dockerfile::tests::test_static_template ... ok
test output::tests::test_dry_run_mode_toggle ... ok
test names::tests::test_generate_name_not_empty ... ok
test names::tests::test_generate_name_format ... ok
test output::tests::test_is_interactive_false_in_json_mode ... ok
test output::tests::test_json_mode_toggle ... ok
test dockerfile::tests::test_nextjs_template ... ok
test dockerfile::tests::test_nextjs_pnpm ... ok
test dockerfile::tests::test_vite_template ... ok
test dockerfile::tests::test_nextjs_yarn ... ok
test project_config::app_config::tests::test_load_app_config_accepts_path_and_repo ... ok
test project_config::app_config::tests::test_load_app_config_github_section_defaults_none ... ok
test project_config::app_config::tests::test_load_app_config_auth_unknown_field_rejected ... ok
test project_config::app_config::tests::test_load_app_config_missing_returns_none ... ok
test project_config::app_config::tests::test_load_app_config_inline_requires_port_for_all_user_managed ... ok
test project_config::app_config::tests::test_load_app_config_github_unknown_field_rejected ... ok
test project_config::app_config::tests::test_load_app_config_minimal ... ok
test project_config::app_config::tests::test_load_app_config_invalid_service_type ... ok
test project_config::app_config::tests::test_load_app_config_invalid_access_mode ... ok
test project_config::app_config::tests::test_load_app_config_mixed_services ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_password ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_accounts ... ok
test project_config::app_config::tests::test_load_app_config_inline_services_with_port ... ok
test project_config::app_config::tests::test_load_app_config_repo_without_path_in_inline_mode ... ok
test project_config::app_config::tests::test_load_app_config_unknown_field_rejected ... ok
test project_config::app_config::tests::test_load_app_config_with_auth_redirect_uris ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_floo_accounts_alias ... ok
test project_config::app_config::tests::test_load_app_config_with_floo_managed_service ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_sso ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_public ... ok
test project_config::app_config::tests::test_load_app_config_with_github_section ... ok
test project_config::app_config::tests::test_load_app_config_without_access_mode_defaults_none ... ok
test project_config::discover::tests::test_discover_errors_no_deployable_services ... ok
test project_config::app_config::tests::test_load_app_config_without_auth_section ... ok
test project_config::app_config::tests::test_load_app_config_with_user_managed_service_repo ... ok
test project_config::app_config::tests::test_load_app_config_with_service_ingress ... ok
test project_config::app_config::tests::test_load_app_config_with_user_managed_service_path ... ok
test project_config::discover::tests::test_app_toml_domain_overrides_service_toml ... ok
test project_config::app_config::tests::test_write_and_reload_app_config ... ok
test project_config::discover::tests::test_app_toml_ingress_overrides_service_toml ... ok
test project_config::discover::tests::test_discover_errors_on_missing_service_toml ... ok
test project_config::discover::tests::test_all_internal_multi_service_errors ... ok
test project_config::discover::tests::test_discover_errors_on_duplicate_names ... ok
test project_config::discover::tests::test_discover_managed_services_empty_when_no_app_config ... ok
test project_config::discover::tests::test_discover_errors_on_app_name_mismatch ... ok
test project_config::discover::tests::test_discover_inline_with_global_resources ... ok
test project_config::discover::tests::test_discover_inline_errors_when_service_toml_exists ... ok
test project_config::discover::tests::test_discover_managed_services_postgres_redis ... ok
test project_config::discover::tests::test_discover_managed_services_empty_when_no_managed ... ok
test project_config::discover::tests::test_discover_includes_root_service_with_app_paths ... ok
test project_config::discover::tests::test_filter_valid_subset ... ok
test project_config::discover::tests::test_discover_single_service_from_service_file ... ok
test project_config::discover::tests::test_filter_empty_returns_all ... ok
test project_config::discover::tests::test_filter_unknown_name_errors ... ok
test project_config::discover::tests::test_discover_inline_services_from_app_config ... ok
test project_config::discover::tests::test_discover_inline_worker_defaults_internal ... ok
test project_config::discover::tests::test_discover_skips_floo_managed_services ... ok
test project_config::discover::tests::test_single_service_with_resources ... ok
test project_config::resolve::tests::test_resolve_no_config_errors ... ok
test project_config::resolve::tests::test_resolve_from_app_config ... ok
test project_config::resolve::tests::test_resolve_legacy_config_errors ... ok
test project_config::discover::tests::test_discover_normalizes_dot_slash_paths ... ok
test project_config::resolve::tests::test_resolve_legacy_config_walk_up ... ok
test project_config::resolve::tests::test_resolve_with_app_flag ... ok
test project_config::resolve::tests::test_resolve_also_loads_app_config_when_service_found ... ok
test project_config::resolve::tests::test_resolve_from_service_config ... ok
test project_config::resolve::tests::test_resolve_service_config_takes_priority_over_app_config ... ok
test project_config::service_config::tests::test_load_service_config_missing_returns_none ... ok
test project_config::resolve::tests::test_resolve_with_app_flag_still_loads_configs ... ok
test project_config::discover::tests::test_service_toml_domain_preserved_when_no_app_override ... ok
test project_config::service_config::tests::test_api_defaults_to_public_ingress ... ok
test project_config::discover::tests::test_discover_multi_service_from_app_config_paths ... ok
test project_config::resolve::tests::test_resolve_walk_up_finds_config ... ok
test project_config::service_config::tests::test_load_service_config_valid ... ok
test project_config::resolve::tests::test_resolve_walk_up_prefers_closer_config ... ok
test project_config::service_config::tests::test_load_service_config_unknown_field_rejected ... ok
test project_config::service_config::tests::test_service_config_json_domain_included_when_set ... ok
test project_config::service_config::tests::test_service_config_json_domain_omitted_when_none ... ok
test project_config::service_config::tests::test_service_config_json_resources_included_when_set ... ok
test project_config::service_config::tests::test_service_config_json_resources_omitted_when_none ... ok
test project_config::service_config::tests::test_load_service_config_invalid_type ... ok
test project_config::service_config::tests::test_service_config_json_serialization ... ok
test project_config::service_config::tests::test_service_section_to_api_service_config ... ok
test project_config::service_config::tests::test_load_service_config_with_domain ... ok
test project_config::service_config::tests::test_load_service_config_with_resources ... ok
test project_config::service_config::tests::test_load_service_config_with_access_mode ... ok
test project_config::service_config::tests::test_to_api_service_config_passes_domain ... ok
test project_config::service_config::tests::test_load_service_config_without_domain ... ok
test project_config::service_config::tests::test_load_service_config_with_env_file ... ok
test project_config::service_config::tests::test_load_service_config_without_access_mode ... ok
test project_config::tests::test_validate_service_name_end_with_letter_or_digit ... ok
test project_config::tests::test_validate_service_name_special_chars ... ok
test project_config::tests::test_validate_service_name_start_with_letter ... ok
test project_config::tests::test_validate_service_name_too_long ... ok
test project_config::tests::test_validate_service_name_too_short ... ok
test project_config::tests::test_validate_service_name_uppercase_rejected ... ok
test project_config::tests::test_validate_service_name_valid ... ok
test resolve::tests::non_uuid_identifier_propagates_list_errors ... ok
test resolve::tests::returns_app_not_found_when_name_lookup_misses ... ok
test resolve::tests::non_uuid_identifier_skips_id_endpoint_lookup ... ok
test project_config::service_config::tests::test_worker_explicit_public_overrides_default ... ok
test resolve::tests::uuid_identifier_does_not_fall_back_when_id_lookup_fails ... ok
test resolve::tests::uuid_identifier_propagates_non_404_lookup_errors ... ok
test project_config::service_config::tests::test_worker_defaults_to_internal_ingress ... ok
test resolve::tests::uuid_identifier_uses_id_endpoint_first ... ok
test updater::tests::test_parse_checksum_invalid ... ok
test resolve::tests::uuid_identifier_propagates_validation_errors_without_fallback ... ok
test updater::tests::test_parse_checksum_ok ... ok
test updater::tests::test_resolve_install_path_override ... ok
test updater::tests::test_resolve_install_path_uses_current_exe_path ... ok
test project_config::service_config::tests::test_write_and_reload_service_config_with_domain ... ok
test version_check::tests::test_cache_is_fresh_recent ... ok
test version_check::tests::test_cache_is_stale ... ok
test project_config::service_config::tests::test_write_and_reload_service_config ... ok
test version_check::tests::test_is_newer_basic ... ok
test version_check::tests::test_is_newer_equal ... ok
test project_config::service_config::tests::test_load_service_config_without_resources ... ok
test version_check::tests::test_is_newer_invalid ... ok
test version_check::tests::test_is_newer_older ... ok
test version_check::tests::test_is_newer_v_prefix_mismatch ... ok
test version_check::tests::test_cache_serde_roundtrip ... ok
test version_check::tests::test_orphaned_downloading_cleaned_when_no_meta ... ok
test version_check::tests::test_downloading_kept_when_meta_exists ... ok
test version_check::tests::test_staged_meta_serde_roundtrip ... ok
test updater::tests::test_release_lookup_404 ... ok
test updater::tests::test_run_update_with_checksum_mismatch ... ok
test updater::tests::test_run_update_with_mock_server_success ... ok

test result: ok. 268 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 268 tests
test cli::tests::rewrite_leaves_bare_invocation_unchanged ... ok
test cli::tests::rewrite_version_long_flag ... ok
test cli::tests::rewrite_version_short_flag ... ok
test cli::tests::rewrite_leaves_version_subcommand_unchanged ... ok
test cli::tests::rewrite_leaves_subcommand_unchanged ... ok
test cli::tests::rewrite_leaves_help_flag_alone ... ok
test commands::analytics::tests::format_number_no_commas ... ok
test cli::tests::rewrite_version_with_json_flag ... ok
test commands::analytics::tests::format_number_with_commas ... ok
test commands::analytics::tests::format_period_known ... ok
test commands::analytics::tests::format_period_unknown ... ok
test commands::command_tree::tests::test_all_commands_have_descriptions ... ok
test commands::command_tree::tests::test_command_tree_not_empty ... ok
test commands::db::tests::test_value_to_display_null ... ok
test commands::db::tests::test_value_to_display_number ... ok
test commands::command_tree::tests::test_command_names_match_cli_enum ... ok
test commands::db::tests::test_value_to_display_string ... ok
test commands::db::tests::test_value_to_display_bool ... ok
test commands::deploys::tests::test_colored_status_unknown_passthrough ... ok
test commands::deploys::tests::test_colored_status_values ... ok
test commands::deploys::tests::test_is_real_log_placeholder ... ok
test commands::deploys::tests::test_is_real_log_empty ... ok
test commands::deploys::tests::test_is_real_log_placeholder_with_whitespace ... ok
test commands::deploy::tests::test_parse_env_file_soft_missing_file ... ok
test commands::deploys::tests::test_is_real_log_real_content ... ok
test commands::deploys::tests::test_is_real_log_whitespace_only ... ok
test commands::deploy::tests::test_parse_env_file_soft_empty_file ... ok
test commands::deploys::tests::test_relative_time_boundary_60_minutes ... ok
test commands::deploys::tests::test_relative_time_boundary_59_minutes ... ok
test commands::deploys::tests::test_relative_time_days_ago ... ok
test commands::deploys::tests::test_relative_time_seconds_ago ... ok
test commands::deploys::tests::test_relative_time_hours_ago ... ok
test commands::deploys::tests::test_relative_time_minutes_ago ... ok
test commands::deploy::tests::test_parse_env_file_soft_basic ... ok
test commands::deploys::tests::test_relative_time_invalid_input ... ok
test commands::deploys::tests::test_truncate_id_exactly_eight ... ok
test commands::deploys::tests::test_relative_time_naive_timestamp ... ok
test commands::deploy::tests::test_parse_env_file_soft_skips_malformed ... ok
test commands::deploys::tests::test_truncate_id_long ... ok
test commands::deploys::tests::test_truncate_id_non_ascii_not_sliced ... ok
test commands::deploys::tests::test_truncate_id_short ... ok
test commands::dev::tests::external_repo_without_dev_command_is_skipped_not_an_error ... ok
test commands::dev::tests::external_service_with_dev_command_still_runs ... ok
test commands::dev::tests::local_service_with_dev_command_is_runnable ... ok
test commands::dev::tests::local_service_without_dev_command_is_a_hard_error ... ok
test commands::docs::tests::test_auth_docs_has_key_concepts ... ok
test commands::docs::tests::test_deploy_explains_dockerfiles ... ok
test commands::docs::tests::test_deploy_mentions_github ... ok
test commands::docs::tests::test_docs_content_not_empty ... ok
test commands::docs::tests::test_overview_has_key_concepts ... ok
test commands::docs::tests::test_quickstart_has_full_flow ... ok
test commands::docs::tests::test_services_explains_routing ... ok
test commands::docs::tests::test_services_no_coming_soon ... ok
test commands::docs::tests::test_templates_has_react_fastapi ... ok
test commands::logs::tests::test_format_log_line_with_prefix ... ok
test commands::logs::tests::test_format_log_line_without_prefix ... ok
test commands::run::tests::shell_join_arg_with_spaces ... ok
test commands::logs::tests::test_format_log_line_with_prefix_missing_service_name ... ok
test commands::run::tests::shell_join_bin_with_spaces_quoted ... ok
test commands::run::tests::shell_join_dollar_sign_quoted ... ok
test commands::env::tests::test_parse_env_file_export_prefix ... ok
test commands::env::tests::test_parse_env_file_comments_and_blanks ... ok
test commands::env::tests::test_parse_env_file_quotes ... ok
test commands::run::tests::shell_join_flag_args ... ok
test commands::env::tests::test_parse_env_file_uppercase_keys ... ok
test commands::run::tests::shell_join_no_args ... ok
test commands::run::tests::shell_join_pipe_quoted ... ok
test commands::run::tests::shell_join_plain_args ... ok
test commands::run::tests::shell_join_semicolon_quoted ... ok
test commands::run::tests::shell_quote_embedded_single_quote ... ok
test commands::env::tests::test_parse_env_file_value_with_equals ... ok
test commands::skills::tests::test_plugin_skills_are_embedded ... ok
test commands::env::tests::test_parse_env_file_basic ... ok
test commands::skills::tests::test_recommended_permissions_read_only ... ok
test commands::skills::tests::test_security_skill_has_anti_patterns ... ok
test commands::skills::tests::test_services_skill_covers_all_services ... ok
test commands::skills::tests::test_recommended_permissions_read_write ... ok
test commands::skills::tests::test_skill_content_is_embedded ... ok
test commands::skills::tests::test_skill_content_has_key_sections ... ok
test commands::update::tests::test_floo_no_update_check_env_var_is_install_sh_contract ... ok
test commands::update::tests::test_display_tag_strips_leading_v ... ok
test config::tests::test_config_env_override ... ok
test commands::update::tests::test_version_skip_network_is_stable ... ok
test config::tests::test_add_skill_path_deduplicates ... ok
test config::tests::test_default_config ... ok
test commands::tests::load_app_config_for_resolved_app_reports_resolved_dir_in_error ... ok
test config::tests::test_config_dir_fallback ... ok
test config::tests::test_config_serialization ... ok
test config::tests::test_skill_paths_omitted_when_empty ... ok
test config::tests::test_config_dir_env_override ... ok
test detection::tests::test_default_port_go ... ok
test detection::tests::test_default_port_nodejs ... ok
test config::tests::test_config_without_skill_paths_deserializes ... ok
test detection::tests::test_default_port_python ... ok
test detection::tests::test_default_service_type_no_framework_is_web ... ok
test detection::tests::test_detect_go ... ok
test detection::tests::test_default_service_type_express_is_api ... ok
test config::tests::test_corrupted_config_file_returns_default ... ok
test detection::tests::test_detect_nodejs_express ... ok
test detection::tests::test_default_service_type_nextjs_is_web ... ok
test detection::tests::test_detect_nodejs_vite ... ok
test detection::tests::test_detect_python_fastapi ... ok
test detection::tests::test_detect_python_django_pyproject ... ok
test detection::tests::test_detect_unknown ... ok
test detection::tests::test_detection_result_to_value ... ok
test dockerfile::tests::test_detect_node_entry_default ... ok
test detection::tests::test_detect_python_flask ... ok
test detection::tests::test_detect_dockerfile ... ok
test detection::tests::test_detect_nodejs_nextjs ... ok
test dockerfile::tests::test_detect_node_entry_from_file_scan ... ok
test dockerfile::tests::test_detect_node_entry_from_main ... ok
test commands::tests::load_app_config_for_resolved_app_uses_resolved_config_dir ... ok
test dockerfile::tests::test_detect_package_manager_pnpm ... ok
test detection::tests::test_detect_static_html ... ok
test dockerfile::tests::test_detect_package_manager_default_npm ... ok
test detection::tests::test_dockerfile_takes_priority ... ok
test dockerfile::tests::test_detect_package_manager_npm ... ok
test dockerfile::tests::test_detect_python_entry_default ... ok
test dockerfile::tests::test_detect_python_version_default ... ok
test dockerfile::tests::test_detect_package_manager_yarn ... ok
test dockerfile::tests::test_detect_python_entry_from_file_scan ... ok
test dockerfile::tests::test_generic_node_uses_express_template ... ok
test dockerfile::tests::test_django_fallback_wsgi ... ok
test dockerfile::tests::test_flask_template ... ok
test dockerfile::tests::test_fastify_uses_express_template ... ok
test dockerfile::tests::test_detect_python_version_from_pyproject ... ok
test dockerfile::tests::test_fastapi_template ... ok
test dockerfile::tests::test_go_version_fallback ... ok
test dockerfile::tests::test_fastapi_with_version ... ok
test dockerfile::tests::test_django_template ... ok
test dockerfile::tests::test_express_template ... ok
test dockerfile::tests::test_go_template ... ok
test dockerfile::tests::test_returns_none_for_docker_runtime ... ok
test dockerfile::tests::test_nextjs_template ... ok
test errors::tests::test_error_code_as_str ... ok
test errors::tests::test_error_code_from_api ... ok
test errors::tests::test_floo_error_display ... ok
test dockerfile::tests::test_static_template ... ok
test dockerfile::tests::test_nextjs_pnpm ... ok
test errors::tests::test_floo_api_error ... ok
test dockerfile::tests::test_returns_none_for_unknown_runtime ... ok
test errors::tests::test_floo_error_with_suggestion ... ok
test dockerfile::tests::test_express_entry_point_fallback ... ok
test errors::tests::test_from_api_roundtrip_all_variants ... ok
test names::tests::test_generate_name_format ... ok
test names::tests::test_generate_name_not_empty ... ok
test output::tests::test_dry_run_mode_toggle ... ok
test output::tests::test_is_interactive_false_in_json_mode ... ok
test output::tests::test_json_mode_toggle ... ok
test dockerfile::tests::test_vite_template ... ok
test dockerfile::tests::test_nextjs_yarn ... ok
test project_config::app_config::tests::test_load_app_config_accepts_path_and_repo ... ok
test project_config::app_config::tests::test_load_app_config_github_section_defaults_none ... ok
test project_config::app_config::tests::test_load_app_config_invalid_access_mode ... ok
test project_config::app_config::tests::test_load_app_config_auth_unknown_field_rejected ... ok
test project_config::app_config::tests::test_load_app_config_missing_returns_none ... ok
test project_config::app_config::tests::test_load_app_config_inline_services_with_port ... ok
test project_config::app_config::tests::test_load_app_config_github_unknown_field_rejected ... ok
test project_config::app_config::tests::test_load_app_config_inline_requires_port_for_all_user_managed ... ok
test project_config::app_config::tests::test_load_app_config_invalid_service_type ... ok
test project_config::app_config::tests::test_load_app_config_minimal ... ok
test project_config::app_config::tests::test_load_app_config_repo_without_path_in_inline_mode ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_password ... ok
test project_config::app_config::tests::test_load_app_config_with_auth_redirect_uris ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_public ... ok
test project_config::app_config::tests::test_load_app_config_unknown_field_rejected ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_floo_accounts_alias ... ok
test project_config::app_config::tests::test_load_app_config_with_service_ingress ... ok
test project_config::app_config::tests::test_load_app_config_with_floo_managed_service ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_sso ... ok
test project_config::app_config::tests::test_load_app_config_mixed_services ... ok
test project_config::app_config::tests::test_load_app_config_with_access_mode_accounts ... ok
test project_config::app_config::tests::test_load_app_config_with_user_managed_service_path ... ok
test project_config::app_config::tests::test_load_app_config_with_github_section ... ok
test project_config::app_config::tests::test_load_app_config_with_user_managed_service_repo ... ok
test project_config::app_config::tests::test_write_and_reload_app_config ... ok
test project_config::discover::tests::test_discover_errors_no_deployable_services ... ok
test project_config::app_config::tests::test_load_app_config_without_auth_section ... ok
test project_config::app_config::tests::test_load_app_config_without_access_mode_defaults_none ... ok
test project_config::discover::tests::test_discover_errors_on_missing_service_toml ... ok
test project_config::discover::tests::test_discover_errors_on_app_name_mismatch ... ok
test project_config::discover::tests::test_app_toml_ingress_overrides_service_toml ... ok
test project_config::discover::tests::test_app_toml_domain_overrides_service_toml ... ok
test project_config::discover::tests::test_discover_inline_services_from_app_config ... ok
test project_config::discover::tests::test_all_internal_multi_service_errors ... ok
test project_config::discover::tests::test_discover_managed_services_empty_when_no_app_config ... ok
test project_config::discover::tests::test_discover_inline_errors_when_service_toml_exists ... ok
test project_config::discover::tests::test_discover_managed_services_empty_when_no_managed ... ok
test project_config::discover::tests::test_discover_inline_with_global_resources ... ok
test project_config::discover::tests::test_filter_empty_returns_all ... ok
test project_config::discover::tests::test_filter_unknown_name_errors ... ok
test project_config::discover::tests::test_discover_managed_services_postgres_redis ... ok
test project_config::discover::tests::test_discover_errors_on_duplicate_names ... ok
test project_config::discover::tests::test_discover_single_service_from_service_file ... ok
test project_config::discover::tests::test_filter_valid_subset ... ok
test project_config::discover::tests::test_discover_includes_root_service_with_app_paths ... ok
test project_config::discover::tests::test_discover_inline_worker_defaults_internal ... ok
test project_config::discover::tests::test_discover_skips_floo_managed_services ... ok
test project_config::discover::tests::test_single_service_with_resources ... ok
test project_config::resolve::tests::test_resolve_no_config_errors ... ok
test project_config::discover::tests::test_service_toml_domain_preserved_when_no_app_override ... ok
test project_config::resolve::tests::test_resolve_from_app_config ... ok
test project_config::resolve::tests::test_resolve_also_loads_app_config_when_service_found ... ok
test project_config::discover::tests::test_discover_normalizes_dot_slash_paths ... ok
test project_config::resolve::tests::test_resolve_with_app_flag ... ok
test project_config::resolve::tests::test_resolve_from_service_config ... ok
test project_config::resolve::tests::test_resolve_legacy_config_errors ... ok
test project_config::discover::tests::test_discover_multi_service_from_app_config_paths ... ok
test project_config::service_config::tests::test_load_service_config_missing_returns_none ... ok
test project_config::resolve::tests::test_resolve_legacy_config_walk_up ... ok
test project_config::service_config::tests::test_load_service_config_invalid_type ... ok
test project_config::resolve::tests::test_resolve_walk_up_prefers_closer_config ... ok
test project_config::service_config::tests::test_api_defaults_to_public_ingress ... ok
test project_config::resolve::tests::test_resolve_with_app_flag_still_loads_configs ... ok
test project_config::resolve::tests::test_resolve_walk_up_finds_config ... ok
test project_config::resolve::tests::test_resolve_service_config_takes_priority_over_app_config ... ok
test project_config::service_config::tests::test_service_config_json_domain_included_when_set ... ok
test project_config::service_config::tests::test_load_service_config_valid ... ok
test project_config::service_config::tests::test_load_service_config_unknown_field_rejected ... ok
test project_config::service_config::tests::test_service_config_json_domain_omitted_when_none ... ok
test project_config::service_config::tests::test_service_config_json_resources_included_when_set ... ok
test project_config::service_config::tests::test_service_config_json_resources_omitted_when_none ... ok
test project_config::service_config::tests::test_load_service_config_with_domain ... ok
test project_config::service_config::tests::test_service_section_to_api_service_config ... ok
test project_config::service_config::tests::test_service_config_json_serialization ... ok
test project_config::service_config::tests::test_load_service_config_with_env_file ... ok
test project_config::service_config::tests::test_to_api_service_config_passes_domain ... ok
test project_config::service_config::tests::test_load_service_config_without_access_mode ... ok
test project_config::service_config::tests::test_load_service_config_with_resources ... ok
test project_config::service_config::tests::test_load_service_config_with_access_mode ... ok
test project_config::tests::test_validate_service_name_end_with_letter_or_digit ... ok
test project_config::tests::test_validate_service_name_special_chars ... ok
test project_config::service_config::tests::test_load_service_config_without_resources ... ok
test project_config::tests::test_validate_service_name_start_with_letter ... ok
test project_config::tests::test_validate_service_name_too_long ... ok
test project_config::tests::test_validate_service_name_too_short ... ok
test project_config::tests::test_validate_service_name_uppercase_rejected ... ok
test resolve::tests::non_uuid_identifier_skips_id_endpoint_lookup ... ok
test project_config::tests::test_validate_service_name_valid ... ok
test resolve::tests::returns_app_not_found_when_name_lookup_misses ... ok
test resolve::tests::non_uuid_identifier_propagates_list_errors ... ok
test project_config::service_config::tests::test_load_service_config_without_domain ... ok
test resolve::tests::uuid_identifier_does_not_fall_back_when_id_lookup_fails ... ok
test project_config::service_config::tests::test_worker_defaults_to_internal_ingress ... ok
test resolve::tests::uuid_identifier_propagates_non_404_lookup_errors ... ok
test resolve::tests::uuid_identifier_propagates_validation_errors_without_fallback ... ok
test resolve::tests::uuid_identifier_uses_id_endpoint_first ... ok
test updater::tests::test_parse_checksum_invalid ... ok
test updater::tests::test_parse_checksum_ok ... ok
test updater::tests::test_resolve_install_path_uses_current_exe_path ... ok
test project_config::service_config::tests::test_worker_explicit_public_overrides_default ... ok
test version_check::tests::test_cache_is_fresh_recent ... ok
test updater::tests::test_resolve_install_path_override ... ok
test project_config::service_config::tests::test_write_and_reload_service_config ... ok
test project_config::service_config::tests::test_write_and_reload_service_config_with_domain ... ok
test version_check::tests::test_cache_is_stale ... ok
test version_check::tests::test_is_newer_equal ... ok
test version_check::tests::test_is_newer_invalid ... ok
test version_check::tests::test_is_newer_basic ... ok
test version_check::tests::test_is_newer_older ... ok
test version_check::tests::test_is_newer_v_prefix_mismatch ... ok
test version_check::tests::test_cache_serde_roundtrip ... ok
test version_check::tests::test_staged_meta_serde_roundtrip ... ok
test version_check::tests::test_orphaned_downloading_cleaned_when_no_meta ... ok
test version_check::tests::test_downloading_kept_when_meta_exists ... ok
test updater::tests::test_release_lookup_404 ... ok
test updater::tests::test_run_update_with_checksum_mismatch ... ok
test updater::tests::test_run_update_with_mock_server_success ... ok

test result: ok. 268 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 79 tests
test test_apps_help ... ok
test test_auth_register_missing_email ... ok
test test_auth_help ... ok
test test_auth_whoami_help ... ok
test test_auth_login_help ... ok
test test_auth_logout_json ... ok
test test_auth_register_help ... ok
test test_apps_list_not_authenticated ... ok
test test_auth_logout_succeeds ... ok
test test_apps_list_json_not_authenticated ... ok
test test_deploy_dry_run_missing_service_toml ... ok
test test_deploy_help ... ok
test test_auth_whoami_json_not_authenticated ... ok
test test_deploy_invalid_service_config ... ok
test test_auth_whoami_not_authenticated ... ok
test test_deploy_dry_run_port_mismatch_warning ... ok
test test_deploy_json_not_authenticated ... ok
test test_deploy_dry_run_valid_config ... ok
test test_deploy_invalid_service_config_json ... ok
test test_deploy_list_json_not_authenticated ... ok
test test_deploy_legacy_floo_toml ... ok
test test_deploy_list_not_authenticated ... ok
test test_deploy_list_help ... ok
test test_deploy_legacy_floo_toml_json ... ok
test test_deploy_rollback_help ... ok
test test_deploy_no_config_piped_errors ... ok
test test_deploy_not_authenticated ... ok
test test_deploy_watch_help ... ok
test test_deploy_rollback_json_not_authenticated ... ok
test test_domains_add_not_authenticated ... ok
test test_deploy_sync_env_help ... ok
test test_deploy_no_config_piped_json_errors ... ok
test test_deploy_rollback_not_authenticated ... ok
test test_domains_list_not_authenticated ... ok
test test_dry_run_domains_add ... ok
test test_domains_help ... ok
test test_dry_run_domains_remove ... ok
test test_dry_run_redeploy_restart ... ok
test test_dry_run_apps_delete ... ok
test test_dry_run_redeploy_rebuild ... ok
test test_dry_run_env_set ... ok
test test_dry_run_env_remove ... ok
test test_dry_run_unsupported_init ... ok
test test_env_help ... ok
test test_env_import_all_conflicts_with_file ... ok
test test_dry_run_rollback ... ok
test test_env_get_not_authenticated ... ok
test test_env_import_all_conflicts_with_services ... ok
test test_env_import_not_authenticated ... ok
test test_env_list_not_authenticated ... ok
test test_env_remove_not_authenticated ... ok
test test_env_set_not_authenticated ... ok
test test_env_set_invalid_format ... ok
test test_help ... ok
test test_init_detects_floo_env ... ok
test test_init_creates_config_json ... ok
test test_env_set_invalid_format_json ... ok
test test_init_falls_back_to_dot_env ... ok
test test_init_help ... ok
test test_init_prefers_floo_env_over_dot_env ... ok
test test_logs_json_not_authenticated ... ok
test test_init_refuses_existing_config ... ok
test test_logs_not_authenticated ... ok
test test_json_mode_no_version_check_output ... ok
test test_no_args_shows_help ... ok
test test_logs_help ... ok
test test_releases_promote_help ... ok
test test_services_info_json_not_authenticated ... ok
test test_init_requires_name_in_json_mode ... ok
test test_services_help ... ok
test test_no_update_check_env_var ... ok
test test_top_level_login_removed ... ok
test test_services_info_not_authenticated ... ok
test test_top_level_logout_removed ... ok
test test_top_level_whoami_removed ... ok
test test_version_command_json ... ok
test test_version ... ok
test test_version_command_human ... ok
test test_update_help ... ok

test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.91s


running 51 tests
test test_apps_list_api_error ... ok
test test_app_not_found_json ... ok
test test_apps_status_name_surfaces_list_apps_api_error ... ok
test test_apps_list_human ... ok
test test_apps_list_json ... ok
test test_apps_status_uuid_surfaces_get_app_api_error ... ok
test test_apps_status_json ... ok
test test_deploy_failed_json_includes_logs_and_suggestion ... ok
test test_apps_delete_json ... ok
test test_deploy_existing_app_by_name_json ... ok
test test_deploy_list_json ... ok
test test_deploy_list_from_config ... ok
test test_deploy_rollback_json ... ok
test test_deploy_new_app_json ... ok
test test_domains_add_json ... ok
test test_domains_list_json ... ok
test test_deploy_fails_with_invalid_response_when_app_id_missing ... ok
test test_domains_list_multi_service_requires_services_flag ... ok
test test_domains_list_multi_service_with_services_flag ... ok
test test_domains_remove_json ... ok
test test_domains_status_json ... ok
test test_domains_watch_fails_on_failed_status ... ok
test test_domains_watch_becomes_active ... ok
test test_domains_status_not_found ... ok
test test_deploy_json_mode_uses_polling ... ok
test test_domains_watch_timeout ... ok
test test_deploy_with_sse_streaming ... ok
test test_env_get_human_raw_stdout ... ok
test test_env_import_json ... ok
test test_env_list_json ... ok
test test_logs_from_config_file ... ok
test test_env_multiple_services_error ... ok
test test_env_set_json ... ok
test test_env_remove_json ... ok
test test_env_get_json ... ok
test test_logs_human ... ok
test test_logs_json ... ok
test test_services_info_app_not_found ... ok
test test_logs_no_config_no_app_errors ... ok
test test_logs_single_service_no_prefix ... ok
test test_logs_multi_services ... ok
test test_logs_search_filter ... ok
test test_releases_list_from_config ... ok
test test_services_info_db_falls_back_to_databases_endpoint ... ok
test test_update_json_release_lookup_failure ... ok
test test_services_info_surfaces_api_errors ... ok
test test_services_info_user_managed ... ok
test test_services_info_db_uses_db_endpoint ... ok
test test_services_list_json ... ok
test test_update_json_success ... ok
test test_deploy_sse_fallback_to_polling ... ok

test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.06s