### PR TITLE
fix(cli): cron docs gap + stale --dry-run command list

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -342,10 +342,22 @@ Examples:
     /// List and trigger scheduled cron jobs for an app.
     #[command(
         subcommand,
+        long_about = "\
+List and trigger scheduled cron jobs for an app.
+
+Cron jobs are declared in floo.app.toml under [cron.<name>] sections — they
+are not created with the CLI. This command surface is read-only (`list`) plus
+manual trigger (`run`); jobs are reconciled from config on every deploy.
+
+See `floo docs app-toml` (look for 'Cron Jobs') for the full [cron.<name>]
+schema, or https://getfloo.com/docs/guides/cron-jobs for the long-form guide.",
         after_help = "\
 Examples:
   floo cron list --app my-app              List all cron jobs and their last run status
-  floo cron run daily-report --app my-app  Manually trigger a cron job"
+  floo cron run daily-report --app my-app  Manually trigger a cron job
+
+Schedules are declared in floo.app.toml under [cron.<name>]. This CLI is
+read-only + manual trigger; new jobs are added by editing config and deploying."
     )]
     Cron(CronCommands),
 
@@ -1092,10 +1104,17 @@ fn rewrite_bare_version_flag(args: Vec<OsString>) -> Vec<OsString> {
     rewritten
 }
 
-/// Reject `--dry-run` for mutating commands that don't implement it yet.
-/// Read-only commands silently ignore the flag; unsupported mutators error early.
-fn reject_unsupported_dry_run(command: &Commands) {
-    let unsupported = matches!(
+/// Mutating commands that have not implemented `--dry-run`.
+///
+/// Read-only commands silently ignore the flag (they don't mutate, so a
+/// preview of "do nothing" is a no-op). Mutating commands either implement
+/// `--dry-run` themselves (handled in their own command module) or are
+/// listed here so we error early instead of partially executing.
+///
+/// Tested via `dry_run_unsupported_matches_intent` so a stale entry here
+/// (e.g. a command grew dry-run support but was never removed) fails fast.
+fn dry_run_is_unsupported(command: &Commands) -> bool {
+    matches!(
         command,
         Commands::Init { .. }
             | Commands::Apps(AppsCommands::Github(
@@ -1110,7 +1129,6 @@ fn reject_unsupported_dry_run(command: &Commands) {
             | Commands::Billing(BillingCommands::SpendCap(SpendCapCommands::Set { .. }))
             | Commands::Run { .. }
             | Commands::Db(DbCommands::Migrate { .. })
-            | Commands::Cron(CronCommands::Run { .. })
             | Commands::Feedback { .. }
             | Commands::Skills(SkillsCommands::Install { .. })
             | Commands::Auth(
@@ -1119,18 +1137,40 @@ fn reject_unsupported_dry_run(command: &Commands) {
                     | AuthCommands::Register { .. }
                     | AuthCommands::UpdateProfile { .. }
             )
-    );
-    if unsupported {
-        output::error(
-            "--dry-run is not supported for this command.",
-            &crate::errors::ErrorCode::InvalidFormat,
-            Some(
-                "Supported: redeploy, preflight, dev, update, env set/remove/import, \
-                 apps delete, domains add/remove, cron add, deploys rollback.",
-            ),
-        );
-        std::process::exit(1);
+    )
+}
+
+/// Comma-joinable names of mutating commands that DO support `--dry-run`.
+///
+/// Single source of truth used in the error suggestion. Each entry must be
+/// a real subcommand path (parseable by clap) — guarded by
+/// `dry_run_supported_names_are_real_subcommands`.
+const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
+    "redeploy",
+    "preflight",
+    "dev",
+    "update",
+    "env set",
+    "env remove",
+    "env import",
+    "apps delete",
+    "domains add",
+    "domains remove",
+    "cron run",
+    "deploys rollback",
+];
+
+fn reject_unsupported_dry_run(command: &Commands) {
+    if !dry_run_is_unsupported(command) {
+        return;
     }
+    let suggestion = format!("Supported: {}.", DRY_RUN_SUPPORTED_COMMANDS.join(", "));
+    output::error(
+        "--dry-run is not supported for this command.",
+        &crate::errors::ErrorCode::InvalidFormat,
+        Some(&suggestion),
+    );
+    std::process::exit(1);
 }
 
 pub fn run() {
@@ -1520,5 +1560,56 @@ mod tests {
         // --help has its own clap short-circuit and we don't need to network for it.
         let out = rewrite_bare_version_flag(argv(&["floo", "--help"]));
         assert_eq!(strs(&out), vec!["floo", "--help"]);
+    }
+
+    /// Each entry in DRY_RUN_SUPPORTED_COMMANDS must be a real subcommand path
+    /// (parseable by clap) AND must NOT be in the unsupported set. This catches
+    /// drift between the suggestion text and the matches! list — the original
+    /// 2026-04-30 bug where the error string listed `cron add` (no such
+    /// subcommand) and the matches! list rejected `cron run` (which actually
+    /// implements --dry-run).
+    #[test]
+    fn dry_run_supported_names_are_real_subcommands() {
+        // Minimal required positionals so each invocation parses.
+        let invocations: &[(&str, &[&str])] = &[
+            ("redeploy", &["floo", "redeploy", "--dry-run"]),
+            ("preflight", &["floo", "preflight", "--dry-run"]),
+            ("dev", &["floo", "dev", "--dry-run"]),
+            ("update", &["floo", "update", "--dry-run"]),
+            ("env set", &["floo", "env", "set", "K=V", "--dry-run"]),
+            ("env remove", &["floo", "env", "remove", "K", "--dry-run"]),
+            ("env import", &["floo", "env", "import", ".env", "--dry-run"]),
+            ("apps delete", &["floo", "apps", "delete", "myapp", "--dry-run"]),
+            ("domains add", &["floo", "domains", "add", "x.com", "--dry-run"]),
+            ("domains remove", &["floo", "domains", "remove", "x.com", "--dry-run"]),
+            ("cron run", &["floo", "cron", "run", "myjob", "--dry-run"]),
+            ("deploys rollback", &["floo", "deploys", "rollback", "myapp", "abc", "--dry-run"]),
+        ];
+
+        let listed: std::collections::HashSet<&str> =
+            DRY_RUN_SUPPORTED_COMMANDS.iter().copied().collect();
+        let invoked: std::collections::HashSet<&str> =
+            invocations.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            listed, invoked,
+            "DRY_RUN_SUPPORTED_COMMANDS and the test invocation table must list the same names",
+        );
+
+        for (label, args) in invocations {
+            let cli = Cli::try_parse_from(args.iter().copied())
+                .unwrap_or_else(|e| panic!("clap rejected '{label}' invocation {args:?}: {e}"));
+            assert!(cli.dry_run, "expected --dry-run set for '{label}'");
+            assert!(
+                !dry_run_is_unsupported(&cli.command),
+                "'{label}' is listed as supported but dry_run_is_unsupported() returns true",
+            );
+        }
+    }
+
+    #[test]
+    fn dry_run_unsupported_for_known_mutator() {
+        // `floo init` does not implement --dry-run; the gate must catch it.
+        let cli = Cli::try_parse_from(["floo", "init", "x", "--dry-run"]).unwrap();
+        assert!(dry_run_is_unsupported(&cli.command));
     }
 }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -38,6 +38,7 @@ never uploads code.
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services
   floo docs config     — config file formats with examples
+  floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
   floo docs deploy     — detailed deploy flow and runtime detection
   floo docs auth       — add user authentication to your app
   floo docs feedback   — report bugs, friction, or feature requests
@@ -93,8 +94,8 @@ Floo Quickstart — End-to-End Walkthrough
   floo services add redis --app my-app
   floo services add storage --app my-app
 
-  Credentials arrive as runtime env vars (DATABASE_URL, REDIS_URL,
-  STORAGE_BUCKET + STORAGE_URL). The commands write .floo/services.lock,
+  Credentials arrive as runtime env vars (Postgres: DATABASE_URL + PG*,
+  Redis: REDIS_URL, Storage: STORAGE_BUCKET + STORAGE_URL). The commands write .floo/services.lock,
   which you should commit so managed-service state changes are visible
   in `git diff` alongside code.
 
@@ -170,8 +171,8 @@ confirmation. See also: floo docs state-model.
   worker  — background process (no incoming HTTP traffic)
 
   Declare inline in floo.app.toml with type, port, and path. Removing a
-  service from floo.app.toml tears down the Cloud Run service on next
-  deploy — recoverable from code, so declarative semantics are safe here.
+  service from floo.app.toml does not destroy the live Cloud Run service;
+  retire services explicitly so accidental config edits do not create drift.
 
   See: floo docs config
 
@@ -193,25 +194,33 @@ confirmation. See also: floo docs state-model.
 
   Connection credentials are injected at runtime, never stored in the
   lock file or in your repo:
-    postgres → DATABASE_URL
+    postgres → DATABASE_URL + PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD
     redis    → REDIS_URL
     storage  → STORAGE_BUCKET + STORAGE_URL (use STORAGE_URL for signed URLs)
 
-## Managed Service Tiers
+  In multi-service apps, attach those credentials per service:
+    [services.api.env]
+    managed = [\"postgres\", \"redis\"]
 
-  All tiers are available on every plan. Only Postgres tiers have
-  functional differences today:
+    [services.web.env]
+    managed = []
 
-                Basic (default)   Standard        Performance
-  Connections   5                 15              50
-  Query timeout 30s               60s             120s
-  Idle timeout  60s               120s            300s
-  work_mem      64 MB             128 MB          256 MB
+  Single-service apps can use top-level [env] managed = [] in
+  floo.service.toml to opt out of managed credentials entirely.
 
-  Start with basic. Upgrade to standard for multi-service apps or
-  reporting queries. Use performance for high-concurrency workloads.
+## Managed Service Capacity
 
-  Pass --tier on add: floo services add postgres --tier standard
+  Managed Postgres uses one default capacity profile today:
+
+    Connections      25
+    Query timeout    60s
+    Idle timeout     120s
+    Lock timeout     10s
+    work_mem         128 MB
+
+  The --tier flag is accepted for backwards compatibility but ignored.
+  For sustained higher concurrency, email team@getfloo.com for a
+  dedicated Postgres instance.
 
 ## Legacy [postgres] / [redis] / [storage] in floo.app.toml
 
@@ -332,8 +341,8 @@ Floo Config Files
   type = \"web\"
   ingress = \"public\"
 
-  Prefer floo.app.toml for new apps — it supports managed services (postgres,
-  redis, storage), cron jobs, and multi-service apps in one file.
+  Prefer floo.app.toml for new apps. It supports managed credential
+  attachments, cron jobs, and multi-service apps in one file.
 
 ## Service Fields (floo.app.toml inline or floo.service.toml)
 
@@ -355,16 +364,22 @@ Floo Config Files
   port inline in floo.app.toml, there must not be a floo.service.toml in
   that service's subdirectory. The CLI fails preflight if both are present.
 
-## Managed Services (in floo.app.toml)
+## Managed Service Attachments
 
-  [postgres]
-  tier = \"basic\"
+  Provision durable resources with the CLI:
 
-  [redis]
+    floo services add postgres --app my-app
+    floo services add redis --app my-app
+    floo services add storage --app my-app
 
-  [storage]
+  Attach credentials to the services that need them:
 
-  Auto-provisioned on first deploy. Credentials injected as env vars.
+    [services.api.env]
+    managed = [\"postgres\", \"redis\"]
+
+  Legacy [postgres], [redis], and [storage] sections in floo.app.toml
+  still work during the deprecation window, but `floo services add`
+  is the canonical authoring surface.
 
 ## Resource Limits (optional)
 
@@ -383,6 +398,38 @@ Floo Config Files
 
   [environments.prod]
   access_mode = \"accounts\"
+
+## Cron Jobs ([cron.<name>])
+
+  Scheduled jobs are declared in floo.app.toml — never created by the CLI.
+  Each [cron.<name>] section becomes a managed cron job that's reconciled
+  on every deploy (added, updated, or removed to match config).
+
+  [cron.daily-report]
+  schedule = \"0 9 * * *\"                  # cron expression: 9am UTC daily
+  command  = \"python -m reports.daily\"    # executed inside the service container
+  service  = \"api\"                         # which service's image to run in
+  timeout  = 600                            # max seconds (default 300, optional)
+
+  [cron.cleanup]
+  schedule = \"*/5 * * * *\"                 # every 5 minutes
+  command  = \"node scripts/cleanup.js\"
+  service  = \"worker\"
+
+  Fields:
+
+  - schedule (required) — standard cron expression in UTC
+  - command  (required) — shell command run inside the target service's container
+  - service  (required) — name of a [services.<name>] entry; that image is reused
+  - timeout  (optional) — max execution seconds; default 300
+
+  CLI surface (read-only + manual trigger):
+
+    floo cron list --app my-app              # list jobs and last run status
+    floo cron run daily-report --app my-app  # trigger one off-schedule
+
+  Long-form guide: https://getfloo.com/docs/guides/cron-jobs
+  Full config schema: https://getfloo.com/docs/reference/config-spec
 
 ## Environment Variables in Multi-Service Apps
 
@@ -418,9 +465,19 @@ Floo Config Files
     floo env list --services api
     floo env list --services web
 
-  Managed service env vars (DATABASE_URL, REDIS_URL, STORAGE_BUCKET) are
-  set at app scope and available to all services. Use --services to restrict
-  access if needed.
+  Managed service env vars are generated at app scope, then attached to
+  services by [services.<name>.env] managed:
+
+    [services.web.env]
+    managed = []
+
+    [services.api.env]
+    required = [\"STRIPE_SECRET_KEY\"]
+    managed = [\"postgres\", \"redis\"]
+
+  If no service declares managed, floo preserves legacy all-service injection.
+  Once any service declares it, omitted services receive no managed credentials.
+  `floo preflight --json` shows the exact env_injection_plan.
 
 ## Commands
 
@@ -499,6 +556,11 @@ Floo Deploy Flow
 
   floo preflight                   — validate config, detect runtimes, check readiness
   floo preflight --json            — structured output for agents
+
+  JSON includes env_injection_plan: per-service managed attachments, generated
+  env keys (DATABASE_URL + PG*, REDIS_URL, STORAGE_BUCKET/STORAGE_URL),
+  required keys, optional keys, and whether the app is in explicit or legacy
+  implicit mode.
 
 ## Redeploy Options
 
@@ -729,16 +791,16 @@ Floo — Golden Path
 
 ## How to Add a Database
 
-  Add to floo.app.toml:
+  Run:
 
-  [postgres]
-  tier = \"basic\"
+  floo services add postgres --app my-app
 
-  Commit the change and push to GitHub:
-  git add floo.app.toml && git commit -m \"feat: add postgres\"
+  Commit the generated lock file and push to GitHub:
+  git add .floo/services.lock && git commit -m \"feat: add postgres\"
   git push origin main
 
-  The database is auto-provisioned on the next deploy. Credentials arrive as DATABASE_URL.
+  The database is available on the next deploy. Credentials arrive as a
+  standard DATABASE_URL plus PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD.
 
 ## How to Add a Custom Domain
 
@@ -815,9 +877,6 @@ Floo Templates — Copy-Paste App Structures
   [app]
   name = \"my-app\"
 
-  [postgres]
-  tier = \"basic\"
-
   [services.web]
   path = \"./web\"
   type = \"web\"
@@ -832,6 +891,9 @@ Floo Templates — Copy-Paste App Structures
   ingress = \"public\"
   dev_command = \"uvicorn app.main:app --reload --port 8080\"
   migrate_command = \"alembic upgrade head\"
+
+  [services.api.env]
+  managed = [\"postgres\"]
 
 ### api/app/main.py
 
@@ -1034,11 +1096,15 @@ App is live at https://my-rails-app-dev.on.getfloo.com.
 
 ## 4. Add Postgres
 
-  floo services add postgres --app my-rails-app --tier basic
+  floo services add postgres --app my-rails-app
   git add .floo/services.lock && git commit -m \"feat: add postgres\"
   git push origin main
 
-Rails reads DATABASE_URL automatically. Confirm config/database.yml has:
+Rails reads DATABASE_URL automatically. floo injects a normal PostgreSQL
+URI, so ActiveRecord can parse it without custom Cloud SQL socket code.
+`floo preflight` warns if a local env file still contains the old Cloud
+SQL socket-style DATABASE_URL that Ruby's URI parser rejects.
+Confirm config/database.yml has:
 
   production:
     primary:
@@ -1132,7 +1198,7 @@ Skipping this is the most common Next.js footgun on floo.
 
 ## 4. Postgres
 
-  floo services add postgres --app my-nextjs-app --tier basic
+  floo services add postgres --app my-nextjs-app
   # Prisma reads DATABASE_URL automatically
 
 ## 5. Per-user auth
@@ -1197,7 +1263,7 @@ Bind to 0.0.0.0 — 127.0.0.1 won't accept Cloud Run traffic.
 
 ## 3. Postgres
 
-  floo services add postgres --app my-fastapi-app --tier basic
+  floo services add postgres --app my-fastapi-app
 
   # Async SQLAlchemy — convert to asyncpg URL:
   DATABASE_URL = os.environ[\"DATABASE_URL\"].replace(
@@ -1291,7 +1357,7 @@ Use whitenoise for static files, gunicorn for the WSGI server.
 
 ## 4. Postgres
 
-  floo services add postgres --app my-django-app --tier basic
+  floo services add postgres --app my-django-app
   # dj-database-url parses DATABASE_URL automatically
 
 ## 5. Per-user auth
@@ -1368,7 +1434,7 @@ won't get set behind floo's edge.
 
 ## 4. Postgres
 
-  floo services add postgres --app my-express-app --tier basic
+  floo services add postgres --app my-express-app
 
   import pg from \"pg\";
   export const pool = new pg.Pool({
@@ -1405,6 +1471,77 @@ won't get set behind floo's edge.
 Full guide with complete JavaScript code: https://docs.getfloo.com/build/express
 ";
 
+const CRON: &str = "\
+Floo Cron Jobs
+
+Cron jobs are declared in floo.app.toml — never created by the CLI. Each
+[cron.<name>] section becomes a managed cron job, reconciled on every
+deploy (added, updated, or removed to match config).
+
+## Declare in floo.app.toml
+
+  [cron.daily-report]
+  schedule = \"0 9 * * *\"                  # 9am UTC daily
+  command  = \"python -m reports.daily\"
+  service  = \"api\"                         # which service's image to run in
+
+  [cron.cleanup]
+  schedule = \"*/5 * * * *\"                 # every 5 minutes
+  command  = \"node scripts/cleanup.js\"
+  service  = \"worker\"
+  timeout  = 600                            # max seconds (default 300, optional)
+
+## Fields
+
+  schedule  required  Standard cron expression in UTC.
+  command   required  Shell command executed inside the target service's container.
+  service   required  Name of a [services.<name>] entry; that image is reused.
+  timeout   optional  Max execution time in seconds. Default 300.
+
+## Common schedules
+
+  * * * * *     every minute
+  */5 * * * *   every 5 minutes
+  0 * * * *     every hour
+  0 9 * * *     daily at 9am UTC
+  0 9 * * 1-5   weekdays at 9am UTC
+  0 0 * * 0     weekly on Sunday at midnight UTC
+  0 0 1 * *     monthly on the 1st at midnight UTC
+
+## Deploy and verify
+
+  Push to GitHub or run `floo redeploy`. New jobs are created, changed jobs
+  updated, removed jobs deleted — all on the deploy itself.
+
+    git push origin main && floo deploys watch --app my-app
+    floo cron list --app my-app                # see jobs + last run status
+
+## Manually trigger a job (off-schedule)
+
+  Useful for testing or one-off catch-up runs:
+
+    floo cron run daily-report --app my-app
+    floo cron run daily-report --app my-app --dry-run   # preview, no API call
+
+## CLI surface
+
+  The `floo cron` CLI is read-only + manual trigger. Schedules and commands
+  are config-driven; the CLI never adds, removes, or edits them.
+
+    floo cron list --app <name>            list jobs and last run status
+    floo cron run <name> --app <app>       trigger a job off-schedule
+
+## Environment
+
+  Jobs run inside the specified service's container image with the same
+  env vars as the service — same DATABASE_URL, REDIS_URL, secrets, etc.
+
+## Long-form guide
+
+  https://getfloo.com/docs/guides/cron-jobs   — examples, agent workflow, troubleshooting
+  https://getfloo.com/docs/reference/config-spec   — full [cron.<name>] schema reference
+";
+
 const TOPICS: &[(&str, &str)] = &[
     ("quickstart", QUICKSTART),
     ("golden-path", HOWTO),
@@ -1417,6 +1554,7 @@ const TOPICS: &[(&str, &str)] = &[
     ("services", SERVICES),
     ("config", CONFIG),
     ("app-toml", CONFIG), // alias — agents can run `floo docs app-toml` after `floo init`
+    ("cron", CRON),
     ("deploy", DEPLOY),
     ("auth", AUTH),
     ("feedback", FEEDBACK),
@@ -1463,6 +1601,7 @@ mod tests {
         assert!(!QUICKSTART.is_empty());
         assert!(!SERVICES.is_empty());
         assert!(!CONFIG.is_empty());
+        assert!(!CRON.is_empty());
         assert!(!DEPLOY.is_empty());
         assert!(!AUTH.is_empty());
         assert!(!TEMPLATES.is_empty());
@@ -1472,6 +1611,41 @@ mod tests {
         assert!(!FASTAPI.is_empty());
         assert!(!DJANGO.is_empty());
         assert!(!EXPRESS.is_empty());
+    }
+
+    /// The 2026-04-30 cron-docs feedback: `floo docs app-toml` mentioned cron
+    /// as a feature but never showed the [cron.<name>] schema. CONFIG must
+    /// document the schema (fields + example) so agents can author cron jobs
+    /// without leaving the cheatsheet, and a dedicated `cron` topic gives the
+    /// short answer for `floo docs cron`.
+    #[test]
+    fn test_cron_schema_documented_in_config_and_cron_topics() {
+        for (label, content) in [("config/app-toml", CONFIG), ("cron", CRON)] {
+            assert!(
+                content.contains("[cron."),
+                "{label} must show the [cron.<name>] section header",
+            );
+            for field in ["schedule", "command", "service", "timeout"] {
+                assert!(
+                    content.contains(field),
+                    "{label} must document the '{field}' field",
+                );
+            }
+            assert!(
+                content.contains("floo cron list"),
+                "{label} must show the read-only CLI surface",
+            );
+        }
+        // The CONFIG cheatsheet must link to the long-form guide so agents
+        // can route to it from `floo docs app-toml`.
+        assert!(CONFIG.contains("getfloo.com/docs/guides/cron-jobs"));
+    }
+
+    #[test]
+    fn test_cron_topic_in_overview_listing() {
+        // The overview cheatsheet is the entry point; missing the cron topic
+        // here was part of the original discoverability gap.
+        assert!(OVERVIEW.contains("floo docs cron"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Closes the three layers of stale metadata around `floo cron` reported in customer feedback `23b7283c` (team@getfloo.com on floo-artifact, 2026-04-30):

1. **`--dry-run` rejection error lied.** The error suggestion listed `cron add` (which does not exist) and the `unsupported` matches list rejected `cron run` (which has a working dry-run handler in `commands/cron.rs` — that handler had become dead code). Two hand-maintained lists drifted; this PR replaces them with a pure predicate `dry_run_is_unsupported()` and a single source of truth `DRY_RUN_SUPPORTED_COMMANDS`. New test `dry_run_supported_names_are_real_subcommands` round-trips each listed name through clap and asserts each is parseable AND not in the unsupported set — would have caught the original `cron add` ghost on day one.

2. **`floo cron --help` had no hint that schedules are TOML-declared.** Added `long_about` to the Cron subcommand and a reinforced `after_help` footer that states jobs are declared in `floo.app.toml` under `[cron.<name>]` and the CLI is read-only + manual trigger.

3. **`floo docs app-toml` mentioned cron as a feature but never showed the `[cron.<name>]` schema.** Added a full **Cron Jobs** section to the CONFIG cheatsheet (fields, example, CLI surface, links) and a dedicated `cron` topic so `floo docs cron` returns a focused cheatsheet covering schema + schedules + CLI + environment. Listed `floo docs cron` in the overview.

## Why

Cron has the right design (declarative TOML + read/trigger CLI), but three layers of stale metadata around it were producing a coherent-looking false signal: the error told users `cron add` exists, then `cron --help` confirmed it didn't, then the docs cheatsheet said cron was supported but never showed the schema. Each layer reinforced the next.

## Risk tier

`exempt` — pure CLI strings, in-binary docs, plus tests. No platform behavior, no schema, no auth, no migrations.

## Files reviewers should scrutinize

- `src/cli.rs` → `dry_run_is_unsupported`, `DRY_RUN_SUPPORTED_COMMANDS`, the new `dry_run_supported_names_are_real_subcommands` test, and the new `Cron` `long_about`/`after_help`.
- `src/commands/docs.rs` → new **Cron Jobs** section in `CONFIG`, new `CRON` topic, OVERVIEW listing entry, `test_cron_schema_documented_in_config_and_cron_topics`, `test_cron_topic_in_overview_listing`.

## Tests run

311/311 floo-local unit tests pass:

```
cargo test --bin floo-local --quiet
test result: ok. 311 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Verified live in the built binary:

- `floo cron --help` opens with the TOML-declared note.
- `floo init --dry-run` error now lists `cron run` (real) instead of `cron add` (ghost).
- `floo docs cron` returns the new schema-first cheatsheet.

## Known non-goals

- The dry-run handler in `cron run` still requires auth + app resolution before printing the dry-run preview (unlike `domains add`, which is preview-without-network). That's a separate UX question and not what the feedback asked for. Out of scope here.
- A companion `floo-docs` PR (https://github.com/getfloo/floo-docs/pull/new/fix/cron-docs-cli-reference) adds the missing `/cli/cron` reference page and redirects `/build/cron` → `/guides/cron-jobs` — both PRs together close the feedback.