### PR TITLE
ci(release): notify Slack #releases on successful binary publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,3 +166,44 @@ jobs:
           # artifact download ever breaks or the directory layout shifts.
           # The CLI auto-updater depends on these assets existing.
           fail_on_unmatched_files: true
+
+      # Post a release-success ping to Slack #releases. Mirrors the
+      # platform's `Notify release success` step in
+      # getfloo/floo's deploy.yml so the CLI shows up alongside platform
+      # releases in the same paper trail.
+      #
+      # Public-repo safety: this repo is open-source. The webhook URL
+      # MUST come from `secrets.SLACK_RELEASES_WEBHOOK` and never be
+      # hardcoded. GitHub Actions does not inject `secrets.*` into
+      # workflow runs from fork PRs, so the only way this step ever
+      # runs is via `push: tags` (org-member push) or `workflow_dispatch`
+      # (org-member trigger). The message body carries only public
+      # information (tag, short SHA, public release URL, public run URL).
+      #
+      # If `SLACK_RELEASES_WEBHOOK` isn't configured (e.g. a fork that
+      # cuts its own tag) the step skips with a warning instead of
+      # failing the release — the binaries are already published.
+      - name: Notify release success
+        if: success()
+        env:
+          SLACK_RELEASES_WEBHOOK: ${{ secrets.SLACK_RELEASES_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SLACK_RELEASES_WEBHOOK" ]; then
+            echo "::warning::SLACK_RELEASES_WEBHOOK is empty; skipping"
+            exit 0
+          fi
+          TAG="${{ github.ref_name }}"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/${TAG}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=":package: *floo-cli ${TAG} released*\nCommit: \`${SHORT_SHA}\` · <${RELEASE_URL}|GitHub release> · <${RUN_URL}|build run>"
+          PAYLOAD=$(jq -nc --arg text "$MSG" '{text:$text}')
+          RESPONSE=$(curl -sSL --fail-with-body -X POST \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$SLACK_RELEASES_WEBHOOK")
+          if [ "$RESPONSE" != "ok" ]; then
+            echo "::error::Slack webhook returned unexpected body: $RESPONSE"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,4 +106,12 @@ The skill file (`skills/floo/SKILL.md`) is a tiny intro (~30 lines). Platform kn
 1. Tag `v*` on main branch
 2. CI builds binaries for 5 targets (macOS x86/arm, Linux x86/arm, Windows x86)
 3. GitHub Release created with binaries + SHA256 checksums + RSA signatures
-4. Install script downloads from these releases and verifies checksum + signature before install
+4. Slack `#releases` ping fires (mirrors the platform's deploy.yml notification — gated on `secrets.SLACK_RELEASES_WEBHOOK`; skips with a warning if unset, fails the release if Slack rejects the post)
+5. Install script downloads from these releases and verifies checksum + signature before install
+
+### Required secrets
+
+- `FLOO_RELEASE_SIGNING_KEY` — RSA private key whose public key is pinned into the CLI updater. Required to publish a signed release; the workflow fails fast if missing or mismatched.
+- `SLACK_RELEASES_WEBHOOK` — Slack incoming-webhook URL for the `#releases` channel. Optional; the notify step warns and skips when empty so a fork that cuts its own tag still gets a successful release.
+
+Both must be set at the org or repo level. **This is a public repo — never reference secret values in workflow files except via `secrets.NAME`, never echo them in `run:` blocks, and never expose them to fork PRs (the workflow's `push: tags` trigger already gates that — fork PRs cannot push tags to upstream).**


### PR DESCRIPTION
## What changed

Adds a release-success Slack ping to floo-cli's release workflow. Mirrors the platform's existing \`Notify release success\` step in \`getfloo/floo\`'s \`deploy.yml\` so CLI releases land in the same \`#releases\` paper trail.

## Why

You asked for it after cutting v2026.04.30 — currently CLI releases are silent in chat. The CLI is a release surface customers and agents both consume, so a tag landing should be as visible as a platform deploy.

## Public-repo safety (this repo is open source — getfloo/floo-cli is MIT, public)

- Webhook URL referenced as \`secrets.SLACK_RELEASES_WEBHOOK\` only; never hardcoded.
- The workflow's existing \`push: tags: v*\` trigger means fork PRs can't reach this step. Two layers: (a) forks can't push tags to upstream, (b) GitHub Actions doesn't inject \`secrets.*\` into workflows running from fork PRs anyway.
- Message body carries only public info: tag, short SHA, public release URL, public run URL. No internal IDs, no env values, no secrets echoed.
- Empty-secret graceful skip (\`::warning::\` then \`exit 0\`) so a fork that cuts its own tag still gets a successful release.
- Hard-fail on non-"ok" Slack response so misconfig surfaces immediately instead of being silently swallowed (same shape as the platform's notify step).

## Test plan

- [ ] Set \`SLACK_RELEASES_WEBHOOK\` in repo secrets (or org-level secret with this repo in scope).
- [ ] Tag the next CLI release (e.g. \`v2026.04.30.1\` or whenever the next change ships).
- [ ] Confirm \`#releases\` shows: \`:package: floo-cli vX.Y.Z released — Commit \`abcd123\` · GitHub release · build run\`
- [ ] Confirm the workflow run still passes when the secret is unset (warning-and-skip path).

## Risk tier

Standard — additive workflow step. The only failure mode is the new step itself. Empty-secret path is no-op; success path is gated on \`if: success()\` so a failing release still goes through the existing fail-paths (no false-positive #releases ping).

## Required secret

\`SLACK_RELEASES_WEBHOOK\` — Slack incoming-webhook URL for \`#releases\`. Optional (warning-and-skip if unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)