### PR TITLE
fix: support macOS release signature verification

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,9 +143,17 @@ verify_release_signature() {
     local public_key_path="$3"
     local asset="$4"
 
-    if ! openssl dgst -sha256 -verify "$public_key_path" -signature "$signature_path" "$binary_path" >/dev/null 2>&1; then
-        fail "Signature verification failed for ${asset}. Do not run this binary."
+    if openssl dgst -sha256 -verify "$public_key_path" -signature "$signature_path" "$binary_path" >/dev/null 2>&1; then
+        return
     fi
+
+    local normalized_public_key_path="${public_key_path}.spki"
+    if openssl rsa -RSAPublicKey_in -in "$public_key_path" -pubout -out "$normalized_public_key_path" >/dev/null 2>&1 &&
+        openssl dgst -sha256 -verify "$normalized_public_key_path" -signature "$signature_path" "$binary_path" >/dev/null 2>&1; then
+        return
+    fi
+
+    fail "Signature verification failed for ${asset}. Do not run this binary."
 }
 
 install_binary() {

--- a/tests/install_script_e2e.sh
+++ b/tests/install_script_e2e.sh
@@ -87,7 +87,7 @@ main() {
     checksum="$(sha256_file "$asset_path")"
     echo "${checksum}  ${asset_name}" >"$checksum_path"
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$signing_key_path" >/dev/null 2>&1
-    openssl rsa -pubout -in "$signing_key_path" -out "$verify_key_path" >/dev/null 2>&1
+    openssl rsa -RSAPublicKey_out -in "$signing_key_path" -out "$verify_key_path" >/dev/null 2>&1
     openssl dgst -sha256 -sign "$signing_key_path" -out "$signature_path" "$asset_path"
 
     FLOO_INSTALL_BINARY_URL="file://${asset_path}" \

--- a/tests/install_script_test.sh
+++ b/tests/install_script_test.sh
@@ -48,7 +48,7 @@ SH
 make_signing_keypair() {
     local dir="$1"
     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "${dir}/signing-private.pem" >/dev/null 2>&1
-    openssl rsa -pubout -in "${dir}/signing-private.pem" -out "${dir}/signing-public.pem" >/dev/null 2>&1
+    openssl rsa -RSAPublicKey_out -in "${dir}/signing-private.pem" -out "${dir}/signing-public.pem" >/dev/null 2>&1
 }
 
 sign_asset() {


### PR DESCRIPTION
## Summary
- Normalize raw RSA public keys to SPKI form before installer signature verification when OpenSSL needs it
- Update installer tests to use the raw `BEGIN RSA PUBLIC KEY` shape published by the release workflow

## Verification
- `bash -n install.sh`
- `bash tests/install_script_test.sh`
- `bash tests/install_script_e2e.sh`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`