### PR TITLE
feat(cli): surface runtime_url in floo apps status

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -129,6 +129,10 @@ pub struct App {
     pub status: Option<String>,
     pub url: Option<String>,
     pub runtime: Option<String>,
+    /// Direct Cloud Run runtime URL of the primary user-facing service.
+    /// Debug-only — clients should hit `url` (the gateway URL).
+    #[serde(default)]
+    pub runtime_url: Option<String>,
     pub created_at: Option<String>,
     #[serde(default)]
     pub environments: Vec<EnvironmentSummary>,

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -113,6 +113,12 @@ pub fn status(app_name: &str) {
             ),
             None,
         );
+        if let Some(runtime_url) = app.runtime_url.as_deref() {
+            output::info(&format!("  Runtime URL:  {runtime_url}"), None);
+            output::dim_line(
+                "              \u{21b3} direct Cloud Run URL — debug only, not for clients",
+            );
+        }
         output::info(&format!("  Org:      {org_display}"), None);
         output::info(&format!("  ID:       {}", app.id), None);
         output::info(

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -220,6 +220,64 @@ fn test_apps_status_json() {
 }
 
 #[test]
+fn test_apps_status_json_surfaces_runtime_url() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let runtime_url = "https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app";
+
+    let _m = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"apps":[{{"id":"{TEST_APP_ID}","name":"{TEST_APP_NAME}","org_id":"{TEST_ORG_ID}","status":"live","url":"https://test.floo.app","runtime":"rails","runtime_url":"{runtime_url}","created_at":"2024-01-01T00:00:00Z"}}]}}"#
+        ))
+        .create();
+
+    floo()
+        .args(["--json", "apps", "status", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""runtime_url""#))
+        .stdout(predicate::str::contains(runtime_url));
+}
+
+#[test]
+fn test_apps_status_human_includes_runtime_url() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let runtime_url = "https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app";
+
+    let _m = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"apps":[{{"id":"{TEST_APP_ID}","name":"{TEST_APP_NAME}","org_id":"{TEST_ORG_ID}","status":"live","url":"https://test.floo.app","runtime":"rails","runtime_url":"{runtime_url}","created_at":"2024-01-01T00:00:00Z"}}]}}"#
+        ))
+        .create();
+    let _m_org = mock_org_me(&mut server);
+
+    floo()
+        .args(["apps", "status", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Runtime URL:"))
+        .stderr(predicate::str::contains(runtime_url))
+        .stderr(predicate::str::contains("debug only"));
+}
+
+#[test]
 fn test_apps_delete_requires_explicit_confirmation_in_json_mode() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed
- Add `runtime_url: Option<String>` field to the `App` API type so `floo apps status --json` includes the direct Cloud Run URL.
- Print the runtime URL alongside the gateway URL in the human-mode `floo apps status` output, with a clear "debug only — not for clients" annotation.
- Add integration tests covering both --json and human modes.

## Why
Customer feedback (ticket 5cc98dfc): agents debugging deploy issues had to scrape deploy build_logs to find the direct Cloud Run URL because `floo apps status --json` only exposed the gateway URL. The new field is debug-only — clients should still hit the gateway URL.

Pairs with the API addition in floo (the new `runtime_url` field on AppResponse).

## Risk tier
standard (CLI-only, parses one new optional field, additive output)

## Files reviewers should scrutinize
- `src/api_types.rs` — new optional field on `App`, opt-in via `#[serde(default)]` so old API responses still parse.
- `src/commands/apps.rs` — only fires the human-mode annotation when the field is present.

## Tests run
- `cargo test --bin floo --tests` (67 passed)
- New tests:
  - `test_apps_status_json_surfaces_runtime_url`
  - `test_apps_status_human_includes_runtime_url`

## Known non-goals
- Dashboard UI work (covered server-side; UI consumes `AppResponse.runtime_url` opportunistically).
- Surfacing per-service `cloud_run_url` in CLI output (already in `floo services info`).

Closes feedback ticket 5cc98dfc.