### PR TITLE
feat(cli): track-2 — releases rollback alias + redeploy --skip-migrations

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -334,10 +334,14 @@ impl FlooClient {
         reparo_config: Option<&crate::project_config::ReparoConfig>,
         cron_jobs: Option<&[crate::project_config::CronJobEntry]>,
         github_config: Option<&crate::project_config::GitHubConfig>,
+        skip_migrations: bool,
     ) -> Result<Deploy, FlooApiError> {
         let mut body = serde_json::json!({
             "runtime": runtime,
         });
+        if skip_migrations {
+            body["skip_migrations"] = Value::Bool(true);
+        }
         if let Some(fw) = framework {
             body["framework"] = Value::String(fw.to_string());
         }
@@ -865,12 +869,19 @@ impl FlooClient {
         app_id: &str,
         runtime: &str,
         services: Option<&[String]>,
+        skip_migrations: bool,
     ) -> Result<Deploy, FlooApiError> {
         let mut body = serde_json::json!({
             "runtime": runtime,
         });
         if let Some(svcs) = services {
             body["services_filter"] = serde_json::to_value(svcs).unwrap_or_default();
+        }
+        // The platform defaults skip_migrations=false on the deploy row;
+        // only send the field when the caller opted in so the wire stays
+        // tight on the common path.
+        if skip_migrations {
+            body["skip_migrations"] = Value::Bool(true);
         }
         let resp = self.post_json(&format!("/v1/apps/{app_id}/deploys"), &body)?;
         self.handle_response(resp)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,6 +171,17 @@ need to apply env var changes or force a rebuild without a code change.")]
         /// Re-sync env vars from configured env_file before deploying.
         #[arg(long)]
         sync_env: bool,
+
+        /// Hotfix: declare no migrations are pending and skip the MIGRATE step.
+        ///
+        /// The platform takes you at your word — if you're wrong, the new
+        /// image boots against an unmigrated schema. The deploy records
+        /// MIGRATE as SKIPPED (not SUCCESS) so the audit trail is
+        /// unambiguous about whether migrations ran. Meaningful only on
+        /// rebuild deploys; rollback and restart already skip MIGRATE
+        /// because the image was previously migrated.
+        #[arg(long)]
+        skip_migrations: bool,
     },
 
     /// View and manage deploy history.
@@ -874,6 +885,26 @@ pub enum ReleasesCommands {
         #[arg(short, long)]
         tag: Option<String>,
     },
+
+    /// Roll back to a previous live deploy by re-pointing gateway routes
+    /// at its image (no rebuild).
+    ///
+    /// Tier-2 destructive: interactive prompts `y/N`; non-interactive
+    /// requires `--yes` to confirm. Equivalent to
+    /// `floo deploys rollback <app> <id>`.
+    Rollback {
+        /// App name or ID.
+        #[arg(short, long)]
+        app: String,
+
+        /// Deploy ID to roll back to (the previous live deploy).
+        #[arg(long)]
+        to: String,
+
+        /// Skip the y/N prompt. Required in non-interactive contexts.
+        #[arg(long, alias = "force")]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1260,7 +1291,8 @@ pub fn run() {
             services,
             rebuild,
             sync_env,
-        } => commands::deploy::deploy(path, app, services, rebuild, sync_env),
+            skip_migrations,
+        } => commands::deploy::deploy(path, app, services, rebuild, sync_env, skip_migrations),
 
         Commands::Deploys(sub) => match sub {
             DeploysSubcommands::List { app } => commands::deploys::list(app.as_deref()),
@@ -1437,6 +1469,14 @@ pub fn run() {
             }
             ReleasesCommands::Promote { app, tag } => {
                 commands::releases::promote(app.as_deref(), tag.as_deref())
+            }
+            // `floo releases rollback --app X --to <id>` is the discoverable
+            // alias for `floo deploys rollback <app> <id>`. Routes to the
+            // same backend (`POST /v1/apps/{id}/rollback`) which re-points
+            // gateway routes at the previous deploy's image without
+            // rebuilding source.
+            ReleasesCommands::Rollback { app, to, yes } => {
+                commands::rollbacks::rollback(&app, &to, yes)
             }
         },
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -235,7 +235,23 @@ pub fn deploy(
     services_filter: Vec<String>,
     rebuild: bool,
     sync_env: bool,
+    skip_migrations: bool,
 ) {
+    // Restart path reuses the existing image and never runs migrations,
+    // so `--skip-migrations` only makes sense on a rebuild path. Reject
+    // the combination loudly rather than silently dropping the flag.
+    if skip_migrations && app.is_some() && !rebuild {
+        output::error(
+            "--skip-migrations requires --rebuild.",
+            &ErrorCode::ConfigInvalid,
+            Some(
+                "Restart paths reuse the existing image and don't run migrations,\
+                 so --skip-migrations has no effect there. Add --rebuild or drop the flag.",
+            ),
+        );
+        process::exit(1);
+    }
+
     // --- Path 1 & 2: --app flag provided — no local directory needed ---
     if let Some(ref app_name) = app {
         // Dry-run exits early — no auth or API calls needed
@@ -246,6 +262,7 @@ pub fn deploy(
                 "action": action,
                 "app": app_name,
                 "services": service_names,
+                "skip_migrations": skip_migrations,
             }));
             return;
         }
@@ -278,7 +295,7 @@ pub fn deploy(
         };
 
         if rebuild {
-            deploy_rebuild(&client, &app_data, &services_filter);
+            deploy_rebuild(&client, &app_data, &services_filter, skip_migrations);
         } else {
             deploy_restart(&client, &app_data, &services_filter);
         }
@@ -592,6 +609,7 @@ pub fn deploy(
         reparo_config,
         cron_jobs_arg,
         github_config,
+        skip_migrations,
     ) {
         Ok(d) => {
             spinner.finish();
@@ -835,6 +853,7 @@ fn deploy_rebuild(
     client: &FlooClient,
     app_data: &crate::api_types::App,
     services_filter: &[String],
+    skip_migrations: bool,
 ) {
     let app_id = &app_data.id;
     let runtime = app_data.runtime.as_deref().unwrap_or("unknown");
@@ -846,6 +865,7 @@ fn deploy_rebuild(
             "app": app_data.name,
             "runtime": runtime,
             "services": service_names,
+            "skip_migrations": skip_migrations,
         }));
         return;
     }
@@ -857,7 +877,7 @@ fn deploy_rebuild(
     };
 
     let spinner = output::Spinner::new("Rebuilding...");
-    let mut deploy_data = match client.rebuild_app(app_id, runtime, svcs) {
+    let mut deploy_data = match client.rebuild_app(app_id, runtime, svcs, skip_migrations) {
         Ok(d) => {
             spinner.finish();
             d

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -565,6 +565,7 @@ Floo Deploy Flow
   floo redeploy [path]             — full redeploy from local project directory
   floo redeploy --services <name>  — redeploy specific services only
   floo redeploy --sync-env         — re-sync env vars from env_file before redeploying
+  floo redeploy --rebuild --skip-migrations  — hotfix path: bypass MIGRATE step
 
 ## Deploy History
 
@@ -572,6 +573,7 @@ Floo Deploy Flow
   floo deploys logs <id> --app <n>  — build logs for a specific deploy
   floo deploys watch --app <name>   — stream deploy progress in real-time
   floo deploys rollback <app> <id>  — rollback to a previous deploy
+  floo releases rollback --app <name> --to <id>  — same, alias under releases
 ";
 
 const AUTH: &str = "\

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -689,13 +689,14 @@ fn run_initial_deploy(
         app_id,
         &detection.runtime,
         detection.framework.as_deref(),
-        None, // API discovers services from GitHub tarball
-        None, // access_mode
-        None, // agent_mode
-        None, // auth_redirect_uris
-        None, // reparo_config
-        None, // cron_jobs
-        None, // github_config
+        None,  // API discovers services from GitHub tarball
+        None,  // access_mode
+        None,  // agent_mode
+        None,  // auth_redirect_uris
+        None,  // reparo_config
+        None,  // cron_jobs
+        None,  // github_config
+        false, // skip_migrations — initial deploy from `floo apps github connect` always runs migrations
     ) {
         Ok(d) => {
             spinner.finish();


### PR DESCRIPTION
## What changed

Closes feedback ids \`532131b0\` (T6) and \`0cb96d9a\` (T7) from the floo Track 2 deploy-lifecycle bundle. Backend support for \`--skip-migrations\` shipped in [getfloo/floo#755](https://github.com/getfloo/floo/pull/755). T1 (preflight \`managed_services=[]\`) was already closed in #125.

### T6 — \`floo releases rollback --app X --to <id>\`

New subcommand under \`releases\` that's a thin alias for the existing \`floo deploys rollback <app> <id>\`. Same backend (\`POST /v1/apps/{id}/rollback\` → re-points gateway routes at the previous deploy's image without rebuild), different surface for discoverability. The user feedback was specifically that they expected the rollback command under \`releases\`, not \`deploys\`.

### T7 — \`floo redeploy --rebuild --skip-migrations\`

New flag on \`Redeploy\` plumbed through to \`rebuild_app\` and \`create_deploy\` API client methods. The platform records MIGRATE as SKIPPED (not SUCCESS) with a reason in the step logs.

The combination \`--skip-migrations\` without \`--rebuild\` is rejected loudly: restart paths reuse the existing image and never run migrations, so the flag would silently no-op there.

\`floo apps github connect\`'s initial deploy hardcodes \`skip_migrations=false\` — first deploys always run migrations.

## Why

Customer asked in feedback id \`0cb96d9a\` for a hotfix path that bypasses migrations on a redeploy when they know none are pending. The CLI surface lands here against the wire-compatible backend in floo#755.

## Risk tier

Standard. Touches CLI dispatch + API client wire shape. No platform/auth surface.

## Files reviewers should scrutinize

- \`src/cli.rs\` — new \`ReleasesCommands::Rollback\` variant and \`Redeploy.skip_migrations\` field.
- \`src/commands/deploy.rs\` — \`--skip-migrations\` requires \`--rebuild\` validation and the rebuild_app threading.
- \`src/api_client.rs\` — \`rebuild_app\` and \`create_deploy\` now accept \`skip_migrations: bool\` and only set the field on the wire when true (keeps the common path tight).
- \`src/commands/docs.rs\` — cheatsheet entries for both new surfaces.

## Tests run

\`cargo test\` — 65 passed (full suite). \`cargo check\` — clean. Pre-existing clippy warning in \`src/commands/db.rs:315\` (\`f32::PI\` near-PI literal in a test fixture) is on \`main\` too, not in this diff.

## Known non-goals

- \`floo db migrate --dry-run\` — deferred. Truly framework-aware preview (\`bin/rails db:migrate:status\`, \`alembic current\`, etc.) is its own design surface; needs backend endpoint + framework-detection logic.
- New tests for the additive boolean plumbing — the API round-trip is pinned by floo#755's integration test.

## Test plan

- [ ] \`floo releases rollback --app <name> --to <deploy-id>\` interactively prompts y/N then rolls back.
- [ ] \`floo releases rollback --app <name> --to <deploy-id> --yes\` rolls back without prompt.
- [ ] \`floo redeploy --app <name> --rebuild --skip-migrations --json\` returns a deploy with \`skip_migrations: true\`.
- [ ] \`floo redeploy --app <name> --skip-migrations\` (no \`--rebuild\`) errors with the new validation message.
- [ ] \`floo redeploy --app <name> --rebuild\` (without \`--skip-migrations\`) still runs migrations as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)