### PR TITLE
feat(cli): launch-sweep cleanups + floo db connections + deprecate --tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Floo CLI
 
-The command-line interface for [Floo](https://getfloo.com) — deploy, manage, and observe web apps.
+The command-line interface for [Floo](https://getfloo.com) — manage and observe web apps. Deploys are git-driven (push to `main` for dev, cut a GitHub release for prod); this CLI handles everything else.
 
 ## Install
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -629,6 +629,18 @@ impl FlooClient {
         Ok(())
     }
 
+    pub fn managed_postgres_connection_usage(
+        &self,
+        app_id: &str,
+        service_id: &str,
+        env: &str,
+    ) -> Result<Value, FlooApiError> {
+        let resp = self.get(&format!(
+            "/v1/apps/{app_id}/managed-services/{service_id}/connection-usage?env={env}"
+        ))?;
+        self.handle_response(resp)
+    }
+
     // --- Preflight ---
 
     pub fn preflight(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ use crate::output;
 #[derive(Parser)]
 #[command(
     name = "floo",
-    about = "Deploy, manage, and observe web apps.",
+    about = "Manage and observe web apps. Deploys are git-driven.",
     version = VERSION,
 )]
 pub struct Cli {
@@ -53,6 +53,11 @@ Examples:
     },
 
     /// Run all services locally with managed-service credentials.
+    ///
+    /// `--json` emits managed-service credentials (DATABASE_URL, REDIS_URL, custom env
+    /// vars) in plaintext. Treat the JSON stream as sensitive: do not commit, paste it
+    /// into chat, or pipe it to a service that retains logs. Redact the `env_vars`
+    /// block before sharing.
     #[command(after_help = "\
 Examples:
   floo dev                                 Start all services defined in floo.app.toml
@@ -329,6 +334,11 @@ Examples:
     Version,
 
     /// Update the CLI binary in-place.
+    ///
+    /// Downloads the target release and overwrites the file at `floo`'s current path
+    /// on disk. There is no automatic rollback — to revert, reinstall the desired
+    /// version with the installer or download the binary directly. Use `--dry-run` to
+    /// preview the release without touching the binary.
     Update {
         /// Specific release tag to install (e.g. v0.2.0).
         #[arg(long)]
@@ -660,7 +670,10 @@ pub enum ServicesCommands {
         #[arg(short, long)]
         app: Option<String>,
 
-        /// Service tier: basic, standard, or performance.
+        /// Deprecated. Every managed Postgres service now ships with the
+        /// same defaults (25 connections, 60s statement timeout); the tier
+        /// value is recorded but ignored. For sustained higher concurrency,
+        /// email team@getfloo.com for a dedicated instance.
         #[arg(long, default_value = "basic", value_parser = ["basic", "standard", "performance"])]
         tier: String,
 
@@ -932,6 +945,27 @@ Examples:
         app: Option<String>,
 
         /// Environment to migrate: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
+    },
+
+    /// Show current Postgres connection usage versus the role's limit.
+    ///
+    /// Useful for diagnosing "too many connections" errors and for
+    /// deciding whether the app needs more capacity. Prints a percentage
+    /// and surfaces team@getfloo.com when the role is near-saturated so
+    /// you can request a dedicated instance without context-switching.
+    #[command(after_help = "\
+Examples:
+  floo db connections --app my-app                Show dev connection usage
+  floo db connections --app my-app --env prod     Show prod connection usage
+  floo db connections --app my-app --json         Machine-readable output")]
+    Connections {
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Environment to query: dev or prod.
         #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
         env: String,
     },
@@ -1311,6 +1345,9 @@ pub fn run() {
             } => commands::db::query(app.as_deref(), &sql, &env, limit),
             DbCommands::Schema { app } => commands::db::schema(app.as_deref()),
             DbCommands::Migrate { app, env } => commands::db::migrate(app.as_deref(), &env),
+            DbCommands::Connections { app, env } => {
+                commands::db::connections(app.as_deref(), &env)
+            }
         },
 
         Commands::Cron(sub) => match sub {

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -204,6 +204,80 @@ pub fn migrate(app_flag: Option<&str>, env: &str) {
     }
 }
 
+pub fn connections(app_flag: Option<&str>, env: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+
+    // Find the app's managed Postgres service.
+    let listing = match client.list_managed_services(&app_id) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+    let postgres_service = listing
+        .managed_services
+        .iter()
+        .find(|s| s.service_type == "postgres");
+
+    let Some(service) = postgres_service else {
+        output::error(
+            &format!("{app_name} has no managed Postgres service to inspect."),
+            &ErrorCode::Other("NO_POSTGRES_SERVICE".into()),
+            Some("Provision one with `floo services add postgres --app <name>`."),
+        );
+        process::exit(1);
+    };
+
+    let usage = match client.managed_postgres_connection_usage(&app_id, &service.id, env) {
+        Ok(v) => v,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success("Connection usage retrieved.", Some(usage));
+        return;
+    }
+
+    let used = usage.get("active_connections").and_then(|v| v.as_u64()).unwrap_or(0);
+    let limit = usage.get("connection_limit").and_then(|v| v.as_u64()).unwrap_or(0);
+    let ratio = usage.get("ratio").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let near = usage.get("near_capacity").and_then(|v| v.as_bool()).unwrap_or(false);
+    let support_email = usage
+        .get("support_email")
+        .and_then(|v| v.as_str())
+        .unwrap_or("team@getfloo.com");
+
+    let percent = (ratio * 100.0).round() as u32;
+
+    output::info(
+        &format!(
+            "{app_name} ({env}): {used}/{limit} Postgres connections in use ({percent}%)"
+        ),
+        None,
+    );
+
+    if near {
+        output::info(
+            &format!(
+                "Heads up — you're near capacity. Most apps that hit this either need \
+                 connection pooling at the application layer (PgBouncer, SQLAlchemy pool \
+                 tuning) or more raw capacity."
+            ),
+            None,
+        );
+        output::info(
+            &format!("Need more? Email {support_email} — we can provision a dedicated instance."),
+            None,
+        );
+    }
+}
+
 fn value_to_display(v: &Value) -> String {
     match v {
         Value::Null => "NULL".to_string(),


### PR DESCRIPTION
## Summary

Three threads bundled: launch-sweep cleanups, the new `floo db connections` command (matching the platform-side `/connection-usage` endpoint), and the `--tier` flag deprecation now that managed Postgres ships with a single set of defaults.

## Launch-sweep cleanups

- **`src/cli.rs`** top-level `about` no longer calls `floo` a deploy tool — deploys are git-driven and the CLI is for everything else.
- **`README.md`** tagline rewritten to match.
- **`Dev` command long_about** warns that `--json` emits managed-service credentials in plaintext (treat the JSON stream as sensitive, redact `env_vars` before sharing).
- **`Update` command long_about** explains the in-place binary mutation and points at `--dry-run` as the safe preview.

## New `floo db connections` command

- **`src/cli.rs`** — adds the `Connections` variant under `DbCommands` with `--app` and `--env` flags.
- **`src/commands/db.rs`** — handler finds the app's managed Postgres service, hits the `/connection-usage` endpoint, prints `used / limit Postgres connections in use (X%)`, and surfaces `team@getfloo.com` when the role is near-saturated. `--json` returns the raw payload for agents.
- **`src/api_client.rs`** — adds `managed_postgres_connection_usage` that GETs `/v1/apps/{app_id}/managed-services/{service_id}/connection-usage?env=...`.

## `--tier` deprecation

- `src/cli.rs` `services add --tier` flag is now documented as deprecated. Every value (basic/standard/performance) maps to the same defaults on the platform; the flag stays for backwards-compat. For sustained higher concurrency, customers email `team@getfloo.com` for a dedicated Postgres instance.

## Test plan

- [ ] `cargo check` is clean (verified locally)
- [ ] `floo db connections --help` shows the new flags + examples
- [ ] `floo db connections --app <name>` against an app with managed Postgres prints used/limit
- [ ] `floo db connections --app <name> --json` returns the structured payload
- [ ] `floo --help` shows the new tagline; `floo dev --help` and `floo update --help` show the security caveats

🤖 Generated with [Claude Code](https://claude.com/claude-code)