### PR TITLE
feat(deploys): floo deploys status — agent-safe deploy summary

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -898,6 +898,24 @@ pub enum DeploysSubcommands {
         commit: Option<String>,
     },
 
+    /// Print a compact, agent-safe deploy status summary.
+    ///
+    /// Emits the latest deploy's id, commit, derived phase booleans
+    /// (image_built / service_ready / host_bound), the gateway URL, and a
+    /// next recommended command — without dumping build logs, Cloud Run
+    /// audit payloads, or env-var values. Use this from agents and
+    /// scripts that need to know "what state is the deploy in?" without
+    /// risking secret exfiltration through verbose log output.
+    Status {
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Deploy ID. Defaults to the latest deploy for the app.
+        #[arg(long)]
+        id: Option<String>,
+    },
+
     /// Rollback to a previous deploy.
     ///
     /// Tier-2 destructive: interactive prompts `y/N`; non-interactive
@@ -1206,6 +1224,9 @@ pub fn run() {
             } => commands::deploys::logs(deploy_id.as_deref(), app.as_deref(), follow),
             DeploysSubcommands::Watch { app, commit } => {
                 commands::deploys::watch(app.as_deref(), commit.as_deref())
+            }
+            DeploysSubcommands::Status { app, id } => {
+                commands::deploys::status(app.as_deref(), id.as_deref())
             }
             DeploysSubcommands::Rollback {
                 app,

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -11,6 +11,136 @@ use crate::commands::deploy::{poll_deploy, stream_deploy, stream_deploy_json, TE
 use crate::errors::ErrorCode;
 use crate::output;
 
+/// Compact, agent-safe deploy status summary.
+///
+/// Composed entirely from existing API endpoints (`get_app` + the
+/// latest entry in `list_deploys` / `get_deploy`). Emits derived phase
+/// booleans the user can branch on without parsing build logs:
+///
+/// - `image_built` — the deploy moved past the build phase
+/// - `service_ready` — Cloud Run is serving the new revision
+/// - `host_bound` — the gateway URL is wired and the deploy is LIVE
+///
+/// Always emits the same compact shape; never includes build logs or
+/// other audit payload that could carry secret env values. Closes
+/// feedback `5c7621fd` (floo-artifact, 2026-04-30): "add a safe
+/// status/debug command that summarizes deploy state without dumping
+/// build logs, Cloud Run audit payloads, or secret env values."
+pub fn status(app: Option<&str>, deploy_id: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+
+    let app_info = match client.get_app(&app_id) {
+        Ok(a) => a,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let deploy = match deploy_id {
+        Some(id) => match client.get_deploy(&app_id, id) {
+            Ok(d) => d,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        },
+        None => match client.list_deploys(&app_id) {
+            Ok(list) => match list.deploys.into_iter().next() {
+                Some(d) => d,
+                None => {
+                    output::error(
+                        "No deploys found for this app yet.",
+                        &ErrorCode::DeployNotFound,
+                        Some("Run `floo deploy .` or push to the connected GitHub branch."),
+                    );
+                    process::exit(1);
+                }
+            },
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        },
+    };
+
+    let deploy_status = deploy.status.as_deref().unwrap_or("unknown");
+    let app_status = app_info.status.as_deref().unwrap_or("unknown");
+    let gateway_url = app_info.url.as_deref().or(deploy.url.as_deref());
+    let commit_short = deploy.commit_sha.as_deref().map(super::short_sha);
+
+    let image_built = matches!(
+        deploy_status,
+        "deploying" | "configuring_routing" | "live" | "superseded"
+    );
+    let service_ready = matches!(deploy_status, "live");
+    // host_bound is the strict signal: the gateway URL is wired AND the
+    // deploy is the one currently serving. A deploy that "looks live"
+    // because the direct Cloud Run URL serves new code but the gateway
+    // 502s is exactly the floo-artifact 2026-04-30 fed461a6 shape — so
+    // host_bound=false on that state is the right answer for an agent.
+    let host_bound = service_ready && gateway_url.is_some() && app_status == "live";
+
+    let next_command = derive_next_command(deploy_status, host_bound);
+
+    let summary = serde_json::json!({
+        "app": app_name,
+        "deploy_id": deploy.id,
+        "commit": commit_short,
+        "status": deploy_status,
+        "app_status": app_status,
+        "url": gateway_url,
+        "image_built": image_built,
+        "service_ready": service_ready,
+        "host_bound": host_bound,
+        "created_at": deploy.created_at,
+        "next_command": next_command,
+    });
+
+    if output::is_json_mode() {
+        output::success("Deploy status retrieved.", Some(summary));
+        return;
+    }
+
+    let header = format!("{} ({})", app_name, deploy.id);
+    output::bold_line(&header);
+    output::dim_line(&format!(
+        "  status:        {}",
+        colored_status(deploy_status)
+    ));
+    output::dim_line(&format!("  app_status:    {}", app_status));
+    output::dim_line(&format!(
+        "  commit:        {}",
+        commit_short.unwrap_or("\u{2014}")
+    ));
+    output::dim_line(&format!(
+        "  url:           {}",
+        gateway_url.unwrap_or("\u{2014}")
+    ));
+    output::dim_line(&format!("  image_built:   {}", image_built));
+    output::dim_line(&format!("  service_ready: {}", service_ready));
+    output::dim_line(&format!("  host_bound:    {}", host_bound));
+    output::dim_line(&format!("  next_command:  {}", next_command));
+}
+
+/// Suggest the next command an agent or operator should run, based on
+/// the current state. Agent-safe: never names a destructive command
+/// without explicit caller confirmation.
+fn derive_next_command(deploy_status: &str, host_bound: bool) -> &'static str {
+    match deploy_status {
+        "pending" | "scheduled" | "building" | "deploying" | "configuring_routing" => {
+            "floo deploys watch"
+        }
+        "failed" => "floo deploys logs",
+        "live" if host_bound => "floo logs",
+        "live" => "floo apps status",
+        _ => "floo apps status",
+    }
+}
+
 pub fn list(app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);


### PR DESCRIPTION
## Summary

Closes feedback \`5c7621fd\` (floo-artifact, 2026-04-30): "add a safe status/debug command that summarizes deploy state without dumping build logs, Cloud Run audit payloads, or secret env values."

Adds \`floo deploys status [--app NAME] [--id DEPLOY_ID]\`. Always compact, always safe — never includes build logs.

\`\`\`json
{
  "app": "...",
  "deploy_id": "...",
  "commit": "5505f3e",
  "status": "failed",
  "app_status": "live",
  "url": "https://...on.getfloo.com",
  "image_built": false,
  "service_ready": false,
  "host_bound": false,
  "created_at": "...",
  "next_command": "floo deploys logs"
}
\`\`\`

\`host_bound\` is the strict truth signal: gateway URL wired AND deploy is currently serving. The fed461a6 floo-artifact incoherence (deploy=failed but app.status=live with stale URL → gateway 502) shows up as \`host_bound=false\`, so agents branch on the truth signal instead of trusting any single field.

Verified live against the floo-artifact prod app — output above is the actual command output.

Pairs with getfloo/floo PR [#743](https://github.com/getfloo/floo/pull/743) (trust boundary), [#744](https://github.com/getfloo/floo/pull/744) (state coherence), [#745](https://github.com/getfloo/floo/pull/745) (secret redaction). Same floo-artifact 2026-04-30 feedback batch.

## Test plan

- [x] \`cargo test --bin floo\` — 319 passing
- [x] \`cargo clippy --bin floo -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Smoke-tested live against prod \`floo-artifact\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)