### PR TITLE
fix(cli): friction batch from floo-alerts feedback (2026-05-01)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,7 +79,8 @@ Examples:
                                                         in production. Prints both the raw service
                                                         URL and the auth-proxied URL.")]
     Dev {
-        /// App name or ID (reads from config if omitted).
+        /// App name or ID. Overrides the app name in floo.app.toml, but the
+        /// file itself is still required for service definitions.
         #[arg(short, long)]
         app: Option<String>,
 
@@ -124,7 +125,8 @@ Examples:
         #[arg(long, required = true)]
         service: String,
 
-        /// App name or ID (reads from config if omitted).
+        /// App name or ID. Overrides the app name in floo.app.toml, but the
+        /// file itself is still required for service definitions.
         #[arg(short, long)]
         app: Option<String>,
 
@@ -528,9 +530,16 @@ pub enum AppsCommands {
     },
 
     /// Show details for an app.
+    ///
+    /// Accepts either a positional name (legacy form) or `--app` for parity
+    /// with the rest of the CLI's flag-based API. Pass exactly one.
     Status {
-        /// App name or ID.
-        app_name: String,
+        /// App name or ID (positional form). Mutually exclusive with `--app`.
+        app_name: Option<String>,
+
+        /// App name or ID. Mutually exclusive with the positional form.
+        #[arg(short, long, conflicts_with = "app_name")]
+        app: Option<String>,
     },
 
     /// Permanently delete an app and all its data.
@@ -731,13 +740,22 @@ pub enum ServicesCommands {
     },
 
     /// Show details for a service (managed or user-managed).
+    ///
+    /// Accepts the service name as a positional (legacy form) or via
+    /// `--service` for parity with the rest of the CLI's flag-based API.
+    /// Pass exactly one. `--services` is accepted as a plural alias to
+    /// match the multi-service flag used by `floo logs` / `floo redeploy`.
     Info {
-        /// Service name.
-        service_name: String,
+        /// Service name (positional form). Mutually exclusive with `--service`.
+        service_name: Option<String>,
 
         /// App name or ID (uses config file if omitted).
         #[arg(short, long)]
         app: Option<String>,
+
+        /// Service name. Mutually exclusive with the positional form.
+        #[arg(long = "service", alias = "services", conflicts_with = "service_name")]
+        service: Option<String>,
     },
 
     /// Provision a managed service (postgres, redis, or storage).
@@ -927,8 +945,10 @@ pub enum ReleasesCommands {
         #[arg(short, long)]
         app: String,
 
-        /// Deploy ID to roll back to (the previous live deploy).
-        #[arg(long)]
+        /// Deploy ID to roll back to (the previous live deploy). Aliased
+        /// as `--deploy` for parity with the rest of the CLI's flag
+        /// vocabulary, which already speaks "deploy" everywhere else.
+        #[arg(long, alias = "deploy")]
         to: String,
 
         /// Skip the y/N prompt. Required in non-interactive contexts.
@@ -1023,11 +1043,20 @@ pub enum SkillsCommands {
 #[derive(Subcommand)]
 pub enum DbCommands {
     /// Run a SQL query against the app's managed database.
+    ///
+    /// Tables live in a per-app namespaced Postgres schema (e.g.
+    /// `app_<unique_id>_<env>`), not `public`. The API auto-sets
+    /// `search_path` to that schema, so unqualified references like
+    /// `SELECT * FROM users` work. Introspection queries that hard-code
+    /// `WHERE table_schema = 'public'` will return empty. Use
+    /// `current_schema()` or run `floo db schema` to see the actual schema
+    /// name.
     #[command(after_help = "\
 Examples:
   floo db query --app my-app \"SELECT id, email FROM users LIMIT 5\"
   floo db query --app my-app \"SELECT COUNT(*) FROM orders\" --env prod
-  floo db query --app my-app \"SELECT * FROM logs\" --limit 50")]
+  floo db query --app my-app \"SELECT * FROM logs\" --limit 50
+  floo db query --app my-app \"SELECT current_schema()\"   Show the namespaced schema")]
     Query {
         /// SQL query to execute.
         sql: String,
@@ -1131,13 +1160,21 @@ pub enum CronCommands {
     },
 
     /// Manually trigger a cron job by name.
+    ///
+    /// Accepts the job name positionally (legacy form) or as `--name` for
+    /// parity with the rest of the CLI's flag-based API. Pass exactly one.
     Run {
-        /// Cron job name (as defined in floo.app.toml [cron] section).
-        name: String,
+        /// Cron job name as defined in floo.app.toml [cron] section
+        /// (positional form). Mutually exclusive with `--name`.
+        name: Option<String>,
 
         /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
         app: Option<String>,
+
+        /// Cron job name. Mutually exclusive with the positional form.
+        #[arg(long = "name", conflicts_with = "name")]
+        name_flag: Option<String>,
     },
 }
 
@@ -1215,11 +1252,9 @@ fn rewrite_bare_version_flag(args: Vec<OsString>) -> Vec<OsString> {
 fn dry_run_is_unsupported(command: &Commands) -> bool {
     matches!(
         command,
-        Commands::Init { .. }
-            | Commands::Apps(AppsCommands::Github(
-                GitHubCommands::Connect { .. } | GitHubCommands::Disconnect { .. },
-            ))
-            | Commands::Releases(ReleasesCommands::Promote { .. })
+        Commands::Apps(AppsCommands::Github(
+            GitHubCommands::Connect { .. } | GitHubCommands::Disconnect { .. },
+        )) | Commands::Releases(ReleasesCommands::Promote { .. })
             | Commands::Orgs(
                 OrgsCommands::Members(MembersCommands::SetRole { .. })
                     | OrgsCommands::Switch { .. },
@@ -1249,6 +1284,7 @@ fn dry_run_is_unsupported(command: &Commands) -> bool {
 /// the suggestion text in the error will silently lie about what's supported
 /// — that drift class is exactly what this PR was opened to fix.
 const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
+    "init",
     "redeploy",
     "preflight",
     "dev",
@@ -1397,7 +1433,9 @@ pub fn run() {
 
         Commands::Apps(sub) => match sub {
             AppsCommands::List { page, per_page } => commands::apps::list(page, per_page),
-            AppsCommands::Status { app_name } => commands::apps::status(&app_name),
+            AppsCommands::Status { app_name, app } => {
+                commands::apps::status(app_name.as_deref().or(app.as_deref()))
+            }
             AppsCommands::Delete {
                 app_name,
                 confirmed,
@@ -1465,8 +1503,20 @@ pub fn run() {
 
         Commands::Services(sub) => match sub {
             ServicesCommands::List { app, env } => commands::services::list(app.as_deref(), &env),
-            ServicesCommands::Info { service_name, app } => {
-                commands::services::info(&service_name, app.as_deref())
+            ServicesCommands::Info {
+                service_name,
+                app,
+                service,
+            } => {
+                let resolved = service_name.or(service).unwrap_or_else(|| {
+                    output::error(
+                        "Service name required.",
+                        &crate::errors::ErrorCode::InvalidFormat,
+                        Some("Pass --service <name> or supply the name positionally."),
+                    );
+                    std::process::exit(1);
+                });
+                commands::services::info(&resolved, app.as_deref())
             }
             ServicesCommands::Add {
                 service_type,
@@ -1549,7 +1599,21 @@ pub fn run() {
 
         Commands::Cron(sub) => match sub {
             CronCommands::List { app } => commands::cron::list(app.as_deref()),
-            CronCommands::Run { name, app } => commands::cron::run(app.as_deref(), &name),
+            CronCommands::Run {
+                name,
+                app,
+                name_flag,
+            } => {
+                let resolved = name.or(name_flag).unwrap_or_else(|| {
+                    output::error(
+                        "Cron job name required.",
+                        &crate::errors::ErrorCode::InvalidFormat,
+                        Some("Pass --name <job> or supply the name positionally."),
+                    );
+                    std::process::exit(1);
+                });
+                commands::cron::run(app.as_deref(), &resolved)
+            }
         },
 
         Commands::Reparo(sub) => match sub {
@@ -1695,6 +1759,7 @@ mod tests {
     fn dry_run_supported_names_are_real_subcommands() {
         // Minimal required positionals so each invocation parses.
         let invocations: &[(&str, &[&str])] = &[
+            ("init", &["floo", "init", "--dry-run"]),
             ("redeploy", &["floo", "redeploy", "--dry-run"]),
             ("preflight", &["floo", "preflight", "--dry-run"]),
             ("dev", &["floo", "dev", "--dry-run"]),
@@ -1750,8 +1815,18 @@ mod tests {
 
     #[test]
     fn dry_run_unsupported_for_known_mutator() {
-        // `floo init` does not implement --dry-run; the gate must catch it.
-        let cli = Cli::try_parse_from(["floo", "init", "x", "--dry-run"]).unwrap();
+        // `floo apps github connect` does not implement --dry-run; the
+        // gate must catch it. (Replaces the prior `floo init` spot-check
+        // since `init` now implements --dry-run.)
+        let cli = Cli::try_parse_from([
+            "floo",
+            "apps",
+            "github",
+            "connect",
+            "owner/repo",
+            "--dry-run",
+        ])
+        .unwrap();
         assert!(dry_run_is_unsupported(&cli.command));
     }
 }

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -128,6 +128,25 @@ fn render_org_analytics(period: &str, data: &AppAnalyticsResponse) {
         format_number(apps_with_traffic)
     );
 
+    // Org-level latency mirrors the per-app surface (request-weighted avg,
+    // max of per-app p95s). Free-tier orgs see no latency line because the
+    // API gates these fields by tier; the absence is the same signal as on
+    // the per-app endpoint.
+    if let Some(avg) = summary.avg_latency_ms {
+        eprintln!("  {:18}{:>10}", "Avg Latency", format!("{}ms", avg));
+    }
+    if let Some(p95) = summary.p95_latency_ms {
+        eprintln!("  {:18}{:>10}", "P95 Latency", format!("{}ms", p95));
+    }
+
+    if let Some(breakdown) = &summary.status_code_breakdown {
+        if !breakdown.is_empty() {
+            eprintln!();
+            eprintln!("Status Codes");
+            render_status_code_chart(breakdown, total_requests);
+        }
+    }
+
     if !data.apps.is_empty() {
         eprintln!();
 

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -88,10 +88,18 @@ pub fn list(page: u32, per_page: u32) {
     }
 }
 
-pub fn status(app_name: &str) {
+/// Show details for an app.
+///
+/// `app_flag` is `Some` when the user passed `--app` or supplied the
+/// positional name; `None` falls back to the local config so the command
+/// "just works" inside a project directory. clap enforces that the
+/// positional form and the `--app` flag are mutually exclusive, so we
+/// don't have to reconcile them here.
+pub fn status(app_flag: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
-    let app = super::resolve_app_or_exit(&client, app_name);
+    let (_, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let app = super::resolve_app_or_exit(&client, &app_name);
 
     if output::is_json_mode() {
         output::success(&format!("App {}", app.name), Some(output::to_value(&app)));

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -32,6 +32,19 @@ pub fn query(app_flag: Option<&str>, sql: &str, environment: &str, limit: u32) {
 
     if rows_arr.is_empty() {
         output::info("0 rows", None);
+        if queries_public_schema(sql) {
+            // The API auto-sets `search_path` to the app's namespaced schema
+            // (e.g. `app_<id>_dev`), so unqualified table refs work. Explicit
+            // `WHERE table_schema = 'public'` queries return empty because
+            // the app's tables are not in `public`. Surface the hint before
+            // the user copy-pastes the next variant of the same query.
+            output::info(
+                "This app's tables live in a namespaced schema, not 'public'. \
+                 Run `floo db schema` to see the schema name, or use \
+                 `current_schema()` / `WHERE table_schema = current_schema()`.",
+                None,
+            );
+        }
         return;
     }
 
@@ -88,6 +101,14 @@ pub fn schema(app_flag: Option<&str>) {
     }
 
     // Human mode: print tables with columns and types.
+    if let Some(schema_name) = result.get("schema_name").and_then(|v| v.as_str()) {
+        // Surface the namespaced schema name up-front so anyone writing raw
+        // SQL has the schema to qualify against. The API auto-applies it
+        // via `search_path` for /db/query, but introspection queries that
+        // hard-code `table_schema = 'public'` return empty without it.
+        output::info(&format!("Schema: {schema_name}"), None);
+    }
+
     let tables_val = result.get("tables");
     let Some(tables_arr) = tables_val.and_then(|v| v.as_array()) else {
         output::info("No schema information available.", None);
@@ -303,6 +324,23 @@ pub fn connections(app_flag: Option<&str>, env: &str) {
     }
 }
 
+/// Detect SQL that explicitly filters on `table_schema = 'public'` (or
+/// `schemaname = 'public'`, the pg_catalog spelling): the canonical
+/// "list my tables" pattern that returns empty against a floo app
+/// because tables live in a namespaced schema. Used to gate a one-line
+/// hint after a 0-row result.
+fn queries_public_schema(sql: &str) -> bool {
+    let lower: String = sql
+        .to_lowercase()
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    lower.contains("table_schema='public'")
+        || lower.contains("table_schema=\"public\"")
+        || lower.contains("schemaname='public'")
+        || lower.contains("schemaname=\"public\"")
+}
+
 fn value_to_display(v: &Value) -> String {
     match v {
         Value::Null => "NULL".to_string(),
@@ -338,5 +376,46 @@ mod tests {
     #[test]
     fn test_value_to_display_string() {
         assert_eq!(value_to_display(&json!("hello")), "hello");
+    }
+
+    #[test]
+    fn test_queries_public_schema_information_schema() {
+        assert!(queries_public_schema(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+        ));
+    }
+
+    #[test]
+    fn test_queries_public_schema_double_quotes() {
+        assert!(queries_public_schema(
+            "SELECT * FROM information_schema.tables WHERE table_schema = \"public\""
+        ));
+    }
+
+    #[test]
+    fn test_queries_public_schema_pg_stat() {
+        assert!(queries_public_schema(
+            "SELECT * FROM pg_stat_user_tables WHERE schemaname = 'public'"
+        ));
+    }
+
+    #[test]
+    fn test_queries_public_schema_qualified_table() {
+        // `public.users` is just an unqualified-from-schema-pov reference,
+        // not the introspection pattern we're flagging. A user explicitly
+        // querying public schema tables likely knows what they're doing.
+        assert!(!queries_public_schema("SELECT * FROM public.users"));
+    }
+
+    #[test]
+    fn test_queries_public_schema_unrelated() {
+        assert!(!queries_public_schema("SELECT * FROM users"));
+    }
+
+    #[test]
+    fn test_queries_public_schema_case_insensitive() {
+        assert!(queries_public_schema(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'public'"
+        ));
     }
 }

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -41,13 +41,16 @@ pub fn status(app: Option<&str>, deploy_id: Option<&str>) {
     };
 
     let deploy = match deploy_id {
-        Some(id) => match client.get_deploy(&app_id, id) {
-            Ok(d) => d,
-            Err(e) => {
-                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-                process::exit(1);
+        Some(id) => {
+            let full_id = resolve_deploy_id(&client, &app_id, id);
+            match client.get_deploy(&app_id, &full_id) {
+                Ok(d) => d,
+                Err(e) => {
+                    output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                    process::exit(1);
+                }
             }
-        },
+        }
         None => match client.list_deploys(&app_id) {
             Ok(list) => match list.deploys.into_iter().next() {
                 Some(d) => d,
@@ -240,7 +243,7 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
     let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
 
     let resolved_deploy_id: String = match deploy_id {
-        Some(id) => id.to_string(),
+        Some(id) => resolve_deploy_id(&client, &app_id, id),
         None => {
             let result = match client.list_deploys(&app_id) {
                 Ok(r) => r,
@@ -392,6 +395,101 @@ fn truncate_id(id: &str) -> String {
         format!("{}...", &id[..8])
     } else {
         id.to_string()
+    }
+}
+
+/// Returns true when `id` is a full UUID (32 hex chars or 36 with dashes).
+/// We want to skip the prefix-resolution round trip in that case (the API
+/// validates the shape). Anything shorter is treated as a prefix and
+/// matched against the deploy list.
+fn is_full_uuid(id: &str) -> bool {
+    let len = id.len();
+    if len != 32 && len != 36 {
+        return false;
+    }
+    id.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+}
+
+fn strip_truncation_marker(id: &str) -> &str {
+    id.strip_suffix("...").unwrap_or(id)
+}
+
+/// True for hex-shaped strings (0-9a-f, optional dashes), i.e. shapes that
+/// could be a UUID prefix. We only attempt prefix-resolution against the
+/// deploy list for these. Anything outside this character set bypasses the
+/// resolver and is passed straight to the API, which keeps the door open for
+/// future non-UUID identifiers and means fixture IDs like `deploy-456` in
+/// tests do not trigger an extra mock requirement.
+fn looks_like_uuid_prefix(id: &str) -> bool {
+    !id.is_empty() && id.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+}
+
+/// Resolve a partial deploy id (git-style prefix) to a full deploy id by
+/// listing the app's deploys and matching by prefix. A full UUID is
+/// returned unchanged (cheap, avoids the list call). Errors and exits the
+/// process with a friendly message when the prefix matches zero or
+/// multiple deploys, replacing the raw FastAPI validation array that
+/// users were seeing when they copy-pasted the truncated id from the
+/// table view.
+pub(crate) fn resolve_deploy_id(client: &FlooClient, app_id: &str, partial: &str) -> String {
+    let partial = strip_truncation_marker(partial);
+
+    if partial.is_empty() {
+        output::error(
+            "Empty deploy ID.",
+            &ErrorCode::DeployNotFound,
+            Some("Pass a deploy ID. Run `floo deploys list --app <name>` to see them."),
+        );
+        process::exit(1);
+    }
+
+    if is_full_uuid(partial) {
+        return partial.to_string();
+    }
+
+    // Non-UUID-shaped strings (e.g. test fixture IDs) bypass prefix
+    // resolution; we pass them through and let the API decide.
+    if !looks_like_uuid_prefix(partial) {
+        return partial.to_string();
+    }
+
+    let deploys = match client.list_deploys(app_id) {
+        Ok(r) => r.deploys,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let matches: Vec<&Deploy> = deploys
+        .iter()
+        .filter(|d| d.id.starts_with(partial))
+        .collect();
+
+    match matches.as_slice() {
+        [single] => single.id.clone(),
+        [] => {
+            output::error(
+                &format!("No deploy found matching '{partial}'."),
+                &ErrorCode::DeployNotFound,
+                Some("Run `floo deploys list --app <name>` to see full deploy IDs."),
+            );
+            process::exit(1);
+        }
+        many => {
+            let preview: Vec<&str> = many.iter().take(3).map(|d| d.id.as_str()).collect();
+            output::error(
+                &format!(
+                    "Deploy ID '{partial}' is ambiguous ({} matches: {}{}).",
+                    many.len(),
+                    preview.join(", "),
+                    if many.len() > 3 { ", ..." } else { "" },
+                ),
+                &ErrorCode::DeployNotFound,
+                Some("Use more characters of the deploy ID, or run `floo deploys list --app <name>`."),
+            );
+            process::exit(1);
+        }
     }
 }
 
@@ -796,5 +894,61 @@ mod tests {
     fn test_relative_time_boundary_60_minutes() {
         let ts = (Utc::now() - chrono::Duration::minutes(60)).to_rfc3339();
         assert_eq!(relative_time(&ts), "1h ago");
+    }
+
+    #[test]
+    fn test_is_full_uuid_dashed() {
+        assert!(is_full_uuid("fed461a6-7c12-4abc-89de-0123456789ab"));
+    }
+
+    #[test]
+    fn test_is_full_uuid_undashed() {
+        assert!(is_full_uuid("fed461a67c124abc89de0123456789ab"));
+    }
+
+    #[test]
+    fn test_is_full_uuid_rejects_prefix() {
+        assert!(!is_full_uuid("fed461a6"));
+    }
+
+    #[test]
+    fn test_is_full_uuid_rejects_with_truncation_marker() {
+        assert!(!is_full_uuid("fed461a6..."));
+    }
+
+    #[test]
+    fn test_is_full_uuid_rejects_non_hex() {
+        assert!(!is_full_uuid("zed461a6-7c12-4abc-89de-0123456789ab"));
+    }
+
+    #[test]
+    fn test_strip_truncation_marker_present() {
+        assert_eq!(strip_truncation_marker("fed461a6..."), "fed461a6");
+    }
+
+    #[test]
+    fn test_strip_truncation_marker_absent() {
+        assert_eq!(strip_truncation_marker("fed461a6"), "fed461a6");
+    }
+
+    #[test]
+    fn test_looks_like_uuid_prefix_hex() {
+        assert!(looks_like_uuid_prefix("fed461a6"));
+    }
+
+    #[test]
+    fn test_looks_like_uuid_prefix_with_dash() {
+        assert!(looks_like_uuid_prefix("fed461a6-7c12"));
+    }
+
+    #[test]
+    fn test_looks_like_uuid_prefix_rejects_letters_outside_hex() {
+        // 'p', 'l', 'o', 'y' are not hex digits, so this is not a UUID prefix
+        assert!(!looks_like_uuid_prefix("deploy-456"));
+    }
+
+    #[test]
+    fn test_looks_like_uuid_prefix_rejects_empty() {
+        assert!(!looks_like_uuid_prefix(""));
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -43,11 +43,101 @@ pub fn init(name: Option<String>, path: PathBuf) {
 
     let detection = detect(&project_path);
 
+    if output::is_dry_run_mode() {
+        // `floo init --dry-run` is non-interactive by contract: a preview
+        // should never block on prompts. We pick the same scaffold the
+        // non-interactive path would write (auto-generated app name when
+        // none is given) and emit it as a JSON/human plan. Closes
+        // feedback 87b756f9 (2026-05-01).
+        init_dry_run(&project_path, name, &detection);
+        return;
+    }
+
     if output::is_interactive() {
         init_interactive(&project_path, name, &detection);
     } else {
         init_non_interactive(&project_path, name, &detection);
     }
+}
+
+fn init_dry_run(project_path: &std::path::Path, name: Option<String>, detection: &DetectionResult) {
+    let app_name = name.unwrap_or_else(|| {
+        // Mirror init_interactive's default-name behaviour. Non-interactive
+        // dry-run can't ask, so we surface the would-be name in the preview;
+        // users who care about a specific name pass it as an arg.
+        crate::names::generate_name()
+    });
+
+    let default_type = detection.default_service_type();
+    let service_type = match default_type {
+        "api" => ServiceType::Api,
+        _ => ServiceType::Web,
+    };
+    let port = detection.default_port();
+    let env_file = super::detect_env_file(project_path);
+
+    let agents_md_exists = project_path.join("AGENTS.md").exists();
+    let dockerfile_exists = project_path.join("Dockerfile").exists();
+
+    // Mirror generate_dockerfile_if_needed's auto-generate gate exactly:
+    // high/medium confidence only. Low confidence prompts in interactive
+    // mode and skips otherwise. Dry-run is non-interactive, so it skips.
+    let dockerfile_will_generate = !dockerfile_exists
+        && detection.runtime != "docker"
+        && (detection.confidence == "high" || detection.confidence == "medium")
+        && dockerfile::generate_dockerfile(detection, project_path).is_some();
+
+    let mut planned_files: Vec<&str> = vec![project_config::APP_CONFIG_FILE];
+    if dockerfile_will_generate {
+        planned_files.push("Dockerfile");
+    }
+    if !agents_md_exists {
+        planned_files.push("AGENTS.md");
+    }
+
+    let preview = {
+        let mut lines = vec![
+            format!(
+                "Would initialize app '{app_name}' in '{}':",
+                project_path.display()
+            ),
+            format!("  service '{default_type}' (type={service_type}, port={port})"),
+        ];
+        for f in &planned_files {
+            lines.push(format!("  create {f}"));
+        }
+        if agents_md_exists {
+            lines.push("  skip AGENTS.md (already exists)".to_string());
+        }
+        if dockerfile_exists {
+            lines.push("  skip Dockerfile (already exists)".to_string());
+        } else if !dockerfile_will_generate && detection.runtime != "docker" {
+            lines.push(
+                "  skip Dockerfile (no runtime detected with sufficient confidence)".to_string(),
+            );
+        }
+        lines.join("\n")
+    };
+
+    output::dry_run_preview(
+        &preview,
+        serde_json::json!({
+            "action": "init",
+            "app_name": app_name,
+            "project_path": project_path.display().to_string(),
+            "files_to_create": planned_files,
+            "agents_md_exists": agents_md_exists,
+            "dockerfile_exists": dockerfile_exists,
+            "dockerfile_will_generate": dockerfile_will_generate,
+            "detection": detection.to_value(),
+            "service": {
+                "name": default_type,
+                "type": service_type.to_string(),
+                "port": port,
+                "env_file": env_file,
+            },
+        }),
+    );
 }
 
 /// Agent-safe operating notes scaffold. Written next to floo.app.toml on

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -613,7 +613,12 @@ pub fn request_logs(args: RequestLogsArgs) {
     };
 
     if output::is_json_mode() {
-        output::print_json(&output::to_value(&result));
+        let message = if result.requests.is_empty() {
+            "No requests found."
+        } else {
+            "Request logs retrieved."
+        };
+        output::success(message, Some(output::to_value(&result)));
         return;
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -112,15 +112,34 @@ pub(crate) fn load_app_config_for_resolved_app(
 ) -> Result<crate::project_config::AppFileConfig, FlooError> {
     match crate::project_config::load_app_config(&resolved.config_dir)? {
         Some(config) => Ok(config),
-        None => Err(FlooError::with_suggestion(
-            ErrorCode::NoConfigFound,
-            format!(
-                "No {} found in '{}'.",
-                crate::project_config::APP_CONFIG_FILE,
-                resolved.config_dir.display()
-            ),
-            "Run 'floo init' to create a project config, or cd to your project root.".to_string(),
-        )),
+        None => {
+            // When the caller passed `--app`, the flag's help text reads
+            // "reads from config if omitted", which suggests it can fully
+            // substitute for the local config. It can't: `floo.app.toml`
+            // is also where service definitions live, and `dev` / `run`
+            // need those. Disambiguate here so the error doesn't read
+            // like the flag was ignored.
+            let suggestion = match resolved.source {
+                crate::project_config::AppSource::Flag => {
+                    "--app sets the app name but service definitions still come \
+                     from floo.app.toml. cd to your project root, or run \
+                     'floo init' if this directory is a new project."
+                        .to_string()
+                }
+                _ => "Run 'floo init' to create a project config, or cd to your \
+                      project root."
+                    .to_string(),
+            };
+            Err(FlooError::with_suggestion(
+                ErrorCode::NoConfigFound,
+                format!(
+                    "No {} found in '{}'.",
+                    crate::project_config::APP_CONFIG_FILE,
+                    resolved.config_dir.display()
+                ),
+                suggestion,
+            ))
+        }
     }
 }
 
@@ -200,5 +219,35 @@ dev_command = "npm run dev"
         let err = load_app_config_for_resolved_app(&resolved).unwrap_err();
         assert_eq!(err.code, ErrorCode::NoConfigFound);
         assert!(err.message.contains(&dir.path().display().to_string()));
+    }
+
+    #[test]
+    fn load_app_config_for_resolved_app_explains_app_flag_when_used() {
+        // Regression for feedback 65b28405 (2026-05-01): `floo dev --app X`
+        // run from a directory without floo.app.toml errored with the same
+        // generic suggestion as no-flag mode. The flag's --help reads "reads
+        // from config if omitted" which implies it can substitute for the
+        // file; the error must be honest that service definitions still
+        // live in the file.
+        let dir = TempDir::new().unwrap();
+        let resolved = crate::project_config::ResolvedApp {
+            app_name: "via-flag".to_string(),
+            source: crate::project_config::AppSource::Flag,
+            service_config: None,
+            app_config: None,
+            config_dir: dir.path().to_path_buf(),
+        };
+
+        let err = load_app_config_for_resolved_app(&resolved).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoConfigFound);
+        let suggestion = err.suggestion.expect("suggestion should be present");
+        assert!(
+            suggestion.contains("--app"),
+            "suggestion should explain --app: {suggestion}"
+        );
+        assert!(
+            suggestion.contains("service definitions"),
+            "suggestion should mention service definitions: {suggestion}"
+        );
     }
 }

--- a/src/commands/rollbacks.rs
+++ b/src/commands/rollbacks.rs
@@ -29,6 +29,12 @@ pub fn rollback(app_name: &str, deploy_id: &str, yes: bool) {
     let name = &app_data.name;
     let app_id = &app_data.id;
 
+    // Accept truncated UUIDs from `floo deploys list` output (`fed461a6...`)
+    // via git-style prefix resolution. Without this, the API returns a raw
+    // FastAPI validation array that surfaces as an unformatted error.
+    let deploy_id = super::deploys::resolve_deploy_id(&client, app_id, deploy_id);
+    let deploy_id = deploy_id.as_str();
+
     match confirm_tier2("Rollback", &format!("{name} to deploy {deploy_id}"), yes) {
         ConfirmOutcome::Proceed => {}
         ConfirmOutcome::Aborted => {

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -220,6 +220,24 @@ fn test_apps_status_json() {
 }
 
 #[test]
+fn test_apps_status_with_app_flag() {
+    // Parity with the rest of the CLI's flag-based API: `--app` is
+    // accepted in addition to the legacy positional form. Closes
+    // feedback 4419e7d3 (2026-05-01) for the `apps status` surface.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    floo()
+        .args(["--json", "apps", "status", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(TEST_APP_ID));
+}
+
+#[test]
 fn test_apps_status_json_surfaces_runtime_url() {
     let mut server = Server::new();
     let home = setup_config(&server);
@@ -513,6 +531,11 @@ fn test_env_remove_json() {
 
 #[test]
 fn test_env_get_json() {
+    // PR #138 made `--json` redact secret-shaped values by default and
+    // stamp the payload with `contains_secrets: true`. `floo env get` is
+    // the canonical secret-fetch surface, so the redacted shape is what
+    // agents will see; revealing the plaintext now requires the explicit
+    // global flag (covered by `test_env_get_json_reveal_secrets` below).
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -535,6 +558,47 @@ fn test_env_get_json() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""contains_secrets":true"#))
+        .stdout(predicate::str::contains(r#""value":"***REDACTED***""#))
+        .stdout(predicate::str::contains("secret123").not());
+}
+
+#[test]
+fn test_env_get_json_reveal_secrets() {
+    // `--reveal-secrets` opts back in to plaintext for callers that
+    // control where the JSON goes. The `contains_secrets` marker still
+    // fires so harnesses can detect-and-refuse even under reveal.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+
+    let _m_get = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/env/MY_KEY").as_str())
+        .match_query(Matcher::UrlEncoded(
+            "service_id".into(),
+            TEST_SERVICE_ID.into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"key":"MY_KEY","value":"secret123"}"#)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "--reveal-secrets",
+            "env",
+            "get",
+            "MY_KEY",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""contains_secrets":true"#))
         .stdout(predicate::str::contains("secret123"));
 }
 
@@ -1311,14 +1375,23 @@ fn test_logs_requests_json_default_tail() {
         )
         .create();
 
-    floo()
+    let assert = floo()
         .args(["--json", "logs", "--requests", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
-        .success()
-        .stdout(predicate::str::contains("requests"))
-        .stdout(predicate::str::contains("/"))
-        .stdout(predicate::str::contains("401"));
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be a single JSON envelope");
+    assert_eq!(envelope["success"], serde_json::Value::Bool(true));
+    let data = &envelope["data"];
+    assert!(data.is_object(), "data must be the request-logs payload");
+    assert_eq!(data["total"], serde_json::json!(1));
+    assert_eq!(data["app_name"], serde_json::json!("my-app"));
+    let requests = data["requests"].as_array().expect("requests array");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["status_code"], serde_json::json!(401));
 }
 
 #[test]


### PR DESCRIPTION
## What changed
Closes seven items from the 2026-05-01 floo-alerts batch (team@getfloo.com agent feedback):

| Feedback | Fix |
|---|---|
| 2884d9ac (bug) | \`floo logs --requests --json\` now emits the \`{success, data}\` envelope, matching every other \`--json\` command. |
| 6afe0383 (friction) | Deploy IDs accept git-style prefixes. Truncated IDs from \`floo deploys list\` (\`fed461a6...\`) now resolve via \`resolve_deploy_id\` in \`deploys.rs\`. Replaces the raw FastAPI validation array with a clear ambiguity / not-found error. Wired into \`deploys logs\`, \`deploys status\`, and \`releases rollback\`. |
| 28eb1e65 (friction) | \`floo db query\` hints when a 0-row result came from \`table_schema = 'public'\`. \`floo db schema\` displays the namespaced schema name (paired with API change in getfloo/floo). |
| 65b28405 (friction) | \`floo dev/run --app\` errors clearly when no \`floo.app.toml\` is present, calling out that service definitions still live in the file. \`--app\` help text updated to be honest. |
| 0a1efb4a (friction) | CLI renders org-level avg/p95 latency and status-code chart in human + JSON when present (paired with API change). |
| 87b756f9 (friction) | \`floo init --dry-run\` previews app name, planned files, service shape, and Dockerfile decision without writing anything. |
| 4419e7d3 (friction) | Argument naming parity. \`apps status --app\`, \`services info --app --service\` (with \`--services\` alias), \`cron run --name\`, \`releases rollback --deploy\` (alias for \`--to\`). Positional forms still work. |

## Why
Single-batch resolution lands the whole class together: every report came from the same floo-alerts run on 2026-05-01 by an agent shaking out the CLI surface. Splitting them across 7 PRs would just be churn for the same review priors.

## Risk tier
standard — pure CLI changes, no auth/wire-boundary surface. Two paired API changes (analytics latency parity, db schema_name) ship in getfloo/floo separately and the CLI is null-safe against the pre-API state.

## Files reviewers should scrutinize
- \`src/commands/deploys.rs\` — new \`resolve_deploy_id\` helper. The hex-only gate prevents the resolver from breaking fixture-id callers like \`deploy-456\`.
- \`src/cli.rs\` — three subcommands grew \`Option<String>\` positionals + \`conflicts_with\` flag pairs. Existing positional invocations still parse.
- \`src/commands/init.rs\` — new \`init_dry_run\` mirrors \`init_non_interactive\` semantics; auto-name fallback uses the same \`names::generate_name\`.

## Tests run
\`\`\`
cargo test --bin floo            → 379 passed
cargo test --test mock_api_tests → 71 passed (incl. new test_env_get_json_reveal_secrets and test_apps_status_with_app_flag)
cargo clippy --bin floo -- -D warnings → clean
\`\`\`

The pre-existing \`test_env_get_json\` failure on main was brought in line with the #138 redaction contract; new \`test_env_get_json_reveal_secrets\` pins the \`--reveal-secrets\` round-trip.

## Known non-goals
- API-side schema_name + analytics latency parity ship as a separate PR in getfloo/floo (the CLI deserialises both fields as \`Option\` and is null-safe before that lands).
- The argument-naming additions are additive only. We do not deprecate or remove any positional form in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)