### PR TITLE
fix(cli): cron docs gap + stale --dry-run command list

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -342,10 +342,22 @@ Examples:
     /// List and trigger scheduled cron jobs for an app.
     #[command(
         subcommand,
+        long_about = "\
+List and trigger scheduled cron jobs for an app.
+
+Cron jobs are declared in floo.app.toml under [cron.<name>] sections — they
+are not created with the CLI. This command surface is read-only (`list`) plus
+manual trigger (`run`); jobs are reconciled from config on every deploy.
+
+See `floo docs app-toml` (look for 'Cron Jobs') for the full [cron.<name>]
+schema, or https://getfloo.com/docs/guides/cron-jobs for the long-form guide.",
         after_help = "\
 Examples:
   floo cron list --app my-app              List all cron jobs and their last run status
-  floo cron run daily-report --app my-app  Manually trigger a cron job"
+  floo cron run daily-report --app my-app  Manually trigger a cron job
+
+Schedules are declared in floo.app.toml under [cron.<name>]. This CLI is
+read-only + manual trigger; new jobs are added by editing config and deploying."
     )]
     Cron(CronCommands),
 
@@ -1110,10 +1122,19 @@ fn rewrite_bare_version_flag(args: Vec<OsString>) -> Vec<OsString> {
     rewritten
 }
 
-/// Reject `--dry-run` for mutating commands that don't implement it yet.
-/// Read-only commands silently ignore the flag; unsupported mutators error early.
-fn reject_unsupported_dry_run(command: &Commands) {
-    let unsupported = matches!(
+/// Mutating commands that have not implemented `--dry-run`.
+///
+/// Read-only commands silently ignore the flag (they don't mutate, so a
+/// preview of "do nothing" is a no-op). Mutating commands either implement
+/// `--dry-run` themselves (handled in their own command module) or are
+/// listed here so we error early instead of partially executing.
+///
+/// Tested via `dry_run_supported_names_are_real_subcommands` (which pins
+/// the listed-supported set against parseable subcommands) and
+/// `dry_run_unsupported_for_known_mutator` (a spot-check that a known
+/// mutator stays in the unsupported set). A stale entry here fails fast.
+fn dry_run_is_unsupported(command: &Commands) -> bool {
+    matches!(
         command,
         Commands::Init { .. }
             | Commands::Apps(AppsCommands::Github(
@@ -1128,7 +1149,6 @@ fn reject_unsupported_dry_run(command: &Commands) {
             | Commands::Billing(BillingCommands::SpendCap(SpendCapCommands::Set { .. }))
             | Commands::Run { .. }
             | Commands::Db(DbCommands::Migrate { .. })
-            | Commands::Cron(CronCommands::Run { .. })
             | Commands::Feedback { .. }
             | Commands::Skills(SkillsCommands::Install { .. })
             | Commands::Auth(
@@ -1137,18 +1157,45 @@ fn reject_unsupported_dry_run(command: &Commands) {
                     | AuthCommands::Register { .. }
                     | AuthCommands::UpdateProfile { .. }
             )
-    );
-    if unsupported {
-        output::error(
-            "--dry-run is not supported for this command.",
-            &crate::errors::ErrorCode::InvalidFormat,
-            Some(
-                "Supported: redeploy, preflight, dev, update, env set/remove/import, \
-                 apps delete, domains add/remove, cron add, deploys rollback.",
-            ),
-        );
-        std::process::exit(1);
+    )
+}
+
+/// Comma-joinable names of mutating commands that DO support `--dry-run`.
+///
+/// Single source of truth used in the error suggestion. Each entry must be
+/// a real subcommand path (parseable by clap) — guarded by
+/// `dry_run_supported_names_are_real_subcommands`.
+///
+/// **When you add a new `--dry-run` handler in a `commands/*.rs` module,
+/// add an entry here AND a matching invocation row in the test.** Otherwise
+/// the suggestion text in the error will silently lie about what's supported
+/// — that drift class is exactly what this PR was opened to fix.
+const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
+    "redeploy",
+    "preflight",
+    "dev",
+    "update",
+    "env set",
+    "env remove",
+    "env import",
+    "apps delete",
+    "domains add",
+    "domains remove",
+    "cron run",
+    "deploys rollback",
+];
+
+fn reject_unsupported_dry_run(command: &Commands) {
+    if !dry_run_is_unsupported(command) {
+        return;
     }
+    let suggestion = format!("Supported: {}.", DRY_RUN_SUPPORTED_COMMANDS.join(", "));
+    output::error(
+        "--dry-run is not supported for this command.",
+        &crate::errors::ErrorCode::InvalidFormat,
+        Some(&suggestion),
+    );
+    std::process::exit(1);
 }
 
 pub fn run() {
@@ -1540,5 +1587,56 @@ mod tests {
         // --help has its own clap short-circuit and we don't need to network for it.
         let out = rewrite_bare_version_flag(argv(&["floo", "--help"]));
         assert_eq!(strs(&out), vec!["floo", "--help"]);
+    }
+
+    /// Each entry in DRY_RUN_SUPPORTED_COMMANDS must be a real subcommand path
+    /// (parseable by clap) AND must NOT be in the unsupported set. This catches
+    /// drift between the suggestion text and the matches! list — the original
+    /// 2026-04-30 bug where the error string listed `cron add` (no such
+    /// subcommand) and the matches! list rejected `cron run` (which actually
+    /// implements --dry-run).
+    #[test]
+    fn dry_run_supported_names_are_real_subcommands() {
+        // Minimal required positionals so each invocation parses.
+        let invocations: &[(&str, &[&str])] = &[
+            ("redeploy", &["floo", "redeploy", "--dry-run"]),
+            ("preflight", &["floo", "preflight", "--dry-run"]),
+            ("dev", &["floo", "dev", "--dry-run"]),
+            ("update", &["floo", "update", "--dry-run"]),
+            ("env set", &["floo", "env", "set", "K=V", "--dry-run"]),
+            ("env remove", &["floo", "env", "remove", "K", "--dry-run"]),
+            ("env import", &["floo", "env", "import", ".env", "--dry-run"]),
+            ("apps delete", &["floo", "apps", "delete", "myapp", "--dry-run"]),
+            ("domains add", &["floo", "domains", "add", "x.com", "--dry-run"]),
+            ("domains remove", &["floo", "domains", "remove", "x.com", "--dry-run"]),
+            ("cron run", &["floo", "cron", "run", "myjob", "--dry-run"]),
+            ("deploys rollback", &["floo", "deploys", "rollback", "myapp", "abc", "--dry-run"]),
+        ];
+
+        let listed: std::collections::HashSet<&str> =
+            DRY_RUN_SUPPORTED_COMMANDS.iter().copied().collect();
+        let invoked: std::collections::HashSet<&str> =
+            invocations.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            listed, invoked,
+            "DRY_RUN_SUPPORTED_COMMANDS and the test invocation table must list the same names",
+        );
+
+        for (label, args) in invocations {
+            let cli = Cli::try_parse_from(args.iter().copied())
+                .unwrap_or_else(|e| panic!("clap rejected '{label}' invocation {args:?}: {e}"));
+            assert!(cli.dry_run, "expected --dry-run set for '{label}'");
+            assert!(
+                !dry_run_is_unsupported(&cli.command),
+                "'{label}' is listed as supported but dry_run_is_unsupported() returns true",
+            );
+        }
+    }
+
+    #[test]
+    fn dry_run_unsupported_for_known_mutator() {
+        // `floo init` does not implement --dry-run; the gate must catch it.
+        let cli = Cli::try_parse_from(["floo", "init", "x", "--dry-run"]).unwrap();
+        assert!(dry_run_is_unsupported(&cli.command));
     }
 }

--- a/src/commands/cron.rs
+++ b/src/commands/cron.rs
@@ -59,18 +59,24 @@ pub fn list(app_flag: Option<&str>) {
 }
 
 pub fn run(app_flag: Option<&str>, name: &str) {
-    super::require_auth();
-    let client = super::init_client(None);
-    let (app_id, _app_name) = super::resolve_app_from_config(&client, app_flag);
-
+    // Dry-run is a pure echo: every other --dry-run handler in the CLI
+    // (apps.rs, domains.rs, env.rs, rollbacks.rs, deploy.rs) checks
+    // is_dry_run_mode() BEFORE require_auth() / resolve_app_from_config(),
+    // so previewing a mutating command never requires a live API key or
+    // an existing app row. Keep that contract here so logged-out users
+    // and offline agents get a consistent preview shape across commands.
     if output::is_dry_run_mode() {
         output::dry_run_success(serde_json::json!({
             "action": "run_cron_job",
-            "app_id": app_id,
+            "app": app_flag,
             "name": name,
         }));
         return;
     }
+
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app_flag);
 
     let spinner = output::Spinner::new(&format!("Triggering cron job '{name}'..."));
     let result = match client.run_cron_job(&app_id, name) {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -38,6 +38,7 @@ never uploads code.
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services
   floo docs config     — config file formats with examples
+  floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
   floo docs deploy     — detailed deploy flow and runtime detection
   floo docs auth       — add user authentication to your app
   floo docs feedback   — report bugs, friction, or feature requests
@@ -393,6 +394,38 @@ Floo Config Files
 
   [environments.prod]
   access_mode = \"accounts\"
+
+## Cron Jobs ([cron.<name>])
+
+  Scheduled jobs are declared in floo.app.toml — never created by the CLI.
+  Each [cron.<name>] section becomes a managed cron job that's reconciled
+  on every deploy (added, updated, or removed to match config).
+
+  [cron.daily-report]
+  schedule = \"0 9 * * *\"                  # cron expression: 9am UTC daily
+  command  = \"python -m reports.daily\"    # executed inside the service container
+  service  = \"api\"                         # which service's image to run in
+  timeout  = 600                            # max seconds (default 300, optional)
+
+  [cron.cleanup]
+  schedule = \"*/5 * * * *\"                 # every 5 minutes
+  command  = \"node scripts/cleanup.js\"
+  service  = \"worker\"
+
+  Fields:
+
+  - schedule (required) — standard cron expression in UTC
+  - command  (required) — shell command run inside the target service's container
+  - service  (required) — name of a [services.<name>] entry; that image is reused
+  - timeout  (optional) — max execution seconds; default 300
+
+  CLI surface (read-only + manual trigger):
+
+    floo cron list --app my-app              # list jobs and last run status
+    floo cron run daily-report --app my-app  # trigger one off-schedule
+
+  Long-form guide: https://getfloo.com/docs/guides/cron-jobs
+  Full config schema: https://getfloo.com/docs/reference/config-spec
 
 ## Environment Variables in Multi-Service Apps
 
@@ -1434,6 +1467,77 @@ won't get set behind floo's edge.
 Full guide with complete JavaScript code: https://docs.getfloo.com/build/express
 ";
 
+const CRON: &str = "\
+Floo Cron Jobs
+
+Cron jobs are declared in floo.app.toml — never created by the CLI. Each
+[cron.<name>] section becomes a managed cron job, reconciled on every
+deploy (added, updated, or removed to match config).
+
+## Declare in floo.app.toml
+
+  [cron.daily-report]
+  schedule = \"0 9 * * *\"                  # 9am UTC daily
+  command  = \"python -m reports.daily\"
+  service  = \"api\"                         # which service's image to run in
+
+  [cron.cleanup]
+  schedule = \"*/5 * * * *\"                 # every 5 minutes
+  command  = \"node scripts/cleanup.js\"
+  service  = \"worker\"
+  timeout  = 600                            # max seconds (default 300, optional)
+
+## Fields
+
+  schedule  required  Standard cron expression in UTC.
+  command   required  Shell command executed inside the target service's container.
+  service   required  Name of a [services.<name>] entry; that image is reused.
+  timeout   optional  Max execution time in seconds. Default 300.
+
+## Common schedules
+
+  * * * * *     every minute
+  */5 * * * *   every 5 minutes
+  0 * * * *     every hour
+  0 9 * * *     daily at 9am UTC
+  0 9 * * 1-5   weekdays at 9am UTC
+  0 0 * * 0     weekly on Sunday at midnight UTC
+  0 0 1 * *     monthly on the 1st at midnight UTC
+
+## Deploy and verify
+
+  Push to GitHub or run `floo redeploy`. New jobs are created, changed jobs
+  updated, removed jobs deleted — all on the deploy itself.
+
+    git push origin main && floo deploys watch --app my-app
+    floo cron list --app my-app                # see jobs + last run status
+
+## Manually trigger a job (off-schedule)
+
+  Useful for testing or one-off catch-up runs:
+
+    floo cron run daily-report --app my-app
+    floo cron run daily-report --app my-app --dry-run   # preview, no API call
+
+## CLI surface
+
+  The `floo cron` CLI is read-only + manual trigger. Schedules and commands
+  are config-driven; the CLI never adds, removes, or edits them.
+
+    floo cron list --app <name>            list jobs and last run status
+    floo cron run <name> --app <app>       trigger a job off-schedule
+
+## Environment
+
+  Jobs run inside the specified service's container image with the same
+  env vars as the service — same DATABASE_URL, REDIS_URL, secrets, etc.
+
+## Long-form guide
+
+  https://getfloo.com/docs/guides/cron-jobs   — examples, agent workflow, troubleshooting
+  https://getfloo.com/docs/reference/config-spec   — full [cron.<name>] schema reference
+";
+
 const TOPICS: &[(&str, &str)] = &[
     ("quickstart", QUICKSTART),
     ("golden-path", HOWTO),
@@ -1446,6 +1550,7 @@ const TOPICS: &[(&str, &str)] = &[
     ("services", SERVICES),
     ("config", CONFIG),
     ("app-toml", CONFIG), // alias — agents can run `floo docs app-toml` after `floo init`
+    ("cron", CRON),
     ("deploy", DEPLOY),
     ("auth", AUTH),
     ("feedback", FEEDBACK),
@@ -1492,6 +1597,7 @@ mod tests {
         assert!(!QUICKSTART.is_empty());
         assert!(!SERVICES.is_empty());
         assert!(!CONFIG.is_empty());
+        assert!(!CRON.is_empty());
         assert!(!DEPLOY.is_empty());
         assert!(!AUTH.is_empty());
         assert!(!TEMPLATES.is_empty());
@@ -1501,6 +1607,41 @@ mod tests {
         assert!(!FASTAPI.is_empty());
         assert!(!DJANGO.is_empty());
         assert!(!EXPRESS.is_empty());
+    }
+
+    /// The 2026-04-30 cron-docs feedback: `floo docs app-toml` mentioned cron
+    /// as a feature but never showed the [cron.<name>] schema. CONFIG must
+    /// document the schema (fields + example) so agents can author cron jobs
+    /// without leaving the cheatsheet, and a dedicated `cron` topic gives the
+    /// short answer for `floo docs cron`.
+    #[test]
+    fn test_cron_schema_documented_in_config_and_cron_topics() {
+        for (label, content) in [("config/app-toml", CONFIG), ("cron", CRON)] {
+            assert!(
+                content.contains("[cron."),
+                "{label} must show the [cron.<name>] section header",
+            );
+            for field in ["schedule", "command", "service", "timeout"] {
+                assert!(
+                    content.contains(field),
+                    "{label} must document the '{field}' field",
+                );
+            }
+            assert!(
+                content.contains("floo cron list"),
+                "{label} must show the read-only CLI surface",
+            );
+        }
+        // The CONFIG cheatsheet must link to the long-form guide so agents
+        // can route to it from `floo docs app-toml`.
+        assert!(CONFIG.contains("getfloo.com/docs/guides/cron-jobs"));
+    }
+
+    #[test]
+    fn test_cron_topic_in_overview_listing() {
+        // The overview cheatsheet is the entry point; missing the cron topic
+        // here was part of the original discoverability gap.
+        assert!(OVERVIEW.contains("floo docs cron"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Closes the three layers of stale metadata around `floo cron` reported in customer feedback `23b7283c` (team@getfloo.com on floo-artifact, 2026-04-30):

1. **`--dry-run` rejection error lied.** The error suggestion listed `cron add` (which does not exist) and the unsupported matches list rejected `cron run` (which has a working dry-run handler in `commands/cron.rs` — that handler had become dead code). Two hand-maintained lists drifted; this PR replaces them with a pure predicate `dry_run_is_unsupported()` and a single source of truth `DRY_RUN_SUPPORTED_COMMANDS`. New test `dry_run_supported_names_are_real_subcommands` round-trips each listed name through clap and asserts each is parseable AND not in the unsupported set — would have caught the original `cron add` ghost on day one.

2. **`floo cron --help` had no hint that schedules are TOML-declared.** Added `long_about` + reinforced `after_help` to the Cron subcommand stating jobs are declared in `floo.app.toml` under `[cron.<name>]` and the CLI is read-only + manual trigger.

3. **`floo docs app-toml` mentioned cron as a feature but never showed the `[cron.<name>]` schema.** Added a full **Cron Jobs** section to the CONFIG cheatsheet (fields, example, CLI surface, links) and a dedicated `cron` topic so `floo docs cron` returns a focused cheatsheet covering schema + schedules + CLI + environment. Wired into the OVERVIEW listing.

4. **Reordered `commands/cron.rs::run`** so `is_dry_run_mode()` is checked before `require_auth()` + `resolve_app_from_config()`. Every other dry-run handler in the CLI (apps, domains, env, rollbacks, deploy) follows that convention so previewing a mutating command never requires a live API key or an existing app row. Without this reorder, removing `cron run` from the unsupported set would surface a different bug: `cron run X --dry-run` for logged-out users would error with "Not logged in." instead of printing the preview, while every other dry-run preview works offline. Preview now echoes the user-supplied `app` value to match the rest of the codebase.

## Why

Cron has the right design (declarative TOML + read/trigger CLI), but three layers of stale metadata around it produced a coherent-looking false signal: the error told users `cron add` exists, then `cron --help` confirmed it didn't, then the docs cheatsheet said cron was supported but never showed the schema. Each layer reinforced the next. The dry-run convention fix is the load-bearing piece that makes "remove cron run from the unsupported set" actually safe.

## Risk tier

`exempt` — pure CLI strings, in-binary docs, and a handler reorder that aligns with the rest of the codebase. No platform behavior, no schema, no auth, no migrations.

## Files reviewers should scrutinize

- `src/cli.rs` → `dry_run_is_unsupported`, `DRY_RUN_SUPPORTED_COMMANDS`, the new `dry_run_supported_names_are_real_subcommands` test, the new `Cron` `long_about`/`after_help`.
- `src/commands/cron.rs` → reordered `is_dry_run_mode()` check above auth/resolve, preview now echoes user-supplied `app_flag`.
- `src/commands/docs.rs` → new **Cron Jobs** section in `CONFIG`, new `CRON` topic, OVERVIEW listing entry, two new test assertions.

## Tests run

323/323 floo-local unit tests pass:

```
cargo test --bin floo-local --quiet
test result: ok. 323 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Verified live in the built binary:
- `floo cron --help` opens with the TOML-declared note.
- `floo init --dry-run` error lists `cron run` (real) instead of `cron add` (ghost).
- `floo cron run myjob --dry-run --json` echoes the preview with no auth + no network call.
- `floo docs cron` returns the new schema-first cheatsheet.

## Known non-goals

- Companion floo-docs PR (https://github.com/getfloo/floo-docs/pull/14) adds the missing `/cli/cron` reference page and redirects `/build/cron` → `/guides/cron-jobs` — both PRs together close the feedback.

## Replaces

- Closes #128 (which accidentally bundled unrelated managed-services WIP).