### PR TITLE
docs(rails): mirror promoted local-dev section + add floo run

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -1057,7 +1057,40 @@ promote (against prod). Rails migrations stay in sync with deploys.
 
 App is live at https://my-rails-app-dev.on.getfloo.com.
 
-## 4. Add Postgres
+## 4. Local dev and one-shot commands
+
+Two commands cover the daily Rails workflow once your first deploy is up.
+
+Local dev server with prod-shaped env:
+
+  floo dev --app my-rails-app --service web
+
+Runs your dev_command locally with DATABASE_URL and other env vars
+sourced from floo. Real Cloud SQL connection, no exported credentials.
+
+Add --fixture-user to test signed-in (accounts-mode) flows locally:
+
+  floo dev --app my-rails-app --service web --fixture-user you@example.com
+
+The proxy injects the same X-Floo-User-* headers floo's gateway adds in
+production, so the controller reading those headers works locally with
+no conditional code.
+
+One-shot commands (rake tasks, db:seed, console):
+
+  floo run --service web -- bundle exec rake my_task
+  floo run --service web -- bin/rails db:seed
+  floo run --service web -- bin/rails console
+  floo run --service web -- bin/rails db:migrate
+
+floo run inherits stdin/stdout/stderr, so interactive commands like
+bin/rails console work like running them locally — your shell just sees
+the floo-injected env vars instead of your local .env. Migrations run
+automatically on every deploy via migrate_command; use `floo run --
+bin/rails db:migrate` only for ad-hoc migration work outside the deploy
+path.
+
+## 5. Add Postgres
 
   floo services add postgres --app my-rails-app --tier basic
   git add .floo/services.lock && git commit -m \"feat: add postgres\"
@@ -1073,7 +1106,7 @@ Confirm config/database.yml has:
     primary:
       url: <%= ENV[\"DATABASE_URL\"] %>
 
-## 5. Add per-user auth
+## 6. Add per-user auth
 
 floo manages user authentication. Set access_mode = \"accounts\" in floo.app.toml — that is the entire auth config:
 
@@ -1097,18 +1130,14 @@ identity headers. Your Rails controllers read them:
     end
   end
 
-## 6. Add a custom domain
+For local development, run `floo dev --fixture-user` (section 4) — same
+identity headers in front of the local server, no conditional code.
+
+## 7. Add a custom domain
 
   floo domains add app.example.com --app my-rails-app
 
 Add the CNAME shown in the output at your DNS provider.
-
-## 7. Local dev with prod data
-
-  floo dev --app my-rails-app --service web
-
-Runs your dev_command locally with DATABASE_URL and other env vars
-sourced from floo. Real Cloud SQL connection, no exported credentials.
 
 ## Common gotchas
 
@@ -1578,12 +1607,18 @@ mod tests {
 
     #[test]
     fn test_rails_topic_covers_full_journey() {
-        // Stack-journey shape: deploy → DB → auth → domain → local dev
+        // Stack-journey shape: deploy → local dev → DB → auth → domain
         assert!(RAILS.contains("floo init"));
         assert!(RAILS.contains("services add postgres"));
         assert!(RAILS.contains("access_mode = \"accounts\""));
         assert!(RAILS.contains("domains add"));
         assert!(RAILS.contains("floo dev"));
+        // Rails workflow leans on rake/console/db:seed — floo run is the
+        // way to do those with managed env. Mirror this surface to match
+        // the published rails.mdx so agents reading via `floo docs rails`
+        // see the same thing as agents reading via the docs site.
+        assert!(RAILS.contains("floo run"));
+        assert!(RAILS.contains("bin/rails console"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mirror update for the published rails build guide (floo-docs PR _docs(rails): promote local dev section + add floo run for one-shot commands_) so agents reading via `floo docs rails` see the same workflow as agents reading docs.getfloo.com.

Per the docs-alignment skill: "When you add a stack guide to floo-docs/build/rails.mdx, you also add a (\"rails\", RAILS) entry to TOPICS and write a condensed version into RAILS." This PR keeps the offline CLI mirror in sync with the published guide.

## What changed

Updates to the `RAILS` const in `src/commands/docs.rs`:

- Move "Local dev with prod data" from section 7 → **section 4** (right after deploy, before Postgres / auth / domain). Same reordering as floo-docs.
- **Expand it** with `floo run` examples: rake tasks, `db:seed`, `bin/rails console`, and ad-hoc `db:migrate`.
- **Auth section** now points to section 4 for the local fixture-user flow instead of leaving it implicit.

Test addition:

- `test_rails_topic_covers_full_journey` now asserts `RAILS.contains(\"floo run\")` and `RAILS.contains(\"bin/rails console\")`. This pins the mirror to the docs-site section structure — if either drifts, the test catches it before merge.

## Test plan

- [x] `cargo test --bin floo commands::docs::` — all 14 docs tests pass.
- [x] `cargo test --bin floo` — all 319 unit tests pass.
- [x] Manual: `./target/debug/floo docs rails` renders the new section 4 cleanly with the four `floo run` examples and the migration tip.

## Pairs with

- getfloo/floo-docs#15 — published rails build guide changes.

Same source feedback: `d8c20219` (team@getfloo.com on floo-artifact, 2026-04-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)