### PR TITLE
feat(services list): unified view of app + managed services

### DIFF
--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -4,6 +4,11 @@ use crate::api_types::CreateManagedServiceRequest;
 use crate::errors::ErrorCode;
 use crate::output;
 
+/// List every service on an app — both the user-authored app services
+/// (Cloud Run revisions) and the platform-managed services (postgres,
+/// redis, storage). The two live on different authoring surfaces but
+/// belong in one read model so `floo services list` is a complete view.
+/// Matches the info command's "both surfaces" routing landed in #110.
 pub fn list(app: Option<&str>, env: &str) {
     super::require_auth();
     let client = super::init_client(None);
@@ -12,7 +17,7 @@ pub fn list(app: Option<&str>, env: &str) {
     let app_id = app_id.as_str();
     let app_name = app_name.as_str();
 
-    let result = match client.list_services(app_id, Some(env)) {
+    let app_services = match client.list_services(app_id, Some(env)) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
@@ -20,37 +25,78 @@ pub fn list(app: Option<&str>, env: &str) {
         }
     };
 
-    if result.services.is_empty() {
+    // Managed services fetch failure is non-fatal — app services still render
+    // and we surface the error as a warning so the user knows the view is
+    // partial, not wrong.
+    let managed_services = match client.list_managed_services(app_id) {
+        Ok(r) => Some(r.managed_services),
+        Err(e) => {
+            output::warn(&format!(
+                "Could not fetch managed services (partial view): {}",
+                e.message
+            ));
+            None
+        }
+    };
+    let managed_services = managed_services.unwrap_or_default();
+
+    if app_services.services.is_empty() && managed_services.is_empty() {
         if output::is_json_mode() {
             output::success(
                 &format!("No services on {app_name}."),
-                Some(serde_json::json!({"services": []})),
+                Some(serde_json::json!({
+                    "app_services": [],
+                    "managed_services": [],
+                })),
             );
         } else {
-            output::info(&format!("No services on {app_name}."), None);
+            output::info(
+                &format!(
+                    "No services on {app_name}. Add one with 'floo services add <type>' or by declaring services in floo.app.toml."
+                ),
+                None,
+            );
         }
         return;
     }
 
-    let rows: Vec<Vec<String>> = result
-        .services
-        .iter()
-        .map(|s| {
-            vec![
-                s.name.clone(),
-                s.service_type.as_deref().unwrap_or("-").to_string(),
-                s.status.as_deref().unwrap_or("-").to_string(),
-                s.ingress.as_deref().unwrap_or("-").to_string(),
-                s.cloud_run_url.as_deref().unwrap_or("-").to_string(),
-            ]
-        })
-        .collect();
+    if output::is_json_mode() {
+        output::success(
+            &format!("Services for {app_name}"),
+            Some(serde_json::json!({
+                "app_services": output::to_value(&app_services.services),
+                "managed_services": output::to_value(&managed_services),
+            })),
+        );
+        return;
+    }
 
-    output::table(
-        &["Name", "Type", "Status", "Ingress", "URL"],
-        &rows,
-        Some(output::to_value(&result)),
+    // Human mode: render unified table rows. Managed services show their
+    // type as the "Type" cell and "managed" as the ingress so users see them
+    // as a distinct class without a second table.
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(
+        app_services.services.len() + managed_services.len(),
     );
+    for s in &app_services.services {
+        rows.push(vec![
+            s.name.clone(),
+            s.service_type.as_deref().unwrap_or("-").to_string(),
+            s.status.as_deref().unwrap_or("-").to_string(),
+            s.ingress.as_deref().unwrap_or("-").to_string(),
+            s.cloud_run_url.as_deref().unwrap_or("-").to_string(),
+        ]);
+    }
+    for ms in &managed_services {
+        rows.push(vec![
+            ms.name.clone(),
+            ms.service_type.clone(),
+            ms.status.clone(),
+            "managed".to_string(),
+            "\u{2014}".to_string(),
+        ]);
+    }
+
+    output::table(&["Name", "Type", "Status", "Ingress", "URL"], &rows, None);
 }
 
 pub fn info(service_name: &str, app: Option<&str>) {

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1227,11 +1227,23 @@ fn test_logs_single_service_no_prefix() {
 // ───────────────────────── Services ─────────────────────────
 
 #[test]
-fn test_services_list_json() {
+fn test_services_list_json_returns_both_app_and_managed_services() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
     let _services = mock_services_single(&mut server);
+
+    let _m_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"managed_services":[{"id":"ms-1","app_id":"app-uuid-1234","type":"postgres","name":"default","status":"ready","env_var_keys":["DATABASE_URL"],"created_at":null,"updated_at":null}],"total":1}"#,
+        )
+        .create();
 
     floo()
         .args(["--json", "services", "list", "--app", TEST_APP_NAME])
@@ -1239,8 +1251,77 @@ fn test_services_list_json() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
-        .stdout(predicate::str::contains("services"))
-        .stdout(predicate::str::contains("web"));
+        .stdout(predicate::str::contains("app_services"))
+        .stdout(predicate::str::contains("managed_services"))
+        .stdout(predicate::str::contains("web"))
+        .stdout(predicate::str::contains("postgres"));
+}
+
+#[test]
+fn test_services_list_partial_view_when_managed_services_fetch_fails() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_services_single(&mut server);
+
+    // Managed services endpoint is broken. `list` must degrade gracefully:
+    // app services render, managed_services is empty, a warning fires.
+    let _m_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"INTERNAL_ERROR","message":"boom"}}"#)
+        .create();
+
+    floo()
+        .args(["--json", "services", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("web"))
+        .stdout(predicate::str::contains(r#""managed_services":[]"#));
+}
+
+#[test]
+fn test_services_list_empty_when_no_services_of_either_kind() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_app = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/services").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "dev".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"services":[]}"#)
+        .create();
+
+    let _m_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"managed_services":[],"total":0}"#)
+        .create();
+
+    floo()
+        .args(["--json", "services", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""app_services":[]"#))
+        .stdout(predicate::str::contains(r#""managed_services":[]"#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`floo services list` previously called only `/v1/apps/{id}/services` and returned app services (Cloud Run revisions). A user who just ran `floo services add postgres` wouldn't see their managed service in the list — the two concepts were correct in the backend but the read surface hadn't caught up. This makes `list` a complete view.

## Changes

- `list()` fetches from both `/services` (app) and `/managed-services` in sequence.
- JSON output shape: `{app_services: [...], managed_services: [...]}` — agents parse the two classes distinctly from the contract.
- Human table merges the two with a single row format. Managed services show `managed` as the ingress and an em-dash for URL (they have no public Cloud Run URL; credentials are injected at runtime).
- **Managed-services fetch failure is non-fatal.** App services still render; `managed_services` is empty in the JSON; a warning fires on stderr. Partial view with a loud signal > blank error page.
- Empty-both case nudges: _"Add one with 'floo services add <type>' or by declaring services in floo.app.toml."_

## Test plan

- [x] `cargo test` — 65 pass (62 prior + 3 new)
- [x] `cargo clippy --bin floo -- -D warnings` clean
- [x] New tests cover: combined view with both kinds present, graceful degradation on managed-services 500, empty-both case

## What this completes

With this + the rest of the session's work, the managed-services CRUD experience is complete across CLI surfaces:

| Op | Command | Surface |
|---|---|---|
| Create | `services add` | #111 |
| Read single | `services info` | #110 |
| Read list | `services list` | **this PR** |
| Destroy | `services remove` | #111 (+ #115 consolidation) |
| Migrate | `services migrate` | #114 |
| Plan | `preflight` | #110 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)