### PR TITLE
feat(cli): floo logs --requests --follow live tailing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -274,8 +274,8 @@ Examples:
         #[arg(long)]
         search: Option<String>,
 
-        /// Stream logs in real-time (poll every 2s).
-        #[arg(short = 'f', long, conflicts_with = "output")]
+        /// Stream logs in real-time (poll every 2s). Works with --requests too.
+        #[arg(short = 'f', long, alias = "follow", conflicts_with = "output")]
         live: bool,
 
         /// Write logs to a file (JSON or plain text based on --json flag).
@@ -1496,6 +1496,7 @@ pub fn run() {
                     app_flag: app,
                     tail,
                     since,
+                    live,
                 });
             } else {
                 let severity = if error {

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -517,6 +517,9 @@ pub struct RequestLogsArgs {
     pub app_flag: Option<String>,
     pub tail: u32,
     pub since: Option<String>,
+    /// Stream new requests as they arrive (poll every 2s). Mirrors `--live`
+    /// for app logs; `--follow` is accepted as an alias on the parent flag.
+    pub live: bool,
 }
 
 fn format_request_line(entry: &RequestLogEntry) -> String {
@@ -586,6 +589,17 @@ pub fn request_logs(args: RequestLogsArgs) {
         }
     };
 
+    if args.live {
+        live_request_logs(
+            &client,
+            &app_data.id,
+            &app_data.name,
+            args.tail,
+            args.since.as_deref(),
+        );
+        return;
+    }
+
     let result = match client.get_request_logs(&app_data.id, args.tail, args.since.as_deref()) {
         Ok(r) => r,
         Err(e) => {
@@ -612,6 +626,120 @@ pub fn request_logs(args: RequestLogsArgs) {
     // oldest-to-newest, like `tail -f`.
     for entry in result.requests.iter().rev() {
         output::dim_line(&format_request_line(entry));
+    }
+}
+
+fn live_request_logs(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    app_name: &str,
+    tail: u32,
+    initial_since: Option<&str>,
+) {
+    let is_json = output::is_json_mode();
+
+    let initial = match client.get_request_logs(app_id, tail, initial_since) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(
+                &format!("Failed to fetch request logs: {e}"),
+                &ErrorCode::from_api("REQUESTS_FETCH_FAILED"),
+                None,
+            );
+            process::exit(1);
+        }
+    };
+
+    let mut last_timestamp: Option<String> = None;
+    // The API returns newest-first; reverse so the console reads
+    // oldest-to-newest like `tail -f`.
+    for entry in initial.requests.iter().rev() {
+        emit_request_entry(entry, is_json);
+        update_last_request_timestamp(&mut last_timestamp, entry);
+    }
+
+    if !is_json && initial.requests.is_empty() {
+        output::dim_line(&format!("No requests yet for {app_name}. Waiting…"));
+    }
+
+    let mut consecutive_errors: u32 = 0;
+
+    loop {
+        thread::sleep(POLL_INTERVAL);
+
+        // Once we've seen any request, we anchor on its timestamp; before
+        // then, fall back to the user-provided --since window so the first
+        // few polls don't re-stream the entire backlog.
+        let since_filter = last_timestamp.as_deref().or(initial_since);
+
+        let poll_result = client.get_request_logs(app_id, tail, since_filter);
+        let new_logs = match poll_result {
+            Ok(r) => {
+                consecutive_errors = 0;
+                r.requests
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_TRANSIENT_RETRIES {
+                    output::error(
+                        &format!(
+                            "Live polling failed after {} consecutive errors: {}",
+                            MAX_TRANSIENT_RETRIES, e.message
+                        ),
+                        &ErrorCode::from_api(&e.code),
+                        Some("Check your network connection and try again."),
+                    );
+                    process::exit(1);
+                }
+                if !is_json {
+                    eprintln!(
+                        "  {} transient error (retry {}/{}): {}",
+                        "!".yellow().bold(),
+                        consecutive_errors,
+                        MAX_TRANSIENT_RETRIES,
+                        e.message
+                    );
+                }
+                continue;
+            }
+        };
+
+        // Strict-greater filter so a request that exactly matches the last
+        // anchor isn't re-emitted. The API's `since` is inclusive
+        // (>= since_dt) and timestamp resolution is microseconds, so without
+        // this filter every poll cycle could re-print the most recent line.
+        let new_entries: Vec<&RequestLogEntry> = match &last_timestamp {
+            None => new_logs.iter().rev().collect(),
+            Some(last_ts) => new_logs
+                .iter()
+                .rev()
+                .filter(|entry| entry.timestamp.as_str() > last_ts.as_str())
+                .collect(),
+        };
+
+        for entry in &new_entries {
+            emit_request_entry(entry, is_json);
+            update_last_request_timestamp(&mut last_timestamp, entry);
+        }
+    }
+}
+
+fn emit_request_entry(entry: &RequestLogEntry, is_json: bool) {
+    if is_json {
+        output::print_json(&output::to_value(entry));
+    } else {
+        output::dim_line(&format_request_line(entry));
+    }
+}
+
+fn update_last_request_timestamp(last: &mut Option<String>, entry: &RequestLogEntry) {
+    let ts = entry.timestamp.as_str();
+    let is_newer = match last.as_deref() {
+        Some(prev) => ts > prev,
+        None => true,
+    };
+    if is_newer {
+        *last = Some(ts.to_string());
     }
 }
 
@@ -660,5 +788,38 @@ mod tests {
         let line = format_log_line(&entry, true);
         assert!(line.contains("[unknown]"));
         assert!(line.contains("something broke"));
+    }
+
+    fn make_request_entry(ts: &str) -> RequestLogEntry {
+        RequestLogEntry {
+            timestamp: ts.to_string(),
+            method: "GET".to_string(),
+            path: Some("/".to_string()),
+            host: Some("my-app.on.getfloo.com".to_string()),
+            status_code: 200,
+            latency_ms: 12,
+            access_mode: "public".to_string(),
+            user_identity: None,
+        }
+    }
+
+    #[test]
+    fn test_update_last_request_timestamp_advances_on_newer_entry() {
+        let mut last: Option<String> = None;
+        update_last_request_timestamp(&mut last, &make_request_entry("2026-04-30T15:42:21Z"));
+        assert_eq!(last.as_deref(), Some("2026-04-30T15:42:21Z"));
+
+        update_last_request_timestamp(&mut last, &make_request_entry("2026-04-30T15:42:22Z"));
+        assert_eq!(last.as_deref(), Some("2026-04-30T15:42:22Z"));
+    }
+
+    #[test]
+    fn test_update_last_request_timestamp_keeps_newer_when_older_arrives() {
+        // Live polling rides on the API's timestamp >= since semantics, so
+        // an older row can show up alongside the new ones; the anchor must
+        // not move backwards or we'd re-emit the same line forever.
+        let mut last: Option<String> = Some("2026-04-30T15:42:22Z".to_string());
+        update_last_request_timestamp(&mut last, &make_request_entry("2026-04-30T15:42:21Z"));
+        assert_eq!(last.as_deref(), Some("2026-04-30T15:42:22Z"));
     }
 }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1232,6 +1232,71 @@ fn test_logs_single_service_no_prefix() {
         .stderr(predicate::str::contains("[api]").not());
 }
 
+// ───────────────────────── Request logs ─────────────────────────
+
+#[test]
+fn test_logs_requests_json_default_tail() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_req = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/requests").as_str(),
+        )
+        .match_query(Matcher::UrlEncoded("limit".into(), "100".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"requests":[{"timestamp":"2026-04-30T15:42:21Z","method":"GET","path":"/","host":"my-app.on.getfloo.com","status_code":401,"latency_ms":12,"access_mode":"public","user_identity":null}],"total":1,"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "logs", "--requests", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("requests"))
+        .stdout(predicate::str::contains("/"))
+        .stdout(predicate::str::contains("401"));
+}
+
+#[test]
+fn test_logs_requests_passes_since_to_api() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    // The API mock only matches when the `since` query param is forwarded;
+    // forgetting to thread it would 501 against this mock.
+    let _m_req = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/requests").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("since".into(), "5m".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"requests":[],"total":0,"app_name":"my-app"}"#)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "logs",
+            "--requests",
+            "--app",
+            TEST_APP_NAME,
+            "--since",
+            "5m",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+}
+
 // ───────────────────────── Services ─────────────────────────
 
 #[test]


### PR DESCRIPTION
## What changed
- Wire the existing `--live` flag (with new `--follow` alias) through to `floo logs --requests` so request logs can be tailed live, polling every 2s.
- Anchor on the last seen request timestamp so reconnects don't replay the entire backlog.
- The existing `--since <duration>` already routed through to `--requests`; help text now mentions both flags work together.
- Unit tests for the timestamp-tracking helper (covers the case where an older row arrives alongside newer ones — the anchor must not move backwards).
- Integration tests covering --json default output and --since param threading.

## Why
Customer feedback (ticket ad3bfcf2): `floo logs --requests --tail N` is one-shot, useful for forensics but painful for live debugging. While iterating on a misbehaving deploy, the user re-ran `--tail` every few seconds. Mirroring the existing `--live` flow for app logs eliminates that loop.

## Risk tier
standard (CLI-only)

## Files reviewers should scrutinize
- `src/commands/logs.rs` — new `live_request_logs` polling loop. Same shape as the existing `live_logs` for app logs (anchor on last_timestamp, transient-error budget, strict-greater filter to avoid re-emitting the boundary line).
- `src/cli.rs` — `--follow` added as alias on `--live`, threaded into `RequestLogsArgs`.

## Tests run
- `cargo test --bin floo --tests` (67 passed)
- New tests:
  - `test_logs_requests_json_default_tail`
  - `test_logs_requests_passes_since_to_api`
  - Unit tests for `update_last_request_timestamp` covering forward + backward arrival ordering

## Known non-goals
- Backend changes (the `since` query param already works on the existing `/v1/apps/{id}/requests` endpoint).
- A new top-level subcommand (the `--requests` modifier is preserved for parity with how the user already invokes the command).

Closes feedback ticket ad3bfcf2.