### PR TITLE
feat(logs): add --requests flag to surface gateway request logs

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -762,6 +762,21 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_request_logs(
+        &self,
+        app_id: &str,
+        limit: u32,
+        since: Option<&str>,
+    ) -> Result<RequestLogsResponse, FlooApiError> {
+        let limit_str = limit.to_string();
+        let mut params: Vec<(&str, &str)> = vec![("limit", &limit_str)];
+        if let Some(s) = since {
+            params.push(("since", s));
+        }
+        let resp = self.get_with_query(&format!("/v1/apps/{app_id}/requests"), &params)?;
+        self.handle_response(resp)
+    }
+
     // --- GitHub ---
 
     pub fn github_setup_begin(&self) -> Result<Value, FlooApiError> {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -247,6 +247,25 @@ pub struct LogsResponse {
     pub logs: Vec<LogEntry>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestLogEntry {
+    pub timestamp: String,
+    pub method: String,
+    pub path: Option<String>,
+    pub host: Option<String>,
+    pub status_code: i32,
+    pub latency_ms: i32,
+    pub access_mode: String,
+    pub user_identity: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestLogsResponse {
+    pub requests: Vec<RequestLogEntry>,
+    pub total: i32,
+    pub app_name: String,
+}
+
 // --- Release ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -250,6 +250,12 @@ Examples:
         /// Environment to query: dev or prod.
         #[arg(long, value_parser = ["dev", "prod"])]
         env: Option<String>,
+
+        /// Show HTTP requests captured by floo's gateway instead of app-level
+        /// log output. Each line is one proxied request with the public URL,
+        /// status, and latency.
+        #[arg(long)]
+        requests: bool,
     },
 
     /// Install agent skills for AI coding assistants.
@@ -1229,23 +1235,32 @@ pub fn run() {
             live,
             output,
             env,
+            requests,
         } => {
-            let severity = if error {
-                Some("ERROR".to_string())
+            if requests {
+                commands::logs::request_logs(commands::logs::RequestLogsArgs {
+                    app_flag: app,
+                    tail,
+                    since,
+                });
             } else {
-                severity
-            };
-            commands::logs::logs(commands::logs::LogsArgs {
-                app_flag: app,
-                tail,
-                since,
-                severity,
-                services,
-                search,
-                live,
-                output_path: output,
-                env,
-            });
+                let severity = if error {
+                    Some("ERROR".to_string())
+                } else {
+                    severity
+                };
+                commands::logs::logs(commands::logs::LogsArgs {
+                    app_flag: app,
+                    tail,
+                    since,
+                    severity,
+                    services,
+                    search,
+                    live,
+                    output_path: output,
+                    env,
+                });
+            }
         }
         Commands::Version => commands::update::version(),
         Commands::Update { version } => commands::update::update(version.as_deref()),

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use colored::Colorize;
 
-use crate::api_types::LogEntry;
+use crate::api_types::{LogEntry, RequestLogEntry};
 use crate::errors::ErrorCode;
 use crate::output;
 use crate::project_config::{self, AppSource};
@@ -508,6 +508,110 @@ fn live_logs(
             }
             update_last_timestamp(&mut last_timestamp, entry);
         }
+    }
+}
+
+// ─── floo logs --requests ──────────────────────────────────────────────────
+
+pub struct RequestLogsArgs {
+    pub app_flag: Option<String>,
+    pub tail: u32,
+    pub since: Option<String>,
+}
+
+fn format_request_line(entry: &RequestLogEntry) -> String {
+    let status_str = entry.status_code.to_string();
+    let colored_status = match entry.status_code / 100 {
+        2 => status_str.green().to_string(),
+        3 => status_str.cyan().to_string(),
+        4 => status_str.yellow().to_string(),
+        5 => status_str.red().bold().to_string(),
+        _ => status_str,
+    };
+    let latency = if entry.latency_ms < 1000 {
+        format!("{}ms", entry.latency_ms)
+    } else {
+        format!("{:.2}s", entry.latency_ms as f64 / 1000.0)
+    };
+    let url = match (&entry.host, &entry.path) {
+        (Some(h), Some(p)) => format!("https://{h}{p}"),
+        (Some(h), None) => format!("https://{h}"),
+        (None, Some(p)) => p.clone(),
+        (None, None) => "-".to_string(),
+    };
+    format!(
+        "{} {} {} {} ({})",
+        entry.timestamp,
+        entry.method.bold(),
+        colored_status,
+        url,
+        latency,
+    )
+}
+
+pub fn request_logs(args: RequestLogsArgs) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let app_data = if let Some(ref app_flag) = args.app_flag {
+        match resolve_app(&client, app_flag) {
+            Ok(a) => a,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        }
+    } else {
+        let cwd = std::env::current_dir().unwrap_or_else(|e| {
+            output::error(
+                &format!("Failed to read current directory: {e}"),
+                &ErrorCode::FileError,
+                None,
+            );
+            process::exit(1);
+        });
+        let resolved = match project_config::resolve_app_context(&cwd, None) {
+            Ok(r) => r,
+            Err(e) => {
+                output::error(&e.message, &e.code, e.suggestion.as_deref());
+                process::exit(1);
+            }
+        };
+        match resolve_app(&client, &resolved.app_name) {
+            Ok(a) => a,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        }
+    };
+
+    let result = match client.get_request_logs(&app_data.id, args.tail, args.since.as_deref()) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(
+                &format!("Failed to fetch request logs: {e}"),
+                &ErrorCode::from_api("REQUESTS_FETCH_FAILED"),
+                None,
+            );
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::print_json(&output::to_value(&result));
+        return;
+    }
+
+    if result.requests.is_empty() {
+        output::dim_line(&format!("No requests yet for {}.", app_data.name));
+        return;
+    }
+
+    // Newest-first from the API — reverse so the console reads top-to-bottom
+    // oldest-to-newest, like `tail -f`.
+    for entry in result.requests.iter().rev() {
+        output::dim_line(&format_request_line(entry));
     }
 }
 


### PR DESCRIPTION
## Summary

Pairs with getfloo/floo#639 (new `GET /v1/apps/{app_id}/requests` endpoint). Gives CLI users the same two log classes the dashboard shows:

- `floo logs --app myapp` — app-level stdout/stderr (unchanged)
- `floo logs --app myapp --requests` — gateway-captured HTTP requests, one row per proxied request, with public URL, status, and latency

Output format:

```
2026-04-24T12:34:56Z POST 502 https://myapp.on.getfloo.com/foo (386ms)
```

Status codes are colorized by class (green 2xx, cyan 3xx, amber 4xx, red 5xx). Newest-first from the API is reversed so the console reads oldest → newest like `tail -f`.

## Why

App-level access logs leak internal Cloud Run hostnames and depend on whatever format the customer's logger uses. The gateway captures every proxied request structurally — public URL, method, status, latency, access mode. Exposing it as its own class in the CLI (like Vercel's "Runtime Logs" vs function stdout) gives users a clean, proxy-level record that isn't at the mercy of their framework's access-log formatter.

## What this PR doesn't do (deliberately)

`--live`, `--services`, `--search`, `--output` are unsupported for `--requests` in this first cut. `--since` + `--tail` are the two filters that map to the server endpoint today. Easy to add later.

## Deploy order

CLI can ship independently of the API. The endpoint is already registered in getfloo/floo#639; once that deploys to dev, users can run this CLI against it. If a user runs this CLI against a floo API that predates the endpoint, they'll get a clear 404 from the server surfaced as the CLI error.

## Test plan
- [x] `cargo test` — 130 passing across both `floo` and `floo-local` binaries
- [x] `cargo check` clean
- [ ] Manual: `floo logs --app floo-crm --requests --since 1h` against dev after the paired floo PR deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)