### PR TITLE
feat: show managed env injection plan

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -4,6 +4,8 @@ use std::process;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use serde::Serialize;
+
 use crate::api_client::FlooClient;
 use crate::api_types::Deploy;
 use crate::config::load_config;
@@ -19,6 +21,27 @@ use crate::resolve::resolve_app;
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
 pub(crate) const TERMINAL_STATUSES: &[&str] = &["live", "failed", "superseded"];
+
+#[derive(Debug, Serialize)]
+struct EnvInjectionPlan {
+    mode: String,
+    services: Vec<ServiceEnvInjectionPlan>,
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ServiceEnvInjectionPlan {
+    service: String,
+    managed: Vec<ManagedEnvInjection>,
+    required: Vec<String>,
+    optional: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ManagedEnvInjection {
+    handle: String,
+    keys: Vec<String>,
+}
 
 fn status_label(status: &str) -> &str {
     match status {
@@ -99,10 +122,11 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
 
     // 5. Validate
     let (preflight_errors, preflight_warnings) =
-        validate_preflight(&project_path, &services, &resolved);
+        validate_preflight(&project_path, &services, &resolved, &managed_services);
 
     // 6. Generate security notes
     let security_notes = generate_security_notes(&services, &managed_services, &resolved);
+    let env_injection_plan = build_env_injection_plan(&services, &managed_services, &resolved);
 
     // 7. Remote preflight audit (declared vs deployed). Best-effort — auth/resolution
     // failures degrade to a note; local validation still ships.
@@ -148,6 +172,7 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
                 "app": app_name,
                 "services": svc_json,
                 "managed_services": managed_json,
+                "env_injection_plan": env_injection_plan,
                 "warnings": warning_strings,
                 "security_notes": security_notes,
                 "plan": remote_plan.as_ref().map(crate::output::to_value),
@@ -160,6 +185,7 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
             &resolved,
             &services,
             &per_service_detection,
+            &env_injection_plan,
             &preflight_warnings,
             &preflight_errors,
         );
@@ -332,7 +358,8 @@ pub fn deploy(
 
     // 5. Validate per-service (port, name, Dockerfile EXPOSE, env_file)
     let (preflight_errors, preflight_warnings) =
-        validate_preflight(&project_path, &services, &resolved);
+        validate_preflight(&project_path, &services, &resolved, &managed_services);
+    let env_injection_plan = build_env_injection_plan(&services, &managed_services, &resolved);
 
     // 6. Display preflight info
     if !output::is_json_mode() {
@@ -341,6 +368,7 @@ pub fn deploy(
             &resolved,
             &services,
             &per_service_detection,
+            &env_injection_plan,
             &preflight_warnings,
             &preflight_errors,
         );
@@ -394,6 +422,7 @@ pub fn deploy(
             "app": app_name,
             "services": svc_json,
             "managed_services": managed_json,
+            "env_injection_plan": env_injection_plan,
             "warnings": warning_strings,
             "valid": preflight_errors.is_empty(),
         }));
@@ -916,16 +945,80 @@ fn deploy_rebuild(
     );
 }
 
+fn service_looks_like_rails(service_dir: &Path) -> bool {
+    let gemfile = service_dir.join("Gemfile");
+    if let Ok(contents) = std::fs::read_to_string(&gemfile) {
+        let lower = contents.to_lowercase();
+        if lower.contains("gem \"rails\"") || lower.contains("gem 'rails'") {
+            return true;
+        }
+    }
+
+    let app_config = service_dir.join("config").join("application.rb");
+    if let Ok(contents) = std::fs::read_to_string(app_config) {
+        return contents.contains("Rails::Application") || contents.contains("require \"rails\"");
+    }
+
+    false
+}
+
+fn env_files_for_service(
+    service_dir: &Path,
+    configured_env_file: Option<&str>,
+) -> Vec<(String, PathBuf)> {
+    let mut files: Vec<(String, PathBuf)> = Vec::new();
+    let mut labels: Vec<String> = Vec::new();
+    if let Some(env_file) = configured_env_file {
+        labels.push(env_file.to_string());
+    }
+    labels.extend(
+        [".env", ".env.local", ".env.production", ".env.development"]
+            .iter()
+            .map(|label| label.to_string()),
+    );
+
+    for label in labels {
+        if files.iter().any(|(existing, _)| existing == &label) {
+            continue;
+        }
+        files.push((label.clone(), service_dir.join(label)));
+    }
+    files
+}
+
+fn parse_env_assignment(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let (key, value) = trimmed.split_once('=')?;
+    Some((
+        key.trim(),
+        value.trim().trim_matches('"').trim_matches('\''),
+    ))
+}
+
+fn is_cloudsql_socket_database_url(value: &str) -> bool {
+    let lower = value.to_lowercase();
+    lower.contains("@/")
+        && (lower.contains("/cloudsql/")
+            || lower.contains("host=/cloudsql")
+            || lower.contains("%2fcloudsql%2f")
+            || lower.contains("host=%2fcloudsql"))
+}
+
 /// Validate services for common config errors. Returns (errors, warnings).
 /// Absorbs the validation logic that was previously in `floo check`.
 fn validate_preflight(
     project_path: &Path,
     services: &[ServiceConfig],
     resolved: &project_config::ResolvedApp,
+    managed_services: &[project_config::ManagedServiceDeclaration],
 ) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
     let mut errors: Vec<serde_json::Value> = Vec::new();
     let mut warnings: Vec<serde_json::Value> = Vec::new();
     let mut seen_names: Vec<String> = Vec::new();
+    let has_managed_postgres = managed_services.iter().any(|ms| ms.name == "postgres");
 
     for svc in services {
         // Validate service name
@@ -958,6 +1051,11 @@ fn validate_preflight(
         }
 
         let svc_dir = project_path.join(&svc.path);
+        let configured_env_file = resolved
+            .app_config
+            .as_ref()
+            .and_then(|app_cfg| app_cfg.services.get(&svc.name))
+            .and_then(|entry| entry.env_file.as_deref());
 
         // Check env_file exists
         if let Some(ref app_cfg) = resolved.app_config {
@@ -970,6 +1068,31 @@ fn validate_preflight(
                             "code": "ENV_FILE_NOT_FOUND",
                             "message": format!("Service '{}' env_file '{env_file}' not found on disk.", svc.name),
                         }));
+                    }
+                }
+            }
+        }
+
+        if has_managed_postgres && service_looks_like_rails(&svc_dir) {
+            for (env_label, env_path) in env_files_for_service(&svc_dir, configured_env_file) {
+                let Ok(contents) = std::fs::read_to_string(&env_path) else {
+                    continue;
+                };
+                for line in contents.lines() {
+                    let Some((key, value)) = parse_env_assignment(line) else {
+                        continue;
+                    };
+                    if key == "DATABASE_URL" && is_cloudsql_socket_database_url(value) {
+                        warnings.push(serde_json::json!({
+                            "path": svc.path,
+                            "code": "RAILS_DATABASE_URL_SOCKET_DSN",
+                            "message": format!(
+                                "Service '{}' looks like Rails and {env_label} contains a Cloud SQL socket-style DATABASE_URL. Rails parses DATABASE_URL with Ruby's URI parser before app code runs, so postgresql://user:pass@/db?host=/cloudsql/... can fail at boot. Remove the stale local override or use floo's framework-compatible managed Postgres URL.",
+                                svc.name
+                            ),
+                            "hint": "Managed Postgres now injects DATABASE_URL plus PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD. The DATABASE_URL value should have a normal host, for example postgresql://user:pass@127.0.0.1:5432/db.",
+                        }));
+                        break;
                     }
                 }
             }
@@ -1107,32 +1230,36 @@ fn generate_security_notes(
         ));
     }
 
-    // Warn about managed service env vars reaching web services
-    if !managed_services.is_empty() && services.len() > 1 {
-        let web_services: Vec<&str> = services
+    // Warn about managed service env vars reaching frontend services.
+    let env_plan = build_env_injection_plan(services, managed_services, resolved);
+    if services.len() > 1 {
+        let web_service_names: Vec<&str> = services
             .iter()
             .filter(|s| s.service_type == ServiceType::Web)
             .map(|s| s.name.as_str())
             .collect();
-
-        if !web_services.is_empty() {
-            let env_var_names: Vec<&str> = managed_services
-                .iter()
-                .flat_map(|ms| match ms.name.as_str() {
-                    "postgres" => vec!["DATABASE_URL"],
-                    "redis" => vec!["REDIS_URL"],
-                    "storage" => vec!["STORAGE_BUCKET", "STORAGE_URL"],
-                    _ => vec![],
-                })
-                .collect();
-
-            if !env_var_names.is_empty() {
-                notes.push(format!(
-                    "Managed service secrets ({}) are available to all services \
-                     including {}. To restrict: floo env set <KEY>=<val> --services <backend>",
-                    env_var_names.join(", "),
-                    web_services.join(", "),
-                ));
+        if env_plan.mode == "implicit_all"
+            && !web_service_names.is_empty()
+            && env_plan.services.iter().any(|svc| !svc.managed.is_empty())
+        {
+            notes.push(format!(
+                "Managed service credentials are implicitly available to every service, including {}. Add [services.<name>.env] managed = [...] to attach them only where needed.",
+                web_service_names.join(", "),
+            ));
+        } else {
+            for svc_plan in &env_plan.services {
+                let Some(svc) = services.iter().find(|s| s.name == svc_plan.service) else {
+                    continue;
+                };
+                if svc.service_type == ServiceType::Web && !svc_plan.managed.is_empty() {
+                    let handles: Vec<&str> =
+                        svc_plan.managed.iter().map(|m| m.handle.as_str()).collect();
+                    notes.push(format!(
+                        "Web service '{}' receives managed credentials: {}. Keep this only if browser-facing code really needs them server-side.",
+                        svc.name,
+                        handles.join(", "),
+                    ));
+                }
             }
         }
     }
@@ -1195,12 +1322,154 @@ fn looks_like_secret(key: &str) -> bool {
     secret_patterns.iter().any(|p| key_upper.contains(p))
 }
 
+fn env_contract_for_service(
+    resolved: &project_config::ResolvedApp,
+    svc: &ServiceConfig,
+) -> Option<project_config::ServiceEnvContract> {
+    if let Some(app_cfg) = resolved.app_config.as_ref() {
+        if let Some(entry) = app_cfg.services.get(&svc.name) {
+            if entry.env.is_some() {
+                return entry.env.clone();
+            }
+        }
+    }
+
+    let service_dir = if svc.path == "." {
+        resolved.config_dir.clone()
+    } else {
+        resolved.config_dir.join(&svc.path)
+    };
+    project_config::load_service_env_contract(&service_dir)
+        .ok()
+        .flatten()
+}
+
+fn build_env_injection_plan(
+    services: &[ServiceConfig],
+    managed_services: &[project_config::ManagedServiceDeclaration],
+    resolved: &project_config::ResolvedApp,
+) -> EnvInjectionPlan {
+    let contracts: Vec<Option<project_config::ServiceEnvContract>> = services
+        .iter()
+        .map(|svc| env_contract_for_service(resolved, svc))
+        .collect();
+    let explicit_managed = contracts
+        .iter()
+        .any(|contract| contract.as_ref().and_then(|c| c.managed.as_ref()).is_some());
+    let declared_handles = managed_env_handles(resolved, managed_services);
+
+    let mut notes = Vec::new();
+    let mode = if explicit_managed {
+        "explicit".to_string()
+    } else if !declared_handles.is_empty() {
+        notes.push(
+            "No service declares env.managed, so managed service credentials use legacy implicit injection."
+                .to_string(),
+        );
+        "implicit_all".to_string()
+    } else {
+        "none".to_string()
+    };
+
+    let service_plans = services
+        .iter()
+        .zip(contracts.iter())
+        .map(|(svc, contract)| {
+            let required = contract
+                .as_ref()
+                .map(|c| c.required.clone())
+                .unwrap_or_default();
+            let optional = contract
+                .as_ref()
+                .map(|c| c.optional.clone())
+                .unwrap_or_default();
+            let handles = if explicit_managed {
+                contract
+                    .as_ref()
+                    .and_then(|c| c.normalized_managed("[env]").ok().flatten())
+                    .unwrap_or_default()
+            } else {
+                declared_handles.clone()
+            };
+            let managed = handles
+                .iter()
+                .map(|handle| ManagedEnvInjection {
+                    handle: handle.clone(),
+                    keys: project_config::managed_env_attachment_keys(handle),
+                })
+                .collect();
+            ServiceEnvInjectionPlan {
+                service: svc.name.clone(),
+                managed,
+                required,
+                optional,
+            }
+        })
+        .collect();
+
+    EnvInjectionPlan {
+        mode,
+        services: service_plans,
+        notes,
+    }
+}
+
+fn managed_env_handles(
+    resolved: &project_config::ResolvedApp,
+    managed_services: &[project_config::ManagedServiceDeclaration],
+) -> Vec<String> {
+    let mut handles: Vec<String> = managed_services.iter().map(|ms| ms.name.clone()).collect();
+    if let Ok(lock) = crate::services_lock::read(&resolved.config_dir) {
+        for managed in lock.managed_services {
+            let handle = if managed.name == "default" {
+                managed.service_type
+            } else {
+                format!("{}:{}", managed.service_type, managed.name)
+            };
+            handles.push(handle);
+        }
+    }
+    handles.sort();
+    handles.dedup();
+    handles
+}
+
+fn display_env_injection_plan(plan: &EnvInjectionPlan) {
+    eprintln!("  Env injection plan:");
+    match plan.mode.as_str() {
+        "explicit" => eprintln!("    mode: explicit per-service env.managed"),
+        "implicit_all" => eprintln!("    mode: legacy implicit managed env on every service"),
+        _ => eprintln!("    mode: no managed service credentials declared locally"),
+    }
+    for note in &plan.notes {
+        eprintln!("    note: {note}");
+    }
+    for svc in &plan.services {
+        eprintln!("    {}", svc.service);
+        if svc.managed.is_empty() {
+            eprintln!("      managed: none");
+        } else {
+            for managed in &svc.managed {
+                eprintln!("      {} -> {}", managed.handle, managed.keys.join(", "));
+            }
+        }
+        if !svc.required.is_empty() {
+            eprintln!("      required: {}", svc.required.join(", "));
+        }
+        if !svc.optional.is_empty() {
+            eprintln!("      optional: {}", svc.optional.join(", "));
+        }
+    }
+    eprintln!();
+}
+
 /// Display preflight info in human-readable format.
 fn display_preflight_human(
     app_name: &str,
     resolved: &project_config::ResolvedApp,
     services: &[ServiceConfig],
     per_service_detection: &[(String, DetectionResult)],
+    env_injection_plan: &EnvInjectionPlan,
     warnings: &[serde_json::Value],
     errors: &[serde_json::Value],
 ) {
@@ -1258,6 +1527,8 @@ fn display_preflight_human(
         );
         eprintln!();
     }
+
+    display_env_injection_plan(env_injection_plan);
 
     // Show global [resources] if present
     if let Some(ref app_cfg) = resolved.app_config {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -93,8 +93,8 @@ Floo Quickstart — End-to-End Walkthrough
   floo services add redis --app my-app
   floo services add storage --app my-app
 
-  Credentials arrive as runtime env vars (DATABASE_URL, REDIS_URL,
-  STORAGE_BUCKET + STORAGE_URL). The commands write .floo/services.lock,
+  Credentials arrive as runtime env vars (Postgres: DATABASE_URL + PG*,
+  Redis: REDIS_URL, Storage: STORAGE_BUCKET + STORAGE_URL). The commands write .floo/services.lock,
   which you should commit so managed-service state changes are visible
   in `git diff` alongside code.
 
@@ -193,9 +193,19 @@ confirmation. See also: floo docs state-model.
 
   Connection credentials are injected at runtime, never stored in the
   lock file or in your repo:
-    postgres → DATABASE_URL
+    postgres → DATABASE_URL + PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD
     redis    → REDIS_URL
     storage  → STORAGE_BUCKET + STORAGE_URL (use STORAGE_URL for signed URLs)
+
+  In multi-service apps, attach those credentials per service:
+    [services.api.env]
+    managed = [\"postgres\", \"redis\"]
+
+    [services.web.env]
+    managed = []
+
+  Single-service apps can use top-level [env] managed = [] in
+  floo.service.toml to opt out of managed credentials entirely.
 
 ## Managed Service Tiers
 
@@ -418,9 +428,19 @@ Floo Config Files
     floo env list --services api
     floo env list --services web
 
-  Managed service env vars (DATABASE_URL, REDIS_URL, STORAGE_BUCKET) are
-  set at app scope and available to all services. Use --services to restrict
-  access if needed.
+  Managed service env vars are generated at app scope, then attached to
+  services by [services.<name>.env] managed:
+
+    [services.web.env]
+    managed = []
+
+    [services.api.env]
+    required = [\"STRIPE_SECRET_KEY\"]
+    managed = [\"postgres\", \"redis\"]
+
+  If no service declares managed, floo preserves legacy all-service injection.
+  Once any service declares it, omitted services receive no managed credentials.
+  `floo preflight --json` shows the exact env_injection_plan.
 
 ## Commands
 
@@ -499,6 +519,11 @@ Floo Deploy Flow
 
   floo preflight                   — validate config, detect runtimes, check readiness
   floo preflight --json            — structured output for agents
+
+  JSON includes env_injection_plan: per-service managed attachments, generated
+  env keys (DATABASE_URL + PG*, REDIS_URL, STORAGE_BUCKET/STORAGE_URL),
+  required keys, optional keys, and whether the app is in explicit or legacy
+  implicit mode.
 
 ## Redeploy Options
 
@@ -729,16 +754,16 @@ Floo — Golden Path
 
 ## How to Add a Database
 
-  Add to floo.app.toml:
+  Run:
 
-  [postgres]
-  tier = \"basic\"
+  floo services add postgres --app my-app
 
-  Commit the change and push to GitHub:
-  git add floo.app.toml && git commit -m \"feat: add postgres\"
+  Commit the generated lock file and push to GitHub:
+  git add .floo/services.lock && git commit -m \"feat: add postgres\"
   git push origin main
 
-  The database is auto-provisioned on the next deploy. Credentials arrive as DATABASE_URL.
+  The database is available on the next deploy. Credentials arrive as a
+  standard DATABASE_URL plus PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD.
 
 ## How to Add a Custom Domain
 
@@ -1038,7 +1063,11 @@ App is live at https://my-rails-app-dev.on.getfloo.com.
   git add .floo/services.lock && git commit -m \"feat: add postgres\"
   git push origin main
 
-Rails reads DATABASE_URL automatically. Confirm config/database.yml has:
+Rails reads DATABASE_URL automatically. floo injects a normal PostgreSQL
+URI, so ActiveRecord can parse it without custom Cloud SQL socket code.
+`floo preflight` warns if a local env file still contains the old Cloud
+SQL socket-style DATABASE_URL that Ruby's URI parser rejects.
+Confirm config/database.yml has:
 
   production:
     primary:

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -928,6 +928,7 @@ port = 8000
 [services.api.env]
 required = ["STRIPE_SECRET_KEY", "JWT_SECRET"]
 optional = ["SENTRY_DSN"]
+managed = ["postgres", "redis:cache"]
 "#,
         )
         .unwrap();
@@ -937,6 +938,10 @@ optional = ["SENTRY_DSN"]
         let env = api.env.as_ref().expect("env contract present");
         assert_eq!(env.required, vec!["STRIPE_SECRET_KEY", "JWT_SECRET"]);
         assert_eq!(env.optional, vec!["SENTRY_DSN"]);
+        assert_eq!(
+            env.normalized_managed("[services.api.env]").unwrap(),
+            Some(vec!["postgres".to_string(), "redis:cache".to_string()])
+        );
     }
 
     #[test]

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -19,7 +19,16 @@ pub use discover::{
     discover_managed_services, discover_services, filter_services, ManagedServiceDeclaration,
 };
 pub use resolve::{resolve_app_context, AppSource, ResolvedApp};
-pub use service_config::{load_service_config, ServiceConfig, ServiceIngress, ServiceType};
+pub use service_config::{
+    load_service_config, managed_env_attachment_keys, ServiceConfig, ServiceEnvContract,
+    ServiceIngress, ServiceType,
+};
+
+pub fn load_service_env_contract(
+    dir: &std::path::Path,
+) -> Result<Option<ServiceEnvContract>, crate::errors::FlooError> {
+    Ok(load_service_config(dir)?.and_then(|cfg| cfg.env))
+}
 
 /// Wire-format representation of a cron job sent to the API.
 ///

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -31,8 +31,9 @@ pub struct ResourceConfig {
 /// Declares names and kinds only — values always live in `.env` (local) or
 /// encrypted EnvVar rows (server-side). The server-side deploy pipeline
 /// gates on `required`: if any named key is missing or empty in the target
-/// environment, the deploy fails with `MISSING_REQUIRED_ENV_VAR`. `optional`
-/// is purely documentary.
+/// environment, the deploy fails with `MISSING_REQUIRED_ENV_VAR`. `managed`
+/// names floo-managed service credentials to inject into this service, and
+/// `optional` is purely documentary.
 ///
 /// Attached under `[services.<name>.env]` in `floo.app.toml` (inline mode)
 /// or `[env]` at the top level of `floo.service.toml` (delegated mode).
@@ -43,6 +44,8 @@ pub struct ServiceEnvContract {
     pub required: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub optional: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub managed: Option<Vec<String>>,
 }
 
 impl ServiceEnvContract {
@@ -72,7 +75,17 @@ impl ServiceEnvContract {
                 }
             }
         }
+        if let Some(managed) = &self.managed {
+            normalize_managed_env_attachments(managed, where_)?;
+        }
         Ok(())
+    }
+
+    pub fn normalized_managed(&self, where_: &str) -> Result<Option<Vec<String>>, FlooError> {
+        self.managed
+            .as_ref()
+            .map(|managed| normalize_managed_env_attachments(managed, where_))
+            .transpose()
     }
 }
 
@@ -83,6 +96,101 @@ fn is_valid_env_name(name: &str) -> bool {
         _ => return false,
     }
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+pub fn normalize_managed_env_attachment(raw: &str, where_: &str) -> Result<String, FlooError> {
+    let handle = raw.trim().to_ascii_lowercase();
+    if handle.is_empty() {
+        return Err(FlooError::with_suggestion(
+            ErrorCode::InvalidProjectConfig,
+            format!("{where_} managed contains an empty attachment handle."),
+            "Use postgres, redis, storage, or type:name for named managed services.".to_string(),
+        ));
+    }
+
+    let mut parts = handle.splitn(2, ':');
+    let service_type = parts.next().unwrap_or_default();
+    let service_name = parts.next().unwrap_or("default");
+    if !["postgres", "redis", "storage"].contains(&service_type) {
+        return Err(FlooError::with_suggestion(
+            ErrorCode::InvalidProjectConfig,
+            format!("{where_} managed contains unknown attachment '{raw}'."),
+            "Supported managed attachments are postgres, redis, storage, or type:name.".to_string(),
+        ));
+    }
+    if !is_valid_managed_service_name(service_name) {
+        return Err(FlooError::with_suggestion(
+            ErrorCode::InvalidProjectConfig,
+            format!("{where_} managed contains invalid attachment '{raw}'."),
+            "Managed service names must match /^[a-z][a-z0-9_]*$/ and be at most 63 chars."
+                .to_string(),
+        ));
+    }
+    if service_name == "default" {
+        Ok(service_type.to_string())
+    } else {
+        Ok(format!("{service_type}:{service_name}"))
+    }
+}
+
+pub fn normalize_managed_env_attachments(
+    handles: &[String],
+    where_: &str,
+) -> Result<Vec<String>, FlooError> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::with_capacity(handles.len());
+    for raw in handles {
+        let handle = normalize_managed_env_attachment(raw, where_)?;
+        if !seen.insert(handle.clone()) {
+            return Err(FlooError::with_suggestion(
+                ErrorCode::InvalidProjectConfig,
+                format!("{where_} managed declares '{handle}' more than once."),
+                "Each managed service attachment may appear at most once.".to_string(),
+            ));
+        }
+        normalized.push(handle);
+    }
+    Ok(normalized)
+}
+
+pub fn managed_env_attachment_keys(handle: &str) -> Vec<String> {
+    let (service_type, service_name) = handle
+        .split_once(':')
+        .map_or((handle, "default"), |(kind, name)| (kind, name));
+    let suffix = if service_name == "default" {
+        String::new()
+    } else {
+        format!("_{}", service_name.to_ascii_uppercase())
+    };
+    match service_type {
+        "postgres" if service_name == "default" => vec![
+            "DATABASE_URL".to_string(),
+            "PGHOST".to_string(),
+            "PGPORT".to_string(),
+            "PGDATABASE".to_string(),
+            "PGUSER".to_string(),
+            "PGPASSWORD".to_string(),
+        ],
+        "postgres" => vec![format!("DATABASE_URL{suffix}")],
+        "redis" => vec![format!("REDIS_URL{suffix}")],
+        "storage" => vec![
+            format!("STORAGE_BUCKET{suffix}"),
+            format!("STORAGE_URL{suffix}"),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+fn is_valid_managed_service_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 63 {
+        return false;
+    }
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
 }
 
 // --- API wire format (sent to the API as JSON) ---
@@ -908,8 +1016,13 @@ optional = ["JWT_SECRET"]
         let contract = ServiceEnvContract {
             required: vec!["STRIPE_KEY".into(), "_INTERNAL".into(), "A1_B2".into()],
             optional: vec![],
+            managed: Some(vec!["postgres".into(), "redis:cache".into()]),
         };
         contract.validate("[env]").unwrap();
+        assert_eq!(
+            contract.normalized_managed("[env]").unwrap(),
+            Some(vec!["postgres".into(), "redis:cache".into()])
+        );
     }
 
     #[test]
@@ -917,8 +1030,21 @@ optional = ["JWT_SECRET"]
         let contract = ServiceEnvContract {
             required: vec!["MY-KEY".into()],
             optional: vec![],
+            managed: None,
         };
         let err = contract.validate("[env]").unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+    }
+
+    #[test]
+    fn test_env_contract_invalid_managed_attachment_rejected() {
+        let contract = ServiceEnvContract {
+            required: vec![],
+            optional: vec![],
+            managed: Some(vec!["mysql".into()]),
+        };
+        let err = contract.validate("[env]").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("unknown attachment"));
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -933,6 +933,138 @@ ingress = "public"
         .stdout(predicate::str::contains("EXPOSE 8080"));
 }
 
+#[test]
+fn test_preflight_warns_for_rails_cloudsql_socket_database_url() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        r#"[app]
+name = "railsapp"
+
+[postgres]
+tier = "basic"
+
+[services.web]
+type = "web"
+path = "."
+port = 3000
+ingress = "public"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join("Gemfile"),
+        "source \"https://rubygems.org\"\ngem \"rails\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join(".env"),
+        "DATABASE_URL=postgresql://user:pass@/floo_apps?host=/cloudsql/project:region:instance\n",
+    )
+    .unwrap();
+
+    floo()
+        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Cloud SQL socket-style DATABASE_URL",
+        ))
+        .stdout(predicate::str::contains("Rails parses DATABASE_URL"));
+}
+
+#[test]
+fn test_preflight_json_shows_managed_env_injection_plan() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        r#"[app]
+name = "myapp"
+
+[postgres]
+tier = "basic"
+
+[redis]
+tier = "basic"
+
+[services.web]
+type = "web"
+path = "./web"
+port = 3000
+ingress = "public"
+
+[services.web.env]
+managed = []
+
+[services.api]
+type = "api"
+path = "./api"
+port = 8000
+ingress = "internal"
+
+[services.api.env]
+required = ["STRIPE_SECRET_KEY"]
+managed = ["postgres", "redis"]
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir(project.path().join("web")).unwrap();
+    std::fs::create_dir(project.path().join("api")).unwrap();
+
+    floo()
+        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""env_injection_plan""#))
+        .stdout(predicate::str::contains(r#""mode":"explicit""#))
+        .stdout(predicate::str::contains(r#""service":"api""#))
+        .stdout(predicate::str::contains(r#""handle":"postgres""#))
+        .stdout(predicate::str::contains(
+            r#""keys":["DATABASE_URL","PGHOST""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""managed":[],"optional":[],"required":[],"service":"web""#,
+        ));
+}
+
+#[test]
+fn test_preflight_env_injection_plan_reads_services_lock() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        r#"[app]
+name = "myapp"
+
+[services.api]
+type = "api"
+path = "./api"
+port = 8000
+ingress = "public"
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir(project.path().join("api")).unwrap();
+    std::fs::create_dir(project.path().join(".floo")).unwrap();
+    std::fs::write(
+        project.path().join(".floo").join("services.lock"),
+        r#"{"version":1,"managed_services":[{"type":"postgres","name":"default","status":"ready","created_at":null}]}"#,
+    )
+    .unwrap();
+
+    floo()
+        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""mode":"implicit_all""#))
+        .stdout(predicate::str::contains(r#""handle":"postgres""#))
+        .stdout(predicate::str::contains(
+            r#""keys":["DATABASE_URL","PGHOST""#,
+        ));
+}
+
 // --- Dry-run ---
 
 #[test]


### PR DESCRIPTION
## Summary
- add the service-level `env.managed` contract for explicit managed-service env injection
- surface an `env_injection_plan` in `floo preflight --json` and the human preflight output
- warn Rails apps about stale Cloud SQL socket-style `DATABASE_URL` values and update bundled CLI docs

## Verification
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`

## Companion PRs
- Platform: https://github.com/getfloo/floo/pull/690
- Docs: https://github.com/getfloo/floo-docs/pull/10