### PR TITLE
feat(doctor): floo doctor accounts CLI command

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -409,6 +409,16 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    // --- Doctor ---
+
+    pub fn diagnose_accounts(
+        &self,
+        app_id: &str,
+    ) -> Result<crate::api_types::AccountsDoctorResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/doctor/accounts"))?;
+        self.handle_response(resp)
+    }
+
     // --- Cron Jobs ---
 
     pub fn list_cron_jobs(&self, app_id: &str) -> Result<CronJobListResponse, FlooApiError> {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -496,6 +496,55 @@ pub struct CronJobRunResponse {
     pub message: Option<String>,
 }
 
+// --- Doctor (`floo doctor accounts`) ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountsDoctorRoute {
+    pub host: String,
+    pub path_prefix: String,
+    pub backend_url: String,
+    pub serving_access_mode: String,
+    pub expected_access_mode: String,
+    pub floo_endpoints_wired: bool,
+    pub identity_headers_injected: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountsDoctorRequested {
+    pub access_mode: String,
+    pub access_policy: String,
+    pub allowed_domains: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountsDoctorLatestDeploy {
+    pub id: String,
+    pub status: String,
+    pub requested_app_access_mode: Option<String>,
+    pub propagated: bool,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountsDoctorDrift {
+    /// Drift kind from the API. `String` (not enum) so a CLI built against
+    /// an older schema doesn't refuse to render new drift kinds — the API
+    /// owns the closed set; the CLI tolerates additions.
+    pub kind: String,
+    pub summary: String,
+    pub likely_fix: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountsDoctorResponse {
+    pub app_id: String,
+    pub app_name: String,
+    pub requested: AccountsDoctorRequested,
+    pub serving: Vec<AccountsDoctorRoute>,
+    pub latest_deploy: Option<AccountsDoctorLatestDeploy>,
+    pub drift: Vec<AccountsDoctorDrift>,
+}
+
 // --- Analytics ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -376,6 +376,21 @@ read-only + manual trigger; new jobs are added by editing config and deploying."
     #[command(subcommand)]
     Reparo(ReparoCommands),
 
+    /// Diagnose an app's posture in one round trip.
+    #[command(
+        subcommand,
+        long_about = "\
+Diagnose an app's posture in one round trip.
+
+Read-only diagnostic surface — answers questions like 'why isn't accounts
+mode active?' without requiring agents to curl the gateway, parse request
+logs, and join four database tables by hand.
+
+The endpoint is intentionally narrow: no env-var values, no secret
+material, no Cloud Run audit payloads. Those live on dedicated surfaces."
+    )]
+    Doctor(DoctorCommands),
+
     /// List all commands (structured for agents in --json mode).
     #[command(name = "commands")]
     Discover,
@@ -1074,6 +1089,24 @@ pub enum ReparoCommands {
 }
 
 #[derive(Subcommand)]
+pub enum DoctorCommands {
+    /// Diagnose an app's accounts-mode posture (feedback 64268e05).
+    #[command(after_help = "\
+Examples:
+  floo doctor accounts                Use the app from floo.app.toml
+  floo doctor accounts --app foo      Diagnose a specific app
+  floo doctor accounts --json         Machine-readable output for agents
+
+Exit code is non-zero when drift is detected, so scripts can branch on
+`floo doctor accounts --json && deploy_things` without parsing the body.")]
+    Accounts {
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum CronCommands {
     /// List all cron jobs for an app and their last run status.
     List {
@@ -1507,6 +1540,10 @@ pub fn run() {
             }
         },
 
+        Commands::Doctor(sub) => match sub {
+            DoctorCommands::Accounts { app } => commands::doctor::accounts(app.as_deref()),
+        },
+
         Commands::Feedback {
             message,
             category,
@@ -1646,12 +1683,27 @@ mod tests {
             ("update", &["floo", "update", "--dry-run"]),
             ("env set", &["floo", "env", "set", "K=V", "--dry-run"]),
             ("env remove", &["floo", "env", "remove", "K", "--dry-run"]),
-            ("env import", &["floo", "env", "import", ".env", "--dry-run"]),
-            ("apps delete", &["floo", "apps", "delete", "myapp", "--dry-run"]),
-            ("domains add", &["floo", "domains", "add", "x.com", "--dry-run"]),
-            ("domains remove", &["floo", "domains", "remove", "x.com", "--dry-run"]),
+            (
+                "env import",
+                &["floo", "env", "import", ".env", "--dry-run"],
+            ),
+            (
+                "apps delete",
+                &["floo", "apps", "delete", "myapp", "--dry-run"],
+            ),
+            (
+                "domains add",
+                &["floo", "domains", "add", "x.com", "--dry-run"],
+            ),
+            (
+                "domains remove",
+                &["floo", "domains", "remove", "x.com", "--dry-run"],
+            ),
             ("cron run", &["floo", "cron", "run", "myjob", "--dry-run"]),
-            ("deploys rollback", &["floo", "deploys", "rollback", "myapp", "abc", "--dry-run"]),
+            (
+                "deploys rollback",
+                &["floo", "deploys", "rollback", "myapp", "abc", "--dry-run"],
+            ),
         ];
 
         let listed: std::collections::HashSet<&str> =

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1991,9 +1991,9 @@ fn collect_declared_managed_services(
 
     if let Ok(lock) = crate::services_lock::read(project_root) {
         for entry in lock.managed_services {
-            let already_present = declared.iter().any(|d| {
-                d.service_type == entry.service_type && d.name == entry.name
-            });
+            let already_present = declared
+                .iter()
+                .any(|d| d.service_type == entry.service_type && d.name == entry.name);
             if !already_present {
                 declared.push(DeclaredManagedService {
                     service_type: entry.service_type,

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,155 @@
+//! `floo doctor accounts` — accounts-mode introspection (feedback 64268e05).
+//!
+//! Thin wrapper over `GET /v1/apps/{app_id}/doctor/accounts`. The endpoint
+//! does the joining and drift computation; the CLI's job is rendering and
+//! exit-code semantics so an agent can act on the response without parsing
+//! prose.
+
+use std::process;
+
+use crate::api_types::{AccountsDoctorDrift, AccountsDoctorResponse};
+use crate::errors::ErrorCode;
+use crate::output;
+
+pub fn accounts(app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app_flag);
+
+    let result = match client.diagnose_accounts(&app_id) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        // Agents read the structured response directly; rendering decisions
+        // live on the human path only.
+        output::success(
+            "Accounts doctor diagnosis.",
+            Some(output::to_value(&result)),
+        );
+        // Exit non-zero when drift was found so scripted agents can branch
+        // on `floo doctor accounts --json` exit code without parsing the
+        // body. Same convention as `preflight` and `db migrate --dry-run`.
+        if !result.drift.is_empty() {
+            process::exit(1);
+        }
+        return;
+    }
+
+    render_human(&result);
+
+    if !result.drift.is_empty() {
+        process::exit(1);
+    }
+}
+
+fn render_human(result: &AccountsDoctorResponse) {
+    output::info(
+        &format!("App: {} ({})", result.app_name, result.app_id),
+        None,
+    );
+    eprintln!();
+
+    output::info("Requested config:", None);
+    eprintln!("  access_mode:    {}", result.requested.access_mode);
+    eprintln!("  access_policy:  {}", result.requested.access_policy);
+    eprintln!(
+        "  allowed_domains: {}",
+        if result.requested.allowed_domains.is_empty() {
+            "(none)".to_string()
+        } else {
+            result.requested.allowed_domains.join(", ")
+        }
+    );
+    eprintln!();
+
+    output::info(
+        &format!("Gateway routes ({} total):", result.serving.len()),
+        None,
+    );
+    if result.serving.is_empty() {
+        eprintln!("  (none — no live deploy has bound a host yet)");
+    } else {
+        let rows: Vec<Vec<String>> = result
+            .serving
+            .iter()
+            .map(|r| {
+                let mode_cell = if r.serving_access_mode == r.expected_access_mode {
+                    r.serving_access_mode.clone()
+                } else {
+                    format!(
+                        "{} (expected {})",
+                        r.serving_access_mode, r.expected_access_mode
+                    )
+                };
+                vec![
+                    format!("{}{}", r.host, r.path_prefix),
+                    mode_cell,
+                    bool_yn(r.floo_endpoints_wired),
+                    bool_yn(r.identity_headers_injected),
+                ]
+            })
+            .collect();
+        output::table(
+            &["Route", "Mode", "/__floo wired", "Identity headers"],
+            &rows,
+            None,
+        );
+    }
+    eprintln!();
+
+    if let Some(deploy) = &result.latest_deploy {
+        output::info("Latest deploy:", None);
+        eprintln!("  id:                          {}", deploy.id);
+        eprintln!("  status:                      {}", deploy.status);
+        eprintln!(
+            "  requested_app_access_mode:   {}",
+            deploy
+                .requested_app_access_mode
+                .as_deref()
+                .unwrap_or("(none)")
+        );
+        eprintln!(
+            "  propagated:                  {}",
+            bool_yn(deploy.propagated)
+        );
+        eprintln!("  created_at:                  {}", deploy.created_at);
+        eprintln!();
+    }
+
+    if result.drift.is_empty() {
+        output::info("No drift detected.", None);
+    } else {
+        output::info(
+            &format!(
+                "Drift detected ({} item{}):",
+                result.drift.len(),
+                if result.drift.len() == 1 { "" } else { "s" }
+            ),
+            None,
+        );
+        for d in &result.drift {
+            render_drift(d);
+        }
+    }
+}
+
+fn render_drift(d: &AccountsDoctorDrift) {
+    eprintln!();
+    eprintln!("  • [{}] {}", d.kind, d.summary);
+    if let Some(fix) = &d.likely_fix {
+        eprintln!("    Suggested fix: {fix}");
+    }
+}
+
+fn bool_yn(b: bool) -> String {
+    if b {
+        "yes".to_string()
+    } else {
+        "no".to_string()
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod deploy;
 pub mod deploys;
 pub mod dev;
 pub mod docs;
+pub mod doctor;
 pub mod domains;
 pub mod env;
 pub mod feedback;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -156,6 +156,7 @@ mod tests {
             status: None,
             url: None,
             runtime: None,
+            runtime_url: None,
             created_at: None,
             environments: vec![],
         }


### PR DESCRIPTION
## Summary

Closes feedback `64268e05` (team@getfloo.com on floo-artifact, 2026-04-30) — CLI consumer for the doctor endpoint shipped in **getfloo/floo#756**.

> _"`floo doctor accounts --app X` that prints (a) what config requests, (b) what the gateway is actually serving, (c) which /__floo/* endpoints are wired, (d) what allowed_domains apply, (e) whether identity headers will reach the app, (f) latest deploy's requested_app_access_mode and whether it propagated. This single command would have caught every accounts bug filed this session in under 10 seconds."_

## What changed

New `floo doctor accounts` subcommand under a new `doctor` namespace (room for `floo doctor <other>` later — deploy doctor, network doctor, etc.).

- **Default output**: human-readable. Surfaces requested-vs-expected per route, latest deploy state, and a drift list with per-kind suggested fixes. Diffs between `serving_access_mode` and `expected_access_mode` are visually obvious.
- **`--json`**: structured response straight from the API. Agents read it directly.
- **Exit code**: non-zero when drift is detected, so `floo doctor accounts --json && deploy_things` works without parsing the body. Same convention as `preflight` and `db migrate --dry-run`.

`AccountsDoctorDrift.kind` is `String` (not enum) — a CLI built against an older schema won't refuse to render new drift kinds the API adds. The API owns the closed set; the CLI tolerates additions.

## Files touched

- `src/commands/doctor.rs` (new, 155 lines) — the command + rendering.
- `src/api_types.rs` (+49) — Pydantic-mirroring response types.
- `src/api_client.rs` (+10) — `diagnose_accounts(app_id)` method.
- `src/cli.rs` (+62) — `Doctor(DoctorCommands)` subcommand group, `Accounts { app }` variant, dispatch.
- `src/commands/mod.rs` (+1) — module registration.
- `src/resolve.rs` (+1) — fix pre-existing test fixture missing `runtime_url` field. This was blocking the unit-test build before my changes; fixing it inline rather than landing a separate trivial commit.
- `src/commands/deploy.rs` (+3 -3) — pre-existing rustfmt drift on main that `cargo fmt` cleaned. Not from this change.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --bin floo` — 329 passing (up from 327; 16 docs tests + the rest of the unit suite)
- [x] `cargo clippy --bin floo -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: `./target/debug/floo doctor accounts --help` renders with examples + exit-code note
- [x] Manual: `./target/debug/floo doctor --help` lists `accounts` subcommand

## Pairs with

- getfloo/floo#756 — backend endpoint `GET /v1/apps/{app_id}/doctor/accounts`. Already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)