### PR TITLE
fix(cli): --dry-run consistency — human preview parity + db migrate

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1212,7 +1212,6 @@ fn dry_run_is_unsupported(command: &Commands) -> bool {
             | Commands::Apps(AppsCommands::Invite { .. })
             | Commands::Billing(BillingCommands::SpendCap(SpendCapCommands::Set { .. }))
             | Commands::Run { .. }
-            | Commands::Db(DbCommands::Migrate { .. })
             | Commands::Feedback { .. }
             | Commands::Skills(SkillsCommands::Install { .. })
             | Commands::Auth(
@@ -1247,6 +1246,7 @@ const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
     "domains remove",
     "cron run",
     "deploys rollback",
+    "db migrate",
 ];
 
 fn reject_unsupported_dry_run(command: &Commands) {
@@ -1703,6 +1703,10 @@ mod tests {
             (
                 "deploys rollback",
                 &["floo", "deploys", "rollback", "myapp", "abc", "--dry-run"],
+            ),
+            (
+                "db migrate",
+                &["floo", "db", "migrate", "--app", "myapp", "--dry-run"],
             ),
         ];
 

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -160,14 +160,20 @@ pub fn delete(app_name: &str, destroy_data_flag: bool) {
 
     if output::is_dry_run_mode() {
         let risk: RiskMetadata = Tier::Three.into();
-        output::dry_run_success(serde_json::json!({
-            "action": "delete",
-            "app": app_name,
-            "warning": "This cannot be undone",
-            "destructive": risk.destructive,
-            "data_loss": risk.data_loss,
-            "tier": risk.tier,
-        }));
+        let preview = format!(
+            "Would permanently delete app '{app_name}' (services, env vars, managed services, domains, deploy history). This cannot be undone."
+        );
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "delete",
+                "app": app_name,
+                "warning": "This cannot be undone",
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+            }),
+        );
         return;
     }
 

--- a/src/commands/cron.rs
+++ b/src/commands/cron.rs
@@ -66,11 +66,16 @@ pub fn run(app_flag: Option<&str>, name: &str) {
     // an existing app row. Keep that contract here so logged-out users
     // and offline agents get a consistent preview shape across commands.
     if output::is_dry_run_mode() {
-        output::dry_run_success(serde_json::json!({
-            "action": "run_cron_job",
-            "app": app_flag,
-            "name": name,
-        }));
+        let target = app_flag.unwrap_or("(reads from config)");
+        let preview = format!("Would trigger cron job '{name}' on {target}.");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "run_cron_job",
+                "app": app_flag,
+                "name": name,
+            }),
+        );
         return;
     }
 

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -140,6 +140,26 @@ pub fn schema(app_flag: Option<&str>) {
 }
 
 pub fn migrate(app_flag: Option<&str>, env: &str) {
+    // Dry-run is a pure echo, like cron.rs:run — runs before require_auth()
+    // and resolve_app_from_config() so logged-out users and offline agents
+    // can preview the action without an API call. The preview reports the
+    // app + environment the migration would target; previewing the actual
+    // pending-migration set would require a server-side endpoint we don't
+    // yet expose.
+    if output::is_dry_run_mode() {
+        let target = app_flag.unwrap_or("(reads from config)");
+        let preview = format!("Would run pending migrations on '{target}' (env: {env}).");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "db_migrate",
+                "app": app_flag,
+                "env": env,
+            }),
+        );
+        return;
+    }
+
     super::require_auth();
     let client = super::init_client(None);
     let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -258,12 +258,26 @@ pub fn deploy(
         if output::is_dry_run_mode() {
             let action = if rebuild { "rebuild" } else { "restart" };
             let service_names: Vec<&str> = services_filter.iter().map(|s| s.as_str()).collect();
-            output::dry_run_success(serde_json::json!({
-                "action": action,
-                "app": app_name,
-                "services": service_names,
-                "skip_migrations": skip_migrations,
-            }));
+            let svc_clause = if service_names.is_empty() {
+                String::new()
+            } else {
+                format!(" (services: {})", service_names.join(", "))
+            };
+            let mig_clause = if skip_migrations {
+                " (skip migrations)"
+            } else {
+                ""
+            };
+            let preview = format!("Would {action} app '{app_name}'{svc_clause}{mig_clause}.");
+            output::dry_run_preview(
+                &preview,
+                serde_json::json!({
+                    "action": action,
+                    "app": app_name,
+                    "services": service_names,
+                    "skip_migrations": skip_migrations,
+                }),
+            );
             return;
         }
 
@@ -434,15 +448,30 @@ pub fn deploy(
             })
             .collect();
 
-        output::dry_run_success(serde_json::json!({
-            "action": "deploy",
-            "app": app_name,
-            "services": svc_json,
-            "managed_services": managed_json,
-            "env_injection_plan": env_injection_plan,
-            "warnings": warning_strings,
-            "valid": preflight_errors.is_empty(),
-        }));
+        // Preflight already printed the human-friendly service table via
+        // display_preflight_human() above (gated on !is_json_mode). Keep the
+        // preview line tight so we don't duplicate it.
+        let svc_count = services.len();
+        let preview = format!(
+            "Would deploy app '{app_name}' with {svc_count} service(s){}.",
+            if preflight_errors.is_empty() {
+                ""
+            } else {
+                "; preflight errors must be fixed first"
+            }
+        );
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "deploy",
+                "app": app_name,
+                "services": svc_json,
+                "managed_services": managed_json,
+                "env_injection_plan": env_injection_plan,
+                "warnings": warning_strings,
+                "valid": preflight_errors.is_empty(),
+            }),
+        );
         return;
     }
 
@@ -733,11 +762,20 @@ fn deploy_restart(
 
     if output::is_dry_run_mode() {
         let service_names: Vec<&str> = services_filter.iter().map(|s| s.as_str()).collect();
-        output::dry_run_success(serde_json::json!({
-            "action": "restart",
-            "app": app_data.name,
-            "services": service_names,
-        }));
+        let svc_clause = if service_names.is_empty() {
+            String::new()
+        } else {
+            format!(" (services: {})", service_names.join(", "))
+        };
+        let preview = format!("Would restart app '{}'{svc_clause}.", app_data.name);
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "restart",
+                "app": app_data.name,
+                "services": service_names,
+            }),
+        );
         return;
     }
 
@@ -860,13 +898,30 @@ fn deploy_rebuild(
 
     if output::is_dry_run_mode() {
         let service_names: Vec<&str> = services_filter.iter().map(|s| s.as_str()).collect();
-        output::dry_run_success(serde_json::json!({
-            "action": "rebuild",
-            "app": app_data.name,
-            "runtime": runtime,
-            "services": service_names,
-            "skip_migrations": skip_migrations,
-        }));
+        let svc_clause = if service_names.is_empty() {
+            String::new()
+        } else {
+            format!(" (services: {})", service_names.join(", "))
+        };
+        let mig_clause = if skip_migrations {
+            " (skip migrations)"
+        } else {
+            ""
+        };
+        let preview = format!(
+            "Would rebuild app '{}' (runtime: {runtime}){svc_clause}{mig_clause}.",
+            app_data.name
+        );
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "rebuild",
+                "app": app_data.name,
+                "runtime": runtime,
+                "services": service_names,
+                "skip_migrations": skip_migrations,
+            }),
+        );
         return;
     }
 

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -256,12 +256,31 @@ pub fn dev(args: DevArgs) {
                 })
             })
             .collect();
-        output::dry_run_success(serde_json::json!({
-            "action": "start_dev_session",
-            "app": app_name,
-            "services": plan_services,
-            "skipped_external": skipped_external,
-        }));
+        let mut preview = format!(
+            "Would start {} service(s) for '{app_name}':",
+            services.len()
+        );
+        for svc in &services {
+            preview.push_str(&format!(
+                "\n    {} on http://localhost:{}",
+                svc.name, svc.port
+            ));
+        }
+        if !skipped_external.is_empty() {
+            preview.push_str(&format!(
+                "\nSkipping external service(s): {}",
+                skipped_external.join(", ")
+            ));
+        }
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "start_dev_session",
+                "app": app_name,
+                "services": plan_services,
+                "skipped_external": skipped_external,
+            }),
+        );
         return;
     }
 

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -39,11 +39,20 @@ fn check_services_flag(client: &FlooClient, app_id: &str, services: Option<&str>
 
 pub fn add(hostname: &str, app: Option<&str>, services: Option<&str>) {
     if output::is_dry_run_mode() {
-        output::dry_run_success(serde_json::json!({
-            "action": "domain_add",
-            "hostname": hostname,
-            "service": services,
-        }));
+        let target = app.unwrap_or("(reads from config)");
+        let svc_clause = services
+            .map(|s| format!(" (service: {s})"))
+            .unwrap_or_default();
+        let preview = format!("Would add domain {hostname} to {target}{svc_clause}.");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "domain_add",
+                "hostname": hostname,
+                "app": app,
+                "service": services,
+            }),
+        );
         return;
     }
 
@@ -164,13 +173,20 @@ pub fn remove(hostname: &str, app: Option<&str>, services: Option<&str>, yes: bo
 
     if output::is_dry_run_mode() {
         let risk: RiskMetadata = Tier::Two.into();
-        output::dry_run_success(serde_json::json!({
-            "action": "domain_remove",
-            "hostname": hostname,
-            "destructive": risk.destructive,
-            "data_loss": risk.data_loss,
-            "tier": risk.tier,
-        }));
+        let target = app.unwrap_or("(reads from config)");
+        let preview = format!("Would remove domain {hostname} from {target}.");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "domain_remove",
+                "hostname": hostname,
+                "app": app,
+                "service": services,
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+            }),
+        );
         return;
     }
 

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -54,6 +54,27 @@ fn format_target(app_name: &str, service_name: Option<&str>) -> String {
     }
 }
 
+/// Render `--services` and `--env` scope as a parenthesized suffix for dry-run
+/// previews — e.g. " (services: api, web) (env: prod)".
+///
+/// Codex review flagged that env dry-run previews previously hid the actual
+/// scope: `floo env set KEY=val --services api --env prod --dry-run` rendered
+/// as "Would set KEY on app foo." even though the real command would only
+/// touch the api service in prod. The preview must reflect the target the
+/// real command would mutate, otherwise an agent or human verifying a prod
+/// change can't tell from the preview that prod is what they're about to
+/// touch.
+fn format_env_scope(service_names: &[String], env: &str) -> String {
+    let mut suffix = String::new();
+    if !service_names.is_empty() {
+        suffix.push_str(&format!(" (services: {})", service_names.join(", ")));
+    }
+    if env != "dev" {
+        suffix.push_str(&format!(" (env: {env})"));
+    }
+    suffix
+}
+
 /// Resolve `--services` names to service IDs.
 ///
 /// Returns a list of `(Option<service_id>, Option<service_name>)` pairs.
@@ -241,8 +262,9 @@ pub fn set(
 
     if output::is_dry_run_mode() {
         let target = app_flag.unwrap_or("(reads from config)");
+        let scope = format_env_scope(service_names, env);
         let restart_clause = if restart { " and restart" } else { "" };
-        let preview = format!("Would set {key} on {target}{restart_clause}.");
+        let preview = format!("Would set {key} on {target}{scope}{restart_clause}.");
         output::dry_run_preview(
             &preview,
             serde_json::json!({
@@ -379,7 +401,8 @@ pub fn remove(key: &str, app_flag: Option<&str>, service_names: &[String], env: 
 
     if output::is_dry_run_mode() {
         let target = app_flag.unwrap_or("(reads from config)");
-        let preview = format!("Would remove {key} from {target}.");
+        let scope = format_env_scope(service_names, env);
+        let preview = format!("Would remove {key} from {target}{scope}.");
         output::dry_run_preview(
             &preview,
             serde_json::json!({
@@ -508,8 +531,9 @@ pub fn import_vars(
             .map(String::from)
             .or_else(|| resolved.as_ref().map(|r| r.app_name.clone()))
             .unwrap_or_else(|| "(reads from config)".to_string());
+        let scope = format_env_scope(service_names, env);
         let preview = format!(
-            "Would import {count} variable(s) from {} to {target}.\nKeys: {}",
+            "Would import {count} variable(s) from {} to {target}{scope}.\nKeys: {}",
             env_file_path.display(),
             keys.join(", "),
         );

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -240,11 +240,20 @@ pub fn set(
     let key = key.to_uppercase();
 
     if output::is_dry_run_mode() {
-        output::dry_run_success(serde_json::json!({
-            "action": "env_set",
-            "key": key,
-            "will_restart": restart,
-        }));
+        let target = app_flag.unwrap_or("(reads from config)");
+        let restart_clause = if restart { " and restart" } else { "" };
+        let preview = format!("Would set {key} on {target}{restart_clause}.");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "env_set",
+                "key": key,
+                "app": app_flag,
+                "services": service_names,
+                "env": env,
+                "will_restart": restart,
+            }),
+        );
         return;
     }
 
@@ -369,10 +378,18 @@ pub fn remove(key: &str, app_flag: Option<&str>, service_names: &[String], env: 
     let key = key.to_uppercase();
 
     if output::is_dry_run_mode() {
-        output::dry_run_success(serde_json::json!({
-            "action": "env_remove",
-            "key": key,
-        }));
+        let target = app_flag.unwrap_or("(reads from config)");
+        let preview = format!("Would remove {key} from {target}.");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "env_remove",
+                "key": key,
+                "app": app_flag,
+                "services": service_names,
+                "env": env,
+            }),
+        );
         return;
     }
 
@@ -487,12 +504,27 @@ pub fn import_vars(
         let vars = parse_env_file(&env_file_path);
         let keys: Vec<&str> = vars.iter().map(|(k, _)| k.as_str()).collect();
         let count = vars.len();
-        output::dry_run_success(serde_json::json!({
-            "action": "env_import",
-            "file": env_file_path.display().to_string(),
-            "keys": keys,
-            "count": count,
-        }));
+        let target = app_flag
+            .map(String::from)
+            .or_else(|| resolved.as_ref().map(|r| r.app_name.clone()))
+            .unwrap_or_else(|| "(reads from config)".to_string());
+        let preview = format!(
+            "Would import {count} variable(s) from {} to {target}.\nKeys: {}",
+            env_file_path.display(),
+            keys.join(", "),
+        );
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "env_import",
+                "file": env_file_path.display().to_string(),
+                "app": target,
+                "services": service_names,
+                "env": env,
+                "keys": keys,
+                "count": count,
+            }),
+        );
         return;
     }
 

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -7,14 +7,18 @@ use crate::output;
 pub fn rollback(app_name: &str, deploy_id: &str, yes: bool) {
     if output::is_dry_run_mode() {
         let risk: RiskMetadata = Tier::Two.into();
-        output::dry_run_success(serde_json::json!({
-            "action": "rollback",
-            "app": app_name,
-            "to_deploy": deploy_id,
-            "destructive": risk.destructive,
-            "data_loss": risk.data_loss,
-            "tier": risk.tier,
-        }));
+        let preview = format!("Would roll back app '{app_name}' to deploy {deploy_id}.");
+        output::dry_run_preview(
+            &preview,
+            serde_json::json!({
+                "action": "rollback",
+                "app": app_name,
+                "to_deploy": deploy_id,
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+            }),
+        );
         return;
     }
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -154,14 +154,17 @@ pub fn update(version: Option<&str>) {
                         display_tag(&plan.target_version),
                     )
                 };
-                output::dry_run_success(serde_json::json!({
-                    "action": "update",
-                    "current_version": plan.current_version,
-                    "target_version": display_tag(&plan.target_version),
-                    "install_path": plan.install_path,
-                    "already_up_to_date": plan.already_up_to_date,
-                    "message": message,
-                }));
+                output::dry_run_preview(
+                    &message,
+                    serde_json::json!({
+                        "action": "update",
+                        "current_version": plan.current_version,
+                        "target_version": display_tag(&plan.target_version),
+                        "install_path": plan.install_path,
+                        "already_up_to_date": plan.already_up_to_date,
+                        "message": message,
+                    }),
+                );
             }
             Err(err) => {
                 output::error(&err.message, &err.code, err.suggestion.as_deref());

--- a/src/output.rs
+++ b/src/output.rs
@@ -29,9 +29,38 @@ pub fn is_dry_run_mode() -> bool {
     DRY_RUN.load(Ordering::SeqCst)
 }
 
-/// Emit a dry-run success response with the given structured data.
-pub fn dry_run_success(data: Value) {
-    success("Dry run — no changes made.", Some(data));
+/// Emit a dry-run preview.
+///
+/// Human mode (stderr):
+///
+/// ```text
+/// → Dry run — no changes will be made.
+///   <line 1 of human_preview>
+///   <line 2 of human_preview>
+/// ```
+///
+/// JSON mode (stdout): `{"success": true, "data": data}` — same payload as
+/// `success(..., Some(data))`. Agents reading `--json` see the structured
+/// preview; humans see the same preview as a multi-line summary on stderr.
+///
+/// `human_preview` is multi-line text — newlines split into bullet lines.
+/// Empty lines are dropped. Pass `""` only if the data payload is genuinely
+/// self-explanatory; in practice every mutator should describe the action.
+pub fn dry_run_preview(human_preview: &str, data: Value) {
+    if is_json_mode() {
+        print_json(&serde_json::json!({"success": true, "data": data}));
+        return;
+    }
+    eprintln!(
+        "{} {}",
+        "\u{2192}".cyan(),
+        "Dry run — no changes will be made.".bold()
+    );
+    for line in human_preview.lines() {
+        if !line.trim().is_empty() {
+            eprintln!("  {line}");
+        }
+    }
 }
 
 /// Returns true when stdin is a TTY and JSON mode is off — i.e. a human is

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1106,6 +1106,55 @@ fn test_dry_run_env_set_human_has_preview() {
 }
 
 #[test]
+fn test_dry_run_env_set_human_includes_services_and_prod_scope() {
+    // Codex review: dry-run preview must reflect --services and non-default
+    // --env so an operator verifying a prod or service-specific change sees
+    // the real scope, not just the app name.
+    floo()
+        .args([
+            "--dry-run",
+            "env",
+            "set",
+            "KEY=value",
+            "--app",
+            "test",
+            "--services",
+            "api",
+            "--env",
+            "prod",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would set KEY on test (services: api) (env: prod).",
+        ));
+}
+
+#[test]
+fn test_dry_run_env_remove_human_includes_services_and_prod_scope() {
+    floo()
+        .args([
+            "--dry-run",
+            "env",
+            "remove",
+            "KEY",
+            "--app",
+            "test",
+            "--services",
+            "api",
+            "--env",
+            "prod",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would remove KEY from test (services: api) (env: prod).",
+        ));
+}
+
+#[test]
 fn test_dry_run_env_set_restart_human() {
     floo()
         .args([

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1065,7 +1065,15 @@ ingress = "public"
         ));
 }
 
-// --- Dry-run ---
+// --- Dry-run matrix ---
+//
+// Every command that advertises --dry-run gets two assertions:
+//   - JSON mode: stdout has the structured action payload (real preview)
+//   - Human mode: stderr has both the standardized "Dry run" header AND a
+//     "Would <verb>" preview line that names the action (no theater).
+//
+// The "Would" line is what blocks regression to the prior bug where dry-run
+// human output was just "✓ Dry run — no changes made." with the data dropped.
 
 #[test]
 fn test_dry_run_env_set() {
@@ -1087,6 +1095,37 @@ fn test_dry_run_env_set() {
 }
 
 #[test]
+fn test_dry_run_env_set_human_has_preview() {
+    floo()
+        .args(["--dry-run", "env", "set", "KEY=value", "--app", "test"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Dry run"))
+        .stderr(predicate::str::contains("Would set KEY on test"));
+}
+
+#[test]
+fn test_dry_run_env_set_restart_human() {
+    floo()
+        .args([
+            "--dry-run",
+            "env",
+            "set",
+            "KEY=value",
+            "--app",
+            "test",
+            "--restart",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would set KEY on test and restart.",
+        ));
+}
+
+#[test]
 fn test_dry_run_env_remove() {
     floo()
         .args([
@@ -1105,6 +1144,62 @@ fn test_dry_run_env_remove() {
 }
 
 #[test]
+fn test_dry_run_env_remove_human_has_preview() {
+    floo()
+        .args(["--dry-run", "env", "remove", "KEY", "--app", "test"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Dry run"))
+        .stderr(predicate::str::contains("Would remove KEY from test"));
+}
+
+#[test]
+fn test_dry_run_env_import() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let env_file = dir.path().join(".env");
+    std::fs::write(&env_file, "KEY=value\nFOO=bar\n").unwrap();
+
+    floo()
+        .args([
+            "--json",
+            "--dry-run",
+            "env",
+            "import",
+            env_file.to_str().unwrap(),
+            "--app",
+            "test",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"env_import"#))
+        .stdout(predicate::str::contains(r#""count":2"#));
+}
+
+#[test]
+fn test_dry_run_env_import_human_has_preview() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let env_file = dir.path().join(".env");
+    std::fs::write(&env_file, "KEY=value\nFOO=bar\n").unwrap();
+
+    floo()
+        .args([
+            "--dry-run",
+            "env",
+            "import",
+            env_file.to_str().unwrap(),
+            "--app",
+            "test",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would import 2 variable(s)"))
+        .stderr(predicate::str::contains("Keys: KEY, FOO"));
+}
+
+#[test]
 fn test_dry_run_apps_delete() {
     floo()
         .args(["--json", "--dry-run", "apps", "delete", "my-app"])
@@ -1112,6 +1207,18 @@ fn test_dry_run_apps_delete() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""action":"delete"#));
+}
+
+#[test]
+fn test_dry_run_apps_delete_human_has_preview() {
+    floo()
+        .args(["--dry-run", "apps", "delete", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would permanently delete app 'my-app'",
+        ));
 }
 
 #[test]
@@ -1133,6 +1240,25 @@ fn test_dry_run_domains_add() {
 }
 
 #[test]
+fn test_dry_run_domains_add_human_has_preview() {
+    floo()
+        .args([
+            "--dry-run",
+            "domains",
+            "add",
+            "example.com",
+            "--app",
+            "test",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would add domain example.com to test",
+        ));
+}
+
+#[test]
 fn test_dry_run_domains_remove() {
     floo()
         .args([
@@ -1148,6 +1274,55 @@ fn test_dry_run_domains_remove() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""action":"domain_remove"#));
+}
+
+#[test]
+fn test_dry_run_domains_remove_human_has_preview() {
+    floo()
+        .args([
+            "--dry-run",
+            "domains",
+            "remove",
+            "example.com",
+            "--app",
+            "test",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would remove domain example.com from test",
+        ));
+}
+
+#[test]
+fn test_dry_run_cron_run() {
+    floo()
+        .args([
+            "--json",
+            "--dry-run",
+            "cron",
+            "run",
+            "myjob",
+            "--app",
+            "test",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"run_cron_job"#));
+}
+
+#[test]
+fn test_dry_run_cron_run_human_has_preview() {
+    floo()
+        .args(["--dry-run", "cron", "run", "myjob", "--app", "test"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would trigger cron job 'myjob' on test",
+        ));
 }
 
 #[test]
@@ -1168,6 +1343,18 @@ fn test_dry_run_rollback() {
 }
 
 #[test]
+fn test_dry_run_rollback_human_has_preview() {
+    floo()
+        .args(["--dry-run", "deploys", "rollback", "my-app", "deploy-123"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would roll back app 'my-app' to deploy deploy-123",
+        ));
+}
+
+#[test]
 fn test_dry_run_redeploy_restart() {
     floo()
         .args(["--json", "--dry-run", "redeploy", "--app", "test-app"])
@@ -1175,6 +1362,16 @@ fn test_dry_run_redeploy_restart() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""action":"restart"#));
+}
+
+#[test]
+fn test_dry_run_redeploy_restart_human_has_preview() {
+    floo()
+        .args(["--dry-run", "redeploy", "--app", "test-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would restart app 'test-app'"));
 }
 
 #[test]
@@ -1195,12 +1392,85 @@ fn test_dry_run_redeploy_rebuild() {
 }
 
 #[test]
+fn test_dry_run_redeploy_rebuild_human_has_preview() {
+    floo()
+        .args(["--dry-run", "redeploy", "--app", "test-app", "--rebuild"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would rebuild app 'test-app'"));
+}
+
+#[test]
+fn test_dry_run_db_migrate() {
+    floo()
+        .args([
+            "--json",
+            "--dry-run",
+            "db",
+            "migrate",
+            "--app",
+            "test",
+            "--env",
+            "dev",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"db_migrate"#))
+        .stdout(predicate::str::contains(r#""env":"dev"#));
+}
+
+#[test]
+fn test_dry_run_db_migrate_human_has_preview() {
+    floo()
+        .args([
+            "--dry-run",
+            "db",
+            "migrate",
+            "--app",
+            "test",
+            "--env",
+            "prod",
+        ])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Would run pending migrations on 'test' (env: prod)",
+        ));
+}
+
+#[test]
 fn test_dry_run_unsupported_init() {
     floo()
         .args(["--json", "--dry-run", "init", "my-app"])
         .assert()
         .failure()
         .stdout(predicate::str::contains("not supported"));
+}
+
+/// Regression for the prior contract bug: human dry-run output was
+/// just "✓ Dry run — no changes made." with the data dropped, while JSON
+/// mode emitted a real preview. Ensure no command we just fixed reverts to
+/// printing the legacy "✓ Dry run — no changes made." sentinel without a
+/// "Would …" preview line above it.
+#[test]
+fn test_dry_run_human_never_emits_legacy_no_preview_line() {
+    let cmd = floo()
+        .args(["--dry-run", "apps", "delete", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success();
+    let stderr = String::from_utf8(cmd.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("Would permanently delete"),
+        "expected human preview, got stderr:\n{stderr}",
+    );
+    assert!(
+        !stderr.contains("Dry run — no changes made."),
+        "human dry-run output should not emit the legacy preview-less sentinel; got:\n{stderr}",
+    );
 }
 
 // --- Env Import --all ---


### PR DESCRIPTION
## What changed

Two reported `--dry-run` bugs had the same shape: the flag's contract was broken.

- **Bug #3 (feedback 07472914)** — `floo env set TEST=hello --dry-run --app foo` printed only `✓ Dry run — no changes made.` while `--json` emitted a real preview. Human output was theater; JSON was real.
- **Bug #4 (feedback 6b57adb6)** — `floo db migrate --help` advertised `--dry-run` but the runtime gate rejected it (`--dry-run is not supported for this command.`). The flag is global, so it inherits into every subcommand's `--help`.

Fix:

1. Renamed `output::dry_run_success(data)` → `output::dry_run_preview(human_preview, data)` in `src/output.rs`. Human mode now prints a standardized "Dry run — no changes will be made." header followed by the per-call multi-line preview ("Would set KEY on app foo and restart."). JSON mode emits the same `{success, data}` payload as before. The new contract makes the previous regression mechanically impossible — every dry-run path must supply preview text.
2. Updated every call site (apps, cron, deploy ×3, dev, domains ×2, env ×3, rollbacks, update) with an action-specific "Would …" preview. JSON payloads also gained the missing target context (app, services, env) so JSON readers see the same scope the human preview describes.
3. Implemented `db migrate --dry-run` as a pure-echo handler (matches `cron run` — runs before `require_auth()` so logged-out users and offline agents get a preview). Removed it from the unsupported-list and added it to `DRY_RUN_SUPPORTED_COMMANDS` plus the regression-test invocation table.
4. Codex follow-up: env previews now include `(services: …)` and `(env: …)` when the flags differ from defaults, so an operator verifying `--env prod` or `--services api` sees the real scope before mutating.

## Why

The `--dry-run` contract is the agent-experience surface for "verify before you mutate." If the human and JSON modes disagree on what the preview shows — or if `--help` advertises a flag that errors at runtime — the contract is broken and humans/agents lose trust in the preview. The reported bugs were the symptom; the underlying cause was a `dry_run_success(data)` helper that dropped the data in human mode and a global `--dry-run` flag that wasn't matched by every subcommand. Both are fixed at the contract level, not just patched at the call site.

## Risk tier

Sensitive — touches `commands/deploy.rs` (CLI deploy code per the SDLC classifier).

## Files reviewers should scrutinize

- `src/output.rs` — new `dry_run_preview` signature; human/JSON branching.
- `src/cli.rs` — `db migrate` moved from unsupported → `DRY_RUN_SUPPORTED_COMMANDS`; regression test row added.
- `src/commands/db.rs` — new dry-run early-return, placed before `require_auth()`.
- `src/commands/env.rs` — `format_env_scope()` helper + per-action preview text.
- `src/commands/deploy.rs` — three dry-run sites (preflight, restart, rebuild) updated to emit human previews.

## Tests run

- `cargo test` — 329 unit + 100 integration (30 dry-run) + 69 mock-API. All pass.
- `cargo clippy --bins -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Test matrix in `tests/cli_tests.rs`: every `DRY_RUN_SUPPORTED_COMMANDS` row now has both a JSON-mode assertion (action payload) and a human-mode assertion ("Would …" preview line). New rows for `cron run`, `env import`, `db migrate`, env scope tests. Regression guard `test_dry_run_human_never_emits_legacy_no_preview_line` blocks reverting to the preview-less sentinel.

## Known non-goals

- Other (c)-class commands (`init`, `run`, `feedback`, `apps invite`, `auth login/logout/register/update-profile`, `releases promote`, `orgs members set-role/switch`, `apps github connect/disconnect`, `billing spend-cap set`, `skills install`) still appear in `--help` due to the global flag and rely on the existing runtime error gate (`--dry-run is not supported for this command. Supported: …`). The error message is helpful and lists the supported set, so this is the minimum-correct surface for now. Implementing dry-run for each of those mutators is a separate scope.
- Pre-existing inner dry-run guards in `deploy_restart` / `deploy_rebuild` are dead today (the outer guard returns first) but were left in as defense-in-depth for future callers — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)