### PR TITLE
feat(services): migrate command (legacy TOML → CLI-managed state)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -684,6 +684,22 @@ pub enum ServicesCommands {
         #[arg(long = "yes-i-know-this-destroys-data")]
         confirmed: bool,
     },
+
+    /// Migrate legacy [postgres]/[redis]/[storage] TOML sections to CLI-managed state.
+    ///
+    /// Reads floo.app.toml, ensures each declared managed service is provisioned
+    /// (idempotent — existing services are recorded, not re-created), and writes
+    /// .floo/services.lock. Zero data impact: the underlying managed services
+    /// are not touched. Prints instructions to delete the TOML sections afterward.
+    Migrate {
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Project directory containing floo.app.toml.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1219,6 +1235,9 @@ pub fn run() {
                 name,
                 confirmed,
             } => commands::services::remove(&service_type, app.as_deref(), &name, confirmed),
+            ServicesCommands::Migrate { app, path } => {
+                commands::services::migrate(app.as_deref(), &path)
+            }
         },
 
         Commands::Domains(sub) => match sub {

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -378,3 +378,163 @@ fn is_interactive_stdin() -> bool {
     use std::io::IsTerminal;
     io::stdin().is_terminal()
 }
+
+/// One-shot migration from legacy `[postgres]`/`[redis]`/`[storage]` TOML
+/// sections to CLI-managed state.
+///
+/// Zero data impact: the underlying managed-service rows already exist
+/// (auto-provisioned by the deprecated TOML path). This command just:
+/// 1. Reads the TOML sections.
+/// 2. Calls POST for each (idempotent — the API returns the existing row).
+/// 3. Writes `.floo/services.lock` with the final state.
+/// 4. Prints instructions to delete the TOML sections going forward.
+///
+/// See docs/knowledge/domains/managed-services.md for the full doctrine.
+pub fn migrate(app: Option<&str>, path: &std::path::Path) {
+    use crate::api_types::CreateManagedServiceRequest;
+    use crate::project_config;
+
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let canonical_path = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            output::error(
+                &format!("Path '{}' is not a directory.", path.display()),
+                &ErrorCode::InvalidPath,
+                Some("Provide a valid project directory."),
+            );
+            process::exit(1);
+        }
+    };
+
+    let resolved = match project_config::resolve_app_context(&canonical_path, app) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &e.code, e.suggestion.as_deref());
+            process::exit(1);
+        }
+    };
+
+    let declarations = project_config::discover_managed_services(&resolved);
+    if declarations.is_empty() {
+        if output::is_json_mode() {
+            output::success(
+                "No legacy managed-service sections to migrate.",
+                Some(serde_json::json!({
+                    "migrated": [],
+                    "app": resolved.app_name,
+                })),
+            );
+        } else {
+            output::info(
+                &format!(
+                    "No [postgres]/[redis]/[storage] sections in floo.app.toml for {}. Nothing to migrate.",
+                    resolved.app_name
+                ),
+                None,
+            );
+        }
+        return;
+    }
+
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+
+    let mut migrated: Vec<serde_json::Value> = Vec::new();
+    for decl in &declarations {
+        // `name` in ManagedServiceDeclaration is the type ("postgres"/"redis"/"storage").
+        let service_type = decl.name.as_str();
+        let tier = decl.tier.as_deref().unwrap_or("basic");
+
+        let request = CreateManagedServiceRequest {
+            service_type,
+            name: "default",
+            tier,
+        };
+
+        let detail = match client.create_managed_service(&app_id, &request) {
+            Ok(d) => d,
+            Err(e) => {
+                output::error(
+                    &format!(
+                        "Failed to migrate {service_type}: {message}",
+                        message = e.message
+                    ),
+                    &ErrorCode::from_api(&e.code),
+                    Some(
+                        "The managed service row may already exist; check 'floo services list'. \
+                         If this persists, file feedback via 'floo feedback --category bug'.",
+                    ),
+                );
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = crate::services_lock::record_add(&detail) {
+            output::warn(&format!(
+                "Migrated {service_type} but failed to update .floo/services.lock: {e}"
+            ));
+        }
+
+        migrated.push(serde_json::json!({
+            "type": service_type,
+            "name": detail.name,
+            "status": detail.status,
+            "tier": tier,
+        }));
+    }
+
+    let sections: Vec<&str> = declarations.iter().map(|d| d.name.as_str()).collect();
+    let sections_display = sections
+        .iter()
+        .map(|s| format!("[{s}]"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    if output::is_json_mode() {
+        output::success(
+            &format!(
+                "Migrated {} managed service(s) for {app_name}.",
+                migrated.len()
+            ),
+            Some(serde_json::json!({
+                "app": app_name,
+                "migrated": migrated,
+                "next_steps": [
+                    format!("Delete the {sections_display} sections from floo.app.toml"),
+                    "Commit the updated .floo/services.lock".to_string(),
+                    "Push — the deprecation warning will stop firing on next deploy".to_string(),
+                ],
+            })),
+        );
+        return;
+    }
+
+    output::info(
+        &format!(
+            "\u{2713} Migrated {} managed service(s) for {app_name}.",
+            migrated.len()
+        ),
+        None,
+    );
+    for item in &migrated {
+        if let (Some(t), Some(n)) = (
+            item.get("type").and_then(|v| v.as_str()),
+            item.get("name").and_then(|v| v.as_str()),
+        ) {
+            output::info(&format!("    {t}/{n}"), None);
+        }
+    }
+    output::info("", None);
+    output::info("Next steps:", None);
+    output::info(
+        &format!("  1. Delete the {sections_display} sections from floo.app.toml"),
+        None,
+    );
+    output::info("  2. Commit the updated .floo/services.lock", None);
+    output::info(
+        "  3. Push — the deprecation warning will stop firing on next deploy",
+        None,
+    );
+}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -2315,3 +2315,132 @@ fn test_services_remove_not_found_surfaces_clear_error() {
         .failure()
         .stdout(predicate::str::contains("MANAGED_SERVICE_NOT_FOUND"));
 }
+
+#[test]
+fn test_services_migrate_upserts_each_declared_section_and_writes_lock() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    // POST is idempotent on (app_id, type, name) — the API returns the existing
+    // row if one exists, so migrate is a "read-and-record" operation, not a
+    // "create-new" operation. Both of our declared sections get a 201.
+    let _m_postgres = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .match_body(mockito::Matcher::JsonString(
+            r#"{"type":"postgres","name":"default","tier":"basic"}"#.to_string(),
+        ))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+                "id":"ms-pg",
+                "app_id":"app-uuid-1234",
+                "type":"postgres",
+                "name":"default",
+                "status":"ready",
+                "env_var_keys":["DATABASE_URL"],
+                "created_at":"2026-04-24T00:00:00Z",
+                "updated_at":"2026-04-24T00:00:00Z"
+            }"#,
+        )
+        .create();
+
+    let _m_redis = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .match_body(mockito::Matcher::JsonString(
+            r#"{"type":"redis","name":"default","tier":"basic"}"#.to_string(),
+        ))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+                "id":"ms-rd",
+                "app_id":"app-uuid-1234",
+                "type":"redis",
+                "name":"default",
+                "status":"ready",
+                "env_var_keys":["REDIS_URL"],
+                "created_at":"2026-04-24T00:00:00Z",
+                "updated_at":"2026-04-24T00:00:00Z"
+            }"#,
+        )
+        .create();
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        format!(
+            r#"[app]
+name = "{TEST_APP_NAME}"
+
+[postgres]
+tier = "basic"
+
+[redis]
+tier = "basic"
+"#
+        ),
+    )
+    .unwrap();
+
+    floo()
+        .args([
+            "--json",
+            "services",
+            "migrate",
+            "--app",
+            TEST_APP_NAME,
+            project.path().to_str().unwrap(),
+        ])
+        .env("HOME", home.path())
+        .current_dir(project.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""type":"postgres""#))
+        .stdout(predicate::str::contains(r#""type":"redis""#))
+        .stdout(predicate::str::contains("next_steps"));
+
+    // Lock file now reflects both migrated services.
+    let lock = std::fs::read_to_string(project.path().join(".floo").join("services.lock")).unwrap();
+    assert!(lock.contains(r#""type": "postgres""#), "lock missing postgres: {lock}");
+    assert!(lock.contains(r#""type": "redis""#), "lock missing redis: {lock}");
+}
+
+#[test]
+fn test_services_migrate_no_op_when_no_legacy_sections() {
+    let server = Server::new();
+    let home = setup_config(&server);
+
+    // No mocks — migrate must short-circuit before any API call when there
+    // are no legacy sections to migrate.
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        format!("[app]\nname = \"{TEST_APP_NAME}\"\n"),
+    )
+    .unwrap();
+
+    floo()
+        .args([
+            "--json",
+            "services",
+            "migrate",
+            "--app",
+            TEST_APP_NAME,
+            project.path().to_str().unwrap(),
+        ])
+        .env("HOME", home.path())
+        .current_dir(project.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("migrated"));
+}


### PR DESCRIPTION
## Summary

Completes the migration story. The per-deploy deprecation warning landed in getfloo/floo#646 points users at `floo services migrate`; this PR is that command.

Zero data impact. Reads `floo.app.toml`, ensures each declared `[postgres]`/`[redis]`/`[storage]` section is recorded via the managed-services API (idempotent on `(app_id, type, name)` — the API returns existing rows rather than creating duplicates), writes `.floo/services.lock`, and prints explicit next steps to delete the TOML sections.

This was originally PR #113 — auto-closed when GitHub detected an old conflict state before my force-push rebase registered. Same commit content, same test coverage, re-opened so it lands cleanly.

## Flow

```
$ floo services migrate
✓ Migrated 2 managed service(s) for my-app.
    postgres/default
    redis/default

Next steps:
  1. Delete the [postgres], [redis] sections from floo.app.toml
  2. Commit the updated .floo/services.lock
  3. Push — the deprecation warning will stop firing on next deploy
```

`--json` output carries a `next_steps` array so agents parse the checklist from the contract, not prompt text.

## Test plan

- [x] `cargo test` — 59 tests pass (57 prior + 2 new migrate mock)
- [x] `cargo clippy --bin floo -- -D warnings` clean
- [x] Mock tests assert: exact POST bodies per section, lock file reflects both types, no-op short-circuits before any API call when TOML has no legacy sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)