### PR TITLE
fix(cli): 2026-04-24 feedback batch — superseded deploys, dry-run safety, contract drift

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -183,9 +183,14 @@ pub struct ListEnvVarsResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetEnvVarResponse {
-    pub key: Option<String>,
+    pub id: String,
+    pub app_id: String,
+    pub environment_id: String,
+    pub service_id: Option<String>,
+    pub key: String,
     pub masked_value: Option<String>,
-    pub status: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 // --- Service ---
@@ -389,21 +394,42 @@ pub struct AnalyticsSummary {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppAnalyticsResponse {
+    pub app_id: Option<String>,
+    pub period: Option<String>,
     pub summary: AnalyticsSummary,
-    pub time_series: Option<Vec<TimeSeriesPoint>>,
-    pub apps: Option<Vec<AppAnalyticsEntry>>,
+    #[serde(default)]
+    pub time_series: Vec<TimeSeriesPoint>,
+    #[serde(default)]
+    pub top_users: Vec<TopUser>,
+    // org-level response reuses this struct and supplies `apps`; for app-level
+    // it stays an empty array. `#[serde(default)]` keeps it [] in JSON output
+    // instead of null.
+    #[serde(default)]
+    pub apps: Vec<AppAnalyticsEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeSeriesPoint {
+    pub period_start: String,
     pub request_count: i64,
-    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub error_count: i64,
+    #[serde(default)]
+    pub error_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopUser {
+    pub identity: String,
+    pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppAnalyticsEntry {
+    pub app_id: Option<String>,
     pub app_name: String,
     pub total_requests: i64,
     pub total_errors: i64,
     pub error_rate: f64,
+    pub avg_latency_ms: Option<i64>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,6 +144,7 @@ need to apply env var changes or force a rebuild without a code change.")]
     /// View and manage deploy history.
     #[command(
         name = "deploys",
+        alias = "deploy",
         subcommand,
         after_help = "\
 Examples:
@@ -152,7 +153,8 @@ Examples:
   floo deploys watch --app my-app           Stream deploy progress
   floo deploys rollback my-app abc123       Rollback to a previous deploy
 
-Note: To trigger a deploy, use `floo redeploy` or push to GitHub."
+Note: To trigger a deploy, use `floo redeploy` or push to GitHub.
+`floo deploy ...` is a backwards-compatible alias for `floo deploys ...`."
     )]
     Deploys(DeploysSubcommands),
 
@@ -962,12 +964,26 @@ fn reject_unsupported_dry_run(command: &Commands) {
             )
             | Commands::Apps(AppsCommands::Invite { .. })
             | Commands::Billing(BillingCommands::SpendCap(SpendCapCommands::Set { .. }))
+            | Commands::Run { .. }
+            | Commands::Db(DbCommands::Migrate { .. })
+            | Commands::Cron(CronCommands::Run { .. })
+            | Commands::Feedback { .. }
+            | Commands::Skills(SkillsCommands::Install { .. })
+            | Commands::Auth(
+                AuthCommands::Login { .. }
+                    | AuthCommands::Logout
+                    | AuthCommands::Register { .. }
+                    | AuthCommands::UpdateProfile { .. }
+            )
     );
     if unsupported {
         output::error(
             "--dry-run is not supported for this command.",
             &crate::errors::ErrorCode::InvalidFormat,
-            Some("Supported commands: redeploy, preflight, env set/remove/import, apps delete, domains add/remove, deploy rollback."),
+            Some(
+                "Supported: redeploy, preflight, dev, update, env set/remove/import, \
+                 apps delete, domains add/remove, cron add, deploys rollback.",
+            ),
         );
         std::process::exit(1);
     }

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -92,12 +92,10 @@ fn render_app_analytics(name: &str, period: &str, data: &AppAnalyticsResponse) {
         }
     }
 
-    if let Some(time_series) = &data.time_series {
-        if !time_series.is_empty() {
-            eprintln!();
-            eprintln!("Traffic");
-            render_sparkline(time_series);
-        }
+    if !data.time_series.is_empty() {
+        eprintln!();
+        eprintln!("Traffic");
+        render_sparkline(&data.time_series);
     }
 
     eprintln!();
@@ -130,32 +128,29 @@ fn render_org_analytics(period: &str, data: &AppAnalyticsResponse) {
         format_number(apps_with_traffic)
     );
 
-    if let Some(apps) = &data.apps {
-        if !apps.is_empty() {
-            eprintln!();
+    if !data.apps.is_empty() {
+        eprintln!();
 
-            let rows: Vec<Vec<String>> = apps
-                .iter()
-                .map(|a| {
-                    vec![
-                        a.app_name.clone(),
-                        format_number(a.total_requests),
-                        format_number(a.total_errors),
-                        format!("{:.2}%", a.error_rate * 100.0),
-                    ]
-                })
-                .collect();
+        let rows: Vec<Vec<String>> = data
+            .apps
+            .iter()
+            .map(|a| {
+                vec![
+                    a.app_name.clone(),
+                    format_number(a.total_requests),
+                    format_number(a.total_errors),
+                    format!("{:.2}%", a.error_rate * 100.0),
+                ]
+            })
+            .collect();
 
-            output::table(&["App", "Requests", "Errors", "Error Rate"], &rows, None);
-        }
+        output::table(&["App", "Requests", "Errors", "Error Rate"], &rows, None);
     }
 
-    if let Some(time_series) = &data.time_series {
-        if !time_series.is_empty() {
-            eprintln!();
-            eprintln!("Traffic");
-            render_sparkline(time_series);
-        }
+    if !data.time_series.is_empty() {
+        eprintln!();
+        eprintln!("Traffic");
+        render_sparkline(&data.time_series);
     }
 
     eprintln!();

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -154,7 +154,24 @@ pub fn migrate(app_flag: Option<&str>, env: &str) {
     let result = match client.db_migrate(&app_id, env) {
         Ok(r) => r,
         Err(e) => {
-            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            let suggestion = match e.code.as_str() {
+                "AGENT_MODE_DDL_BLOCKED" => Some(
+                    "Migrations run DDL, which requires agent_mode = \"autonomous\". \
+                     Set agent_mode in [app] in floo.app.toml (or omit it to default \
+                     to autonomous), commit, then push to redeploy before re-running.",
+                ),
+                "AGENT_MODE_READONLY" => Some(
+                    "Agent mode is \"readonly\". Set agent_mode = \"autonomous\" in \
+                     [app] in floo.app.toml to run migrations.",
+                ),
+                "AGENT_MODE_SUPERVISED" => Some(
+                    "Agent mode is \"supervised\", which blocks prod migrations. \
+                     Run against --env dev, or set agent_mode = \"autonomous\" in \
+                     [app] in floo.app.toml.",
+                ),
+                _ => None,
+            };
+            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
             process::exit(1);
         }
     };

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -18,7 +18,7 @@ use crate::resolve::resolve_app;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
-pub(crate) const TERMINAL_STATUSES: &[&str] = &["live", "failed"];
+pub(crate) const TERMINAL_STATUSES: &[&str] = &["live", "failed", "superseded"];
 
 fn status_label(status: &str) -> &str {
     match status {
@@ -624,6 +624,18 @@ pub fn deploy(
         process::exit(1);
     }
 
+    if final_status == "superseded" {
+        output::success(
+            "Deploy superseded by a newer deploy.",
+            Some(serde_json::json!({
+                "app": output::to_value(&app_data),
+                "deploy": output::to_value(&deploy_data),
+                "detection": detection.to_value(),
+            })),
+        );
+        return;
+    }
+
     let url = deploy_data.url.as_deref().unwrap_or("");
 
     if !output::is_json_mode() {
@@ -712,6 +724,17 @@ fn deploy_restart(
             })),
         );
         process::exit(1);
+    }
+
+    if final_status == "superseded" {
+        output::success(
+            "Restart superseded by a newer deploy.",
+            Some(serde_json::json!({
+                "app": output::to_value(app_data),
+                "deploy": deploy_data,
+            })),
+        );
+        return;
     }
 
     let env_display = deploy_data
@@ -821,6 +844,17 @@ fn deploy_rebuild(
             })),
         );
         process::exit(1);
+    }
+
+    if final_status == "superseded" {
+        output::success(
+            "Rebuild superseded by a newer deploy.",
+            Some(serde_json::json!({
+                "app": output::to_value(app_data),
+                "deploy": output::to_value(&deploy_data),
+            })),
+        );
+        return;
     }
 
     let url = deploy_data.url.as_deref().unwrap_or("");

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -692,7 +692,7 @@ fn deploy_restart(
     };
 
     let spinner = output::Spinner::new("Restarting...");
-    let deploy_data = match client.restart_app(app_id, svcs) {
+    let raw_deploy = match client.restart_app(app_id, svcs) {
         Ok(d) => {
             spinner.finish();
             d
@@ -704,14 +704,54 @@ fn deploy_restart(
         }
     };
 
-    let final_status = deploy_data
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let url = deploy_data
-        .get("url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("(no URL)");
+    // The restart endpoint returns 202 with a DeployResponse — the pipeline
+    // runs out-of-band, so the status is typically "pending" at this point.
+    // Match the main deploy path and wait for a terminal status before
+    // reporting back. Otherwise `floo redeploy --json` returns while the
+    // deploy is still in progress and agents have to poll manually. See
+    // feedback 966b2a4a.
+    let mut deploy_data: Deploy = match serde_json::from_value(raw_deploy.clone()) {
+        Ok(d) => d,
+        Err(_) => {
+            // Server response didn't match the Deploy shape — surface what we
+            // got instead of silently pretending restart succeeded.
+            output::error_with_data(
+                "Restart returned an unexpected response shape.",
+                &ErrorCode::RestartFailed,
+                Some("Run `floo deploys list --app <name>` to check deploy status."),
+                Some(serde_json::json!({
+                    "app": output::to_value(app_data),
+                    "deploy": raw_deploy,
+                })),
+            );
+            process::exit(1);
+        }
+    };
+
+    let initial_status = deploy_data.status.as_deref().unwrap_or("");
+    if !TERMINAL_STATUSES.contains(&initial_status) {
+        let deploy_id = deploy_data.id.clone();
+        deploy_data = if !output::is_json_mode() {
+            match stream_deploy(client, app_id, &deploy_id) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!(
+                        "Stream unavailable ({}), falling back to polling...",
+                        e.code
+                    );
+                    poll_deploy(client, app_id, &deploy_data)
+                }
+            }
+        } else {
+            match stream_deploy_json(client, app_id, &deploy_id) {
+                Ok(d) => d,
+                Err(_) => poll_deploy(client, app_id, &deploy_data),
+            }
+        };
+    }
+
+    let final_status = deploy_data.status.as_deref().unwrap_or("");
+    let url = deploy_data.url.as_deref().unwrap_or("(no URL)");
 
     if final_status == "failed" {
         output::error_with_data(
@@ -720,7 +760,7 @@ fn deploy_restart(
             Some("Run `floo logs` for details."),
             Some(serde_json::json!({
                 "app": output::to_value(app_data),
-                "deploy": deploy_data,
+                "deploy": output::to_value(&deploy_data),
             })),
         );
         process::exit(1);
@@ -731,22 +771,22 @@ fn deploy_restart(
             "Restart superseded by a newer deploy.",
             Some(serde_json::json!({
                 "app": output::to_value(app_data),
-                "deploy": deploy_data,
+                "deploy": output::to_value(&deploy_data),
             })),
         );
         return;
     }
 
     let env_display = deploy_data
-        .get("environment_name")
-        .and_then(|v| v.as_str())
+        .environment_name
+        .as_deref()
         .map(|e| format!("{e} \u{2192} "))
         .unwrap_or_default();
     output::success(
         &format!("Restarted {env_display}{url}"),
         Some(serde_json::json!({
             "app": output::to_value(app_data),
-            "deploy": deploy_data,
+            "deploy": output::to_value(&deploy_data),
         })),
     );
 }

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -306,6 +306,7 @@ fn colored_status(status: &str) -> String {
     match status {
         "live" => status.green().bold().to_string(),
         "failed" => status.red().bold().to_string(),
+        "superseded" => status.dimmed().to_string(),
         "building" | "deploying" | "pending" => status.yellow().to_string(),
         _ => status.to_string(),
     }
@@ -510,6 +511,13 @@ fn print_final_status(deploy: &Deploy) {
             Some("Check build output above, or run `floo logs` for details."),
         );
         process::exit(1);
+    } else if status == "superseded" {
+        output::success(
+            "Deploy superseded by a newer deploy.",
+            Some(serde_json::json!({
+                "deploy": output::to_value(deploy),
+            })),
+        );
     } else if !TERMINAL_STATUSES.contains(&status) {
         output::error(
             &format!("Deploy ended in unexpected state: {status}"),
@@ -576,10 +584,22 @@ mod tests {
         // Verify colored_status returns non-empty strings for all known statuses
         assert!(!colored_status("live").is_empty());
         assert!(!colored_status("failed").is_empty());
+        assert!(!colored_status("superseded").is_empty());
         assert!(!colored_status("building").is_empty());
         assert!(!colored_status("deploying").is_empty());
         assert!(!colored_status("pending").is_empty());
         assert!(!colored_status("unknown").is_empty());
+    }
+
+    #[test]
+    fn test_superseded_is_terminal_status() {
+        // TERMINAL_STATUSES must include "superseded" so poll/stream loops exit
+        // when the platform marks a deploy as superseded. Before this was added,
+        // `floo deploys watch` would spin for POLL_TIMEOUT (10 min) on superseded
+        // deploys. See feedback 1748af72 (2026-04-24).
+        assert!(TERMINAL_STATUSES.contains(&"superseded"));
+        assert!(TERMINAL_STATUSES.contains(&"live"));
+        assert!(TERMINAL_STATUSES.contains(&"failed"));
     }
 
     #[test]

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -180,6 +180,39 @@ pub fn dev(app_flag: Option<String>) {
         }
     }
 
+    // --- Dry run short-circuit ---
+    //
+    // Dry-run must NOT call create_dev_session. That endpoint has two real
+    // side effects: (1) it registers a dev session row on the platform, and
+    // (2) it returns managed-service credentials (DATABASE_URL, REDIS_URL, …).
+    // Previously `floo dev --dry-run --json` did both — the returned env vars
+    // then landed in stdout / agent logs. See feedback 6af7c0c2.
+    //
+    // Dry-run emits a plan describing which services WOULD start on which
+    // ports, with no session, no env vars, and no child processes.
+    if output::is_dry_run_mode() {
+        let plan_services: Vec<serde_json::Value> = services
+            .iter()
+            .map(|svc| {
+                serde_json::json!({
+                    "name": svc.name,
+                    "port": svc.port,
+                    "url": format!("http://localhost:{}", svc.port),
+                    "path": svc.path,
+                    "dev_command": svc.dev_command,
+                    "migrate_command": svc.migrate_command,
+                })
+            })
+            .collect();
+        output::dry_run_success(serde_json::json!({
+            "action": "start_dev_session",
+            "app": app_name,
+            "services": plan_services,
+            "skipped_external": skipped_external,
+        }));
+        return;
+    }
+
     // --- Create dev session via API ---
     let api_services: Vec<crate::api_types::DevSessionService> = services
         .iter()

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -251,6 +251,20 @@ pub fn connect(
                 })),
             );
         }
+        DeployOutcome::Superseded { deploy } => {
+            output::success(
+                &format!("Connected {name} to {repo} — deploy superseded by a newer deploy."),
+                Some(serde_json::json!({
+                    "connected": true,
+                    "app": name,
+                    "repo": repo,
+                    "branch": connected_branch,
+                    "deployed": false,
+                    "deploy_status": "superseded",
+                    "deploy": deploy,
+                })),
+            );
+        }
         DeployOutcome::Failed { deploy } => {
             output::error_with_data(
                 &format!("Connected {name} to {repo} but deploy failed."),
@@ -599,6 +613,9 @@ enum DeployOutcome {
         url: String,
         deploy: serde_json::Value,
     },
+    Superseded {
+        deploy: serde_json::Value,
+    },
     Failed {
         deploy: serde_json::Value,
     },
@@ -725,6 +742,10 @@ fn run_initial_deploy(
         let url = deploy_data.url.as_deref().unwrap_or("").to_string();
         DeployOutcome::Live {
             url,
+            deploy: output::to_value(&deploy_data),
+        }
+    } else if final_status == "superseded" {
+        DeployOutcome::Superseded {
             deploy: output::to_value(&deploy_data),
         }
     } else {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -7,9 +7,7 @@ use crate::dockerfile;
 use crate::errors::ErrorCode;
 use crate::names::generate_name;
 use crate::output;
-use crate::project_config::{
-    self, AppFileAppSection, AppFileConfig, AppServiceEntry, ServiceType,
-};
+use crate::project_config::{self, AppFileAppSection, AppFileConfig, AppServiceEntry, ServiceType};
 
 pub fn init(name: Option<String>, path: PathBuf) {
     let project_path = match path.canonicalize() {
@@ -276,7 +274,11 @@ fn init_interactive(
                 Some(name) => {
                     let use_it =
                         output::confirm(&format!("  {name} detected. Use it for cloud deploy?"));
-                    if use_it { Some(name) } else { None }
+                    if use_it {
+                        Some(name)
+                    } else {
+                        None
+                    }
                 }
                 None => None,
             };

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -143,7 +143,10 @@ pub fn update(version: Option<&str>) {
         match updater::check_update(version) {
             Ok(plan) => {
                 let message = if plan.already_up_to_date {
-                    format!("floo {} is already the latest version.", plan.current_version)
+                    format!(
+                        "floo {} is already the latest version.",
+                        plan.current_version
+                    )
                 } else {
                     format!(
                         "Would update floo from {} to {}.",

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -136,6 +136,38 @@ fn emit_version(freshly_installed: Option<&str>) {
 }
 
 pub fn update(version: Option<&str>) {
+    // Dry-run: resolve the target release but never download or install.
+    // Previously --dry-run silently fell through to run_update(), which
+    // replaces the binary on disk. See feedback 7b98b798.
+    if output::is_dry_run_mode() {
+        match updater::check_update(version) {
+            Ok(plan) => {
+                let message = if plan.already_up_to_date {
+                    format!("floo {} is already the latest version.", plan.current_version)
+                } else {
+                    format!(
+                        "Would update floo from {} to {}.",
+                        plan.current_version,
+                        display_tag(&plan.target_version),
+                    )
+                };
+                output::dry_run_success(serde_json::json!({
+                    "action": "update",
+                    "current_version": plan.current_version,
+                    "target_version": display_tag(&plan.target_version),
+                    "install_path": plan.install_path,
+                    "already_up_to_date": plan.already_up_to_date,
+                    "message": message,
+                }));
+            }
+            Err(err) => {
+                output::error(&err.message, &err.code, err.suggestion.as_deref());
+                process::exit(1);
+            }
+        }
+        return;
+    }
+
     if !output::is_json_mode() {
         let label = version.unwrap_or("latest");
         output::info(&format!("Checking for Floo updates ({label})..."), None);

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -374,6 +374,41 @@ pub fn run_update(version: Option<&str>) -> Result<UpdateResult, FlooError> {
     run_update_with(&client, version, &api_base, &install_path)
 }
 
+pub struct UpdatePlan {
+    pub current_version: String,
+    pub target_version: String,
+    pub install_path: PathBuf,
+    pub already_up_to_date: bool,
+}
+
+/// Dry-run equivalent of `run_update`: resolves which release WOULD be installed
+/// without downloading the binary, verifying its checksum, or touching disk.
+/// Reports the release the updater would have targeted so `--dry-run` callers
+/// can see the plan without mutating the binary. See feedback 7b98b798.
+pub fn check_update(version: Option<&str>) -> Result<UpdatePlan, FlooError> {
+    let client = build_http_client()?;
+    let api_base = releases_api_base();
+    let install_path = resolve_install_path()?;
+    let asset_name = target_asset_name()?;
+    let release_json = fetch_release_json(&client, &api_base, version)?;
+    let release_asset = release_asset_from_json(&release_json, &asset_name)?;
+
+    let current = crate::constants::VERSION.to_string();
+    let remote = release_asset
+        .version
+        .strip_prefix('v')
+        .unwrap_or(&release_asset.version)
+        .to_string();
+    let already_up_to_date = version.is_none() && remote == current;
+
+    Ok(UpdatePlan {
+        current_version: current,
+        target_version: release_asset.version,
+        install_path,
+        already_up_to_date,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -314,7 +314,18 @@ fn test_env_set_json() {
         .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"key":"MY_KEY","masked_value":"my_v****"}"#)
+        .with_body(
+            r#"{
+                "id":"00000000-0000-0000-0000-000000000001",
+                "app_id":"00000000-0000-0000-0000-0000000000aa",
+                "environment_id":"00000000-0000-0000-0000-0000000000ee",
+                "service_id":null,
+                "key":"MY_KEY",
+                "masked_value":"my_v****",
+                "created_at":"2026-04-24T00:00:00Z",
+                "updated_at":"2026-04-24T00:00:00Z"
+            }"#,
+        )
         .create();
 
     floo()
@@ -687,10 +698,7 @@ fn test_domains_status_not_found() {
     let _resolve = mock_resolve_app(&mut server);
 
     let _m_list = server
-        .mock(
-            "GET",
-            format!("/v1/apps/{TEST_APP_ID}/domains").as_str(),
-        )
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/domains").as_str())
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"domains":[]}"#)


### PR DESCRIPTION
## Summary
Batch fix for the CLI feedback items triaged on 2026-04-24. Three commits, all independently reviewable:

1. **superseded deploys are now terminal** — closes a silent regression introduced by platform PR getfloo/floo#636 where `TERMINAL_STATUSES = ["live", "failed"]` caused `floo deploys watch` to spin for 10 min on superseded deploys and `floo deploy/redeploy/rebuild` / `floo github connect` to misreport them as failures (exit 1).
2. **SEV1 dry-run fixes** — `floo dev --dry-run --json` was calling `create_dev_session` and returning managed-service credentials in stdout; `floo update --dry-run` was downloading the binary and overwriting it on disk. Both now honor `--dry-run` properly.
3. **Contract + UX + dry-run drift cleanup** — env set response shape, deploys alias, db migrate agent-mode hints, redeploy waits for terminal, analytics field rename + null-vs-empty, and reject-list completeness for unimplemented `--dry-run` commands.

## Changes by feedback ID
- `1748af72` — superseded status as distinct terminal state across the CLI
- `6af7c0c2` — `floo dev --dry-run` no longer leaks secrets or creates a server-side session
- `7b98b798` — `floo update --dry-run` no longer mutates the binary
- `dfbdf3e2` — `env set --json` returns the real API response shape (id, app_id, environment_id, service_id, key, masked_value, created_at, updated_at) instead of a phantom `status: null`
- `282ce0fd` — `floo deploy ...` is a backwards-compatible alias for `floo deploys ...`
- `c5d581e7` — `floo db migrate` surfaces targeted suggestions for `AGENT_MODE_DDL_BLOCKED` / `AGENT_MODE_READONLY` / `AGENT_MODE_SUPERVISED`
- `966b2a4a` — `floo redeploy` waits for a terminal status (uses same stream/poll path as the main deploy flow)
- `7d4e6236` — analytics types match server schema (`period_start`, `error_count`, `error_rate`); collection fields emit `[]` not `null`
- `e1095ec1`, `ada87f6b` — `reject_unsupported_dry_run` is complete and its suggestion text lists every currently-supported command

## Test plan
- [x] `cargo test` (all 334 unit + integration tests pass)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] Added `test_superseded_is_terminal_status` regression test
- [x] Updated `test_env_set_json` mock to match new response shape

## Prod cut
Platform-side partner (getfloo/floo#636) still pending — cut the CLI once this merges and the monorepo `v2026.04.24` release has been cut, or in whichever order works best for your release cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)