### PR TITLE
feat(preflight): suggest 'floo update' on unknown TOML fields

### DIFF
--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -297,13 +297,8 @@ pub fn load_app_config(dir: &Path) -> Result<Option<AppFileConfig>, FlooError> {
         )
     })?;
 
-    let config: AppFileConfig = toml::from_str(&content).map_err(|e| {
-        FlooError::with_suggestion(
-            ErrorCode::InvalidProjectConfig,
-            format!("Invalid {}: {e}", super::APP_CONFIG_FILE),
-            format!("See {SCHEMA_URL} for the schema reference."),
-        )
-    })?;
+    let config: AppFileConfig =
+        toml::from_str(&content).map_err(|e| super::toml_parse_error(super::APP_CONFIG_FILE, e))?;
 
     validate_app_config(&config)?;
 
@@ -530,6 +525,17 @@ unknown = "bad"
 
         let err = load_app_config(dir.path()).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        let suggestion = err
+            .suggestion
+            .expect("unknown-field rejection must surface a CLI-version-skew suggestion");
+        assert!(
+            suggestion.contains("`unknown`"),
+            "suggestion should name the unknown key, got: {suggestion}"
+        );
+        assert!(
+            suggestion.contains("floo update"),
+            "suggestion should point users at `floo update`, got: {suggestion}"
+        );
     }
 
     #[test]

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -9,6 +9,43 @@ pub const LEGACY_CONFIG_FILE: &str = "floo.toml";
 const SCHEMA_URL: &str = "https://getfloo.com/docs/floo-toml";
 const MAX_WALK_UP_LEVELS: usize = 20;
 
+/// Convert a `toml::de::Error` from project-config parsing into a FlooError
+/// with a helpful suggestion. When serde reports an `unknown field` (the
+/// `deny_unknown_fields` failure mode), surface a CLI-version-skew hint:
+/// the most common cause is a TOML key that exists in newer docs but the
+/// locally-installed CLI doesn't recognize yet, and the previous "see schema"
+/// suggestion sent users to the docs that already document the rejected key.
+pub(super) fn toml_parse_error(file_label: &str, err: toml::de::Error) -> crate::errors::FlooError {
+    let raw = err.to_string();
+    let suggestion = match extract_unknown_field(&raw) {
+        Some(field) => format!(
+            "Unknown key `{field}` may require a newer CLI \
+             (you're on {version}). Try `floo update` and re-run preflight. \
+             If the key is correct for your installed version, see {SCHEMA_URL}.",
+            version = crate::constants::VERSION,
+        ),
+        None => format!("See {SCHEMA_URL} for the schema reference."),
+    };
+
+    crate::errors::FlooError::with_suggestion(
+        crate::errors::ErrorCode::InvalidProjectConfig,
+        format!("Invalid {file_label}: {raw}"),
+        suggestion,
+    )
+}
+
+/// Extract the field name from the `toml` crate's "unknown field" message.
+///
+/// The crate emits errors like:
+///   `unknown field \`access_policy\`, expected one of \`name\`, ...`
+fn extract_unknown_field(msg: &str) -> Option<&str> {
+    const PREFIX: &str = "unknown field `";
+    let start = msg.find(PREFIX)? + PREFIX.len();
+    let rest = &msg[start..];
+    let end = rest.find('`')?;
+    Some(&rest[..end])
+}
+
 #[cfg(test)]
 pub use app_config::AppServiceType;
 pub use app_config::{
@@ -126,5 +163,59 @@ mod tests {
         assert!(validate_service_name("my_service").is_err());
         assert!(validate_service_name("my.service").is_err());
         assert!(validate_service_name("my service").is_err());
+    }
+
+    #[test]
+    fn test_extract_unknown_field_typical_message() {
+        let msg = "TOML parse error at line 4, column 1\n  |\n4 | access_policy = \"domain\"\n  | ^^^^^^^^^^^^^\nunknown field `access_policy`, expected `name`";
+        assert_eq!(extract_unknown_field(msg), Some("access_policy"));
+    }
+
+    #[test]
+    fn test_extract_unknown_field_returns_none_when_no_match() {
+        let msg = "TOML parse error: missing field `name`";
+        assert_eq!(extract_unknown_field(msg), None);
+    }
+
+    #[test]
+    fn test_toml_parse_error_unknown_field_suggests_update() {
+        // Synthesize the same path real callers hit.
+        #[derive(serde::Deserialize, Debug)]
+        #[serde(deny_unknown_fields)]
+        #[allow(dead_code)]
+        struct Probe {
+            name: String,
+        }
+        let err = toml::from_str::<Probe>("name = \"x\"\nfoo = 1\n").unwrap_err();
+        let floo_err = toml_parse_error("floo.app.toml", err);
+        let suggestion = floo_err
+            .suggestion
+            .expect("unknown-field path always sets a suggestion");
+        assert!(suggestion.contains("`foo`"), "got: {suggestion}");
+        assert!(suggestion.contains("floo update"), "got: {suggestion}");
+        // Falls back to schema link when the user is on a current CLI.
+        assert!(suggestion.contains(SCHEMA_URL), "got: {suggestion}");
+    }
+
+    #[test]
+    fn test_toml_parse_error_non_unknown_field_uses_schema_url() {
+        // A non-`unknown field` parse error (here: type mismatch) should fall
+        // back to the schema-reference suggestion. Sending users to
+        // `floo update` for a typo would be misleading.
+        #[derive(serde::Deserialize, Debug)]
+        #[allow(dead_code)]
+        struct Probe {
+            count: u32,
+        }
+        let err = toml::from_str::<Probe>("count = \"not a number\"\n").unwrap_err();
+        let floo_err = toml_parse_error("floo.app.toml", err);
+        let suggestion = floo_err
+            .suggestion
+            .expect("non-unknown-field path still sets a suggestion");
+        assert!(suggestion.contains(SCHEMA_URL), "got: {suggestion}");
+        assert!(
+            !suggestion.contains("floo update"),
+            "should not suggest update for non-schema-skew errors, got: {suggestion}"
+        );
     }
 }

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -335,13 +335,8 @@ pub fn load_service_config(dir: &Path) -> Result<Option<ServiceFileConfig>, Floo
         )
     })?;
 
-    let config: ServiceFileConfig = toml::from_str(&content).map_err(|e| {
-        FlooError::with_suggestion(
-            ErrorCode::InvalidProjectConfig,
-            format!("Invalid {}: {e}", super::SERVICE_CONFIG_FILE),
-            format!("See {SCHEMA_URL} for the schema reference."),
-        )
-    })?;
+    let config: ServiceFileConfig = toml::from_str(&content)
+        .map_err(|e| super::toml_parse_error(super::SERVICE_CONFIG_FILE, e))?;
 
     if let Some(ref env) = config.env {
         env.validate(&format!("[env] in {}", super::SERVICE_CONFIG_FILE))?;


### PR DESCRIPTION
## Summary

Closes feedback `1f9001f8` (team@getfloo.com on floo-artifact, 2026-04-30):

> _"CLI/docs version skew has no detector. In this session I twice had to 'floo update' mid-task because docs.getfloo.com referenced TOML keys (e.g. [auth].access_policy, [auth].allowed_domains, the new managed-service declaration model) that the locally-installed CLI rejected during preflight schema validation. There was no signal until preflight failed with a generic schema error. Ask: when preflight encounters an unknown TOML key, warn explicitly: 'unknown key X — may require newer CLI, try floo update (current 2026.04.29.1)' instead of failing as malformed config."_

## What changed

Schema validation in `load_app_config` / `load_service_config` now detects serde's `unknown field` error (the `deny_unknown_fields` failure mode) and surfaces a CLI-version-skew hint instead of the generic "see schema reference" suggestion.

Both schema entry points (`floo.app.toml` and `floo.service.toml`) route through a new helper `project_config::toml_parse_error`, which reads the field name from the toml crate's error message and produces:

```
Unknown key 'X' may require a newer CLI (you're on <version>).
Try 'floo update' and re-run preflight. If the key is correct for
your installed version, see https://getfloo.com/docs/floo-toml.
```

Type-mismatch and other parse errors still fall back to the schema link; sending those users to `floo update` would be misleading.

## Files touched

- `src/project_config/mod.rs` — new `toml_parse_error` + `extract_unknown_field` helpers.
- `src/project_config/app_config.rs` — route through helper.
- `src/project_config/service_config.rs` — route through helper.

## Test plan

- [x] `cargo test --bin floo project_config::` — 110 passing including 4 new helper tests:
  - `test_extract_unknown_field_typical_message`
  - `test_extract_unknown_field_returns_none_when_no_match`
  - `test_toml_parse_error_unknown_field_suggests_update`
  - `test_toml_parse_error_non_unknown_field_uses_schema_url`
- [x] Existing `test_load_app_config_unknown_field_rejected` extended to assert the new suggestion mentions both the field name and `floo update`.
- [x] `cargo test --bin floo` — 323 passing.
- [x] `cargo fmt --check` — clean for this diff (pre-existing main drift in `deploy.rs` not addressed here; tracked separately).
- [x] Manual: preflight on a TOML with a typo'd key now prints "Unknown key 'not_a_real_key' may require a newer CLI ... Try 'floo update'" instead of "see schema reference".

## Known non-goals

- `floo version --check-docs` (the "bonus" half of feedback `1f9001f8`) is **not** in this PR. That part needs a docs-site schema-version manifest endpoint that doesn't exist yet, and it's worth its own design pass. Filing a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)