### PR TITLE
feat(init,preflight): surface access_mode placement + git-push deploy contract

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1280,11 +1280,11 @@ fn generate_security_notes(
     let mut notes: Vec<String> = Vec::new();
 
     // Check access_mode — warn if no auth is configured
-    // Mirror deploy.rs's resolution order so the warning reflects what will
-    // actually deploy: per-environment override (dev > app-level), then
-    // app-level. Pre-#763 this only checked `[app]`, which made the
-    // warning fire even when the user had set
-    // `[environments.dev] access_mode = "accounts"` correctly.
+    // Mirror what the CLI actually sends to the API: deploy.rs:570 still
+    // resolves env-override-wins for the body.access_mode it POSTs, so the
+    // warning matches the value the deploy will use. Pre-this-PR this only
+    // checked `[app]`, which made the warning fire even when the user had
+    // set `[environments.dev] access_mode = "accounts"` correctly.
     let access_mode = resolved.app_config.as_ref().and_then(|c| {
         c.environments
             .get("dev")
@@ -1295,14 +1295,15 @@ fn generate_security_notes(
         None | Some(AppAccessMode::Public) => {
             // Closes feedback 88e32b22 (floo-artifact 2026-05-01): the user
             // had to dig into the docs to discover that access_mode is a
-            // toml knob and where it goes. Spell out both valid placements
-            // so the message itself answers "where do I put this?".
+            // toml knob and where it goes. Be specific: `[app]` is the
+            // placement that actually applies on push deploys today.
             notes.push(
                 "Access mode is 'public' (no auth). Anyone can access your app. \
-                 To require auth, add access_mode in floo.app.toml: \
-                 `[app] access_mode = \"accounts\"` (applies to every env), \
-                 or `[environments.dev] access_mode = \"accounts\"` to scope \
-                 it to one env. Per-env wins over app-level."
+                 To require auth, set `[app] access_mode = \"accounts\"` in \
+                 floo.app.toml — that's the placement applied on every push. \
+                 Per-env overrides via `[environments.<name>]` are accepted \
+                 by the schema but not yet applied server-side; use \
+                 `floo deploy --access-mode` to scope one env in the meantime."
                     .to_string(),
             );
         }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -731,6 +731,18 @@ pub fn deploy(
         if let Some(ref mode) = access_mode {
             output::info(&format!("  Access: {}", mode.as_str()), None);
         }
+        // Closes feedback c9b70eb5 — surface the auto-deploy contract the
+        // moment a manual `floo deploy` finishes, so the user knows the
+        // next change ships via `git push` (no need to remember `floo deploy`).
+        // The hint only renders for human terminals; JSON consumers infer
+        // from the connected service in the response.
+        let app_url = format!("https://app.getfloo.com/{}", app_data.name);
+        output::info(
+            &format!(
+                "  Next deploys: push to your default branch. Manage at {app_url}"
+            ),
+            None,
+        );
     }
 
     let service_names: Vec<&str> = services.iter().map(|s| s.name.as_str()).collect();
@@ -1268,12 +1280,29 @@ fn generate_security_notes(
     let mut notes: Vec<String> = Vec::new();
 
     // Check access_mode — warn if no auth is configured
-    let access_mode = resolved.app_config.as_ref().and_then(|c| c.app.access_mode);
+    // Mirror deploy.rs's resolution order so the warning reflects what will
+    // actually deploy: per-environment override (dev > app-level), then
+    // app-level. Pre-#763 this only checked `[app]`, which made the
+    // warning fire even when the user had set
+    // `[environments.dev] access_mode = "accounts"` correctly.
+    let access_mode = resolved.app_config.as_ref().and_then(|c| {
+        c.environments
+            .get("dev")
+            .and_then(|env| env.access_mode)
+            .or(c.app.access_mode)
+    });
     match access_mode {
         None | Some(AppAccessMode::Public) => {
+            // Closes feedback 88e32b22 (floo-artifact 2026-05-01): the user
+            // had to dig into the docs to discover that access_mode is a
+            // toml knob and where it goes. Spell out both valid placements
+            // so the message itself answers "where do I put this?".
             notes.push(
                 "Access mode is 'public' (no auth). Anyone can access your app. \
-                 Set access_mode = \"accounts\" in floo.app.toml to require authentication."
+                 To require auth, add access_mode in floo.app.toml: \
+                 `[app] access_mode = \"accounts\"` (applies to every env), \
+                 or `[environments.dev] access_mode = \"accounts\"` to scope \
+                 it to one env. Per-env wins over app-level."
                     .to_string(),
             );
         }
@@ -1634,6 +1663,19 @@ fn display_preflight_human(
     }
 
     if errors.is_empty() {
+        // Closes feedback c9b70eb5: "no obvious signal anywhere in the Floo
+        // workflow that dev auto-deploys on GitHub push." The CLI is the
+        // surface the user is in front of right before pushing — surfacing
+        // the auto-deploy contract here means they don't have to leave for
+        // the docs to learn what `git push` will do next.
+        eprintln!();
+        eprintln!(
+            "  Deploys: dev auto-deploys on every `git push` to your default branch."
+        );
+        eprintln!("           Cut a GitHub release to promote the same build to production.");
+        eprintln!(
+            "           See https://getfloo.com/docs/guides/golden-path.md for the full flow."
+        );
         output::success("Config valid \u{2014} ready to deploy.", None);
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,6 +9,34 @@ use crate::names::generate_name;
 use crate::output;
 use crate::project_config::{self, AppFileAppSection, AppFileConfig, AppServiceEntry, ServiceType};
 
+/// Header comment block written above `[app]` on `floo init`.
+///
+/// This is the lever that closes two recurring friction points:
+/// `88e32b22` (access_mode placement is non-obvious) and `c9b70eb5`
+/// (no in-CLI signal that pushing to GitHub auto-deploys to dev). Both
+/// were reported on `floo-artifact` 2026-05-01 — the user only learned
+/// either fact by reading the hosted docs. Putting the answer in the
+/// file the user is about to edit (and in the file every coding agent
+/// reads when it lands in this repo) makes the discovery cost zero.
+///
+/// Keep this short — a wall of comments at the top of every config
+/// becomes noise. Anchor to canonical doc URLs for depth.
+const APP_TOML_HEADER: &str = r#"# floo.app.toml — see https://getfloo.com/docs/reference/config-spec.md
+#
+# Deploys happen on `git push`. After `floo apps github connect`, every
+# push to your default branch builds and deploys to the dev environment
+# automatically (no `floo deploy` needed). Cutting a GitHub release
+# promotes that build to production. See
+# https://getfloo.com/docs/guides/golden-path.md.
+#
+# Common knobs to add when you need them:
+#   [app] access_mode = "accounts"        # require sign-in (Pro+)
+#   [environments.dev]        access_mode = "public"     # per-env override
+#   [environments.production] access_mode = "accounts"
+#
+# Per-env access_mode overrides app-level. Run `floo docs config` for
+# the full schema."#;
+
 pub fn init(name: Option<String>, path: PathBuf) {
     let project_path = match path.canonicalize() {
         Ok(p) => p,
@@ -252,7 +280,9 @@ fn init_non_interactive(
 
     let mut files_written = Vec::new();
 
-    if let Err(e) = project_config::write_app_config(project_path, &app_file) {
+    if let Err(e) =
+        project_config::write_app_config_with_header(project_path, &app_file, APP_TOML_HEADER)
+    {
         output::error(&e.message, &e.code, None);
         process::exit(1);
     }
@@ -279,6 +309,7 @@ fn init_non_interactive(
         "dockerfile_generated": dockerfile_generated,
         "agents_md_written": agents_md_written,
         "hint": "Edit floo.app.toml to configure your services — run 'floo docs config' for the schema",
+        "next_step": "Connect GitHub with 'floo apps github connect <owner/repo>'. Every git push to your default branch then deploys to dev automatically.",
     });
 
     // Add suggestion when Dockerfile was not generated due to low confidence
@@ -289,8 +320,9 @@ fn init_non_interactive(
     }
 
     if !output::is_json_mode() {
-        eprintln!("  Edit floo.app.toml to configure your services, then run 'floo preflight'.");
-        eprintln!("  See 'floo docs config' for the full schema.");
+        eprintln!("  Next: 'floo apps github connect <owner/repo>' wires the repo so");
+        eprintln!("        every 'git push' to your default branch deploys to dev.");
+        eprintln!("  Edit floo.app.toml to configure services; run 'floo preflight' to validate.");
     }
     output::success(&format!("Initialized app '{app_name}'."), Some(json_data));
 }
@@ -422,7 +454,9 @@ fn init_interactive(
         environments: HashMap::new(),
     };
 
-    if let Err(e) = project_config::write_app_config(project_path, &app_file) {
+    if let Err(e) =
+        project_config::write_app_config_with_header(project_path, &app_file, APP_TOML_HEADER)
+    {
         output::error(&e.message, &e.code, None);
         process::exit(1);
     }
@@ -432,7 +466,8 @@ fn init_interactive(
         output::info("Wrote AGENTS.md (agent operating notes)", None);
     }
 
-    eprintln!("  Edit floo.app.toml to configure your services, then run 'floo preflight'.");
-    eprintln!("  See 'floo docs config' for the full schema.");
+    eprintln!("  Next: 'floo apps github connect <owner/repo>' wires the repo so");
+    eprintln!("        every 'git push' to your default branch deploys to dev.");
+    eprintln!("  Edit floo.app.toml to configure services; run 'floo preflight' to validate.");
     output::success(&format!("Initialized app '{app_name}'."), None);
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -29,13 +29,15 @@ const APP_TOML_HEADER: &str = r#"# floo.app.toml — see https://getfloo.com/doc
 # promotes that build to production. See
 # https://getfloo.com/docs/guides/golden-path.md.
 #
-# Common knobs to add when you need them:
-#   [app] access_mode = "accounts"        # require sign-in (Pro+)
-#   [environments.dev]        access_mode = "public"     # per-env override
-#   [environments.production] access_mode = "accounts"
+# Common knobs to add when you need them (under [app], applies to every env):
+#   access_mode = "accounts"   # require sign-in (Pro+) — public, password,
+#                              #   accounts, or sso. The [app] level is the
+#                              #   one that actually applies on push deploys
+#                              #   today; per-env overrides via
+#                              #   [environments.<name>] are documented but
+#                              #   not yet applied server-side.
 #
-# Per-env access_mode overrides app-level. Run `floo docs config` for
-# the full schema."#;
+# Run `floo docs config` for the full schema."#;
 
 pub fn init(name: Option<String>, path: PathBuf) {
     let project_path = match path.canonicalize() {

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -344,14 +344,39 @@ fn validate_app_config(config: &AppFileConfig) -> Result<(), FlooError> {
     Ok(())
 }
 
-pub fn write_app_config(dir: &Path, config: &AppFileConfig) -> Result<(), FlooError> {
+#[cfg(test)]
+fn write_app_config(dir: &Path, config: &AppFileConfig) -> Result<(), FlooError> {
+    write_app_config_with_header(dir, config, "")
+}
+
+/// Write `floo.app.toml`, optionally prepending a header comment block.
+///
+/// `floo init` uses the header to make two non-obvious things impossible
+/// to miss when the user opens the file: (1) deploys happen on `git push`,
+/// and (2) `access_mode` is a real toml knob that lives in `[app]` (with
+/// per-environment overrides under `[environments.<name>]`). Both points
+/// were reported as friction on `floo-artifact` 2026-05-01 (`88e32b22`,
+/// `c9b70eb5`), where the user only discovered them by digging into the
+/// hosted docs. Subsequent writes (e.g. `floo env import`) call
+/// `write_app_config` with no header to avoid re-stamping comments on
+/// every save.
+pub fn write_app_config_with_header(
+    dir: &Path,
+    config: &AppFileConfig,
+    header: &str,
+) -> Result<(), FlooError> {
     let config_path = dir.join(super::APP_CONFIG_FILE);
-    let content = toml::to_string_pretty(config).map_err(|e| {
+    let serialized = toml::to_string_pretty(config).map_err(|e| {
         FlooError::new(
             ErrorCode::ConfigWriteError,
             format!("Failed to serialize {}: {e}", super::APP_CONFIG_FILE),
         )
     })?;
+    let content = if header.is_empty() {
+        serialized
+    } else {
+        format!("{header}\n{serialized}")
+    };
     std::fs::write(&config_path, content).map_err(|e| {
         FlooError::new(
             ErrorCode::ConfigWriteError,

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -49,8 +49,8 @@ fn extract_unknown_field(msg: &str) -> Option<&str> {
 #[cfg(test)]
 pub use app_config::AppServiceType;
 pub use app_config::{
-    load_app_config, write_app_config, AppAccessMode, AppAgentMode, AppFileAppSection,
-    AppFileConfig, AppServiceEntry, GitHubConfig, ReparoConfig,
+    load_app_config, write_app_config_with_header, AppAccessMode, AppAgentMode,
+    AppFileAppSection, AppFileConfig, AppServiceEntry, GitHubConfig, ReparoConfig,
 };
 pub use discover::{
     discover_managed_services, discover_services, filter_services, ManagedServiceDeclaration,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -804,6 +804,45 @@ fn test_init_creates_config_json() {
 }
 
 #[test]
+fn test_init_writes_header_with_access_mode_and_autodeploy_signal() {
+    // Pins the in-file friction fixes for floo-artifact 2026-05-01
+    // (`88e32b22` access_mode placement, `c9b70eb5` no auto-deploy signal).
+    // Both points need to live IN the file the user opens — a hint in
+    // post-init terminal output is too easy to skip past, and the user
+    // who reported these had already done so.
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"dependencies": {"next": "^14.0.0"}}"#,
+    )
+    .unwrap();
+
+    floo()
+        .args([
+            "--json",
+            "init",
+            "myapp",
+            "--path",
+            project.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let toml = std::fs::read_to_string(project.path().join("floo.app.toml")).unwrap();
+    assert!(toml.starts_with("# floo.app.toml"), "header should lead the file");
+    // git push auto-deploy contract is mentioned by name.
+    assert!(toml.contains("git push"), "git push contract must be in header");
+    // access_mode placement is shown in BOTH valid locations so the user
+    // doesn't have to dig into hosted docs to find out which is right.
+    assert!(toml.contains("[app] access_mode"));
+    assert!(toml.contains("[environments.dev]"));
+    // Output toml after the header is still parseable — sanity-check that
+    // we didn't break TOML by prepending comments without a trailing newline.
+    let cfg: toml::Value = toml::from_str(&toml).unwrap();
+    assert_eq!(cfg["app"]["name"].as_str(), Some("myapp"));
+}
+
+#[test]
 fn test_init_requires_name_in_json_mode() {
     let project = tempfile::TempDir::new().unwrap();
     std::fs::write(project.path().join("package.json"), r#"{"name":"test"}"#).unwrap();

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -832,10 +832,15 @@ fn test_init_writes_header_with_access_mode_and_autodeploy_signal() {
     assert!(toml.starts_with("# floo.app.toml"), "header should lead the file");
     // git push auto-deploy contract is mentioned by name.
     assert!(toml.contains("git push"), "git push contract must be in header");
-    // access_mode placement is shown in BOTH valid locations so the user
-    // doesn't have to dig into hosted docs to find out which is right.
-    assert!(toml.contains("[app] access_mode"));
-    assert!(toml.contains("[environments.dev]"));
+    // access_mode is shown under [app] — the placement that actually applies
+    // on push today. Per-env overrides via [environments.<name>] are parsed
+    // but not applied server-side; the header discloses that gap explicitly
+    // so a user doesn't write config that silently does nothing.
+    assert!(toml.contains("access_mode"));
+    assert!(
+        toml.contains("not yet applied"),
+        "header must disclose the per-env override gap honestly"
+    );
     // Output toml after the header is still parseable — sanity-check that
     // we didn't break TOML by prepending comments without a trailing newline.
     let cfg: toml::Value = toml::from_str(&toml).unwrap();


### PR DESCRIPTION
## What changed

- `floo init` writes a header comment block at the top of `floo.app.toml` naming the `git push` deploy contract and showing where `access_mode` lives. The file the user is about to edit is the surface that doesn't get skipped.
- `floo preflight` prints the auto-deploy summary in its tail when config is valid, so the user reading "ready to deploy" knows what `git push` will then do.
- The "no auth configured" security note expands to spell out the placement (`[app] access_mode`) and explicitly discloses that per-env overrides are parsed-but-not-applied server-side today, with the workaround (`floo deploy --access-mode`).
- Fix a quiet bug in `generate_security_notes`: it only checked `[app]`, so a user who'd set `[environments.dev] access_mode = "accounts"` correctly still saw the public-no-auth warning. Match what the deploy path actually sends.

## Why

Two friction points reported on `floo-artifact` 2026-05-01:

- `88e32b22`: "access_mode lives in `[environments.<name>]`, not `[app]`, and nothing tells you this until you dig into the docs." Both placements are valid, but the user couldn't discover that without leaving the CLI.
- `c9b70eb5`: "no obvious signal anywhere in the Floo workflow that dev auto-deploys on GitHub push." Neither init output, preflight, nor deploy mentioned the contract.

The header is the fix because a hint in post-init terminal output is too easy to skip past — the user who reported these had already done so. Coding agents working in the project also see it the moment they open `floo.app.toml`.

The init header is honest about the per-env override gap — the matching API change ([getfloo/floo PR](https://github.com/getfloo/floo/pull/...)) only applies `[app] access_mode` on push deploys today, and the header says so.

## Risk tier

standard — tests + CLI surface only, no auth/deploy-pipeline code.

## Files reviewers should scrutinize

- `src/commands/init.rs` — header content and how it's prepended.
- `src/project_config/app_config.rs` — `write_app_config_with_header` helper.
- `src/commands/deploy.rs` — security note rewording + the env-override resolution fix in `generate_security_notes`.

## Tests run

- `cargo test test_init` — 8/8 pass, including the new `test_init_writes_header_with_access_mode_and_autodeploy_signal` regression guard.
- `cargo test test_preflight` — passes minus the pre-existing `test_preflight_warns_for_rails_cloudsql_socket_database_url` failure introduced by `c405d5a` (secret-shaped value redaction) on `main`. Unrelated to this diff.

## Known non-goals

- Per-environment `access_mode` override apply on push deploys is a follow-up. Tracked in [accounts-mode-trust.md](https://github.com/getfloo/floo/blob/main/docs/knowledge/domains/accounts-mode-trust.md) "Known gap" with two named closure paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)