### PR TITLE
feat(cli): agent-intuitive subcommand aliases (show/unset) + cron show

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -426,6 +426,11 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_cron_job(&self, app_id: &str, name: &str) -> Result<CronJobResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/cron/{name}"))?;
+        self.handle_response(resp)
+    }
+
     pub fn run_cron_job(
         &self,
         app_id: &str,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -232,7 +232,7 @@ Note: To trigger a deploy, use `floo redeploy` or push to GitHub.
         after_help = "\
 Examples:
   floo apps list --json                    List all apps
-  floo apps status my-app --json           App details and service info
+  floo apps show my-app --json             App details and service info
   floo apps delete my-app                  Delete (typed-name confirmation)
   floo apps delete my-app --yes-i-know-this-destroys-data  Skip prompt (CI-only)"
     )]
@@ -370,14 +370,15 @@ Examples:
 List and trigger scheduled cron jobs for an app.
 
 Cron jobs are declared in floo.app.toml under [cron.<name>] sections — they
-are not created with the CLI. This command surface is read-only (`list`) plus
-manual trigger (`run`); jobs are reconciled from config on every deploy.
+are not created with the CLI. This command surface is read-only (`list`, `show`)
+plus manual trigger (`run`); jobs are reconciled from config on every deploy.
 
 See `floo docs app-toml` (look for 'Cron Jobs') for the full [cron.<name>]
 schema, or https://getfloo.com/docs/guides/cron-jobs for the long-form guide.",
         after_help = "\
 Examples:
   floo cron list --app my-app              List all cron jobs and their last run status
+  floo cron show daily-report --app my-app Show details for a single cron job
   floo cron run daily-report --app my-app  Manually trigger a cron job
 
 Schedules are declared in floo.app.toml under [cron.<name>]. This CLI is
@@ -531,9 +532,10 @@ pub enum AppsCommands {
 
     /// Show details for an app.
     ///
-    /// Accepts either a positional name (legacy form) or `--app` for parity
-    /// with the rest of the CLI's flag-based API. Pass exactly one.
-    Status {
+    /// Accepts either a positional name or `--app` for parity with the rest
+    /// of the CLI's flag-based API. Pass exactly one.
+    #[command(alias = "status")]
+    Show {
         /// App name or ID (positional form). Mutually exclusive with `--app`.
         app_name: Option<String>,
 
@@ -667,6 +669,7 @@ pub enum EnvCommands {
     },
 
     /// Remove an environment variable from an app.
+    #[command(alias = "unset")]
     Remove {
         /// Environment variable key to remove.
         key: String,
@@ -741,11 +744,12 @@ pub enum ServicesCommands {
 
     /// Show details for a service (managed or user-managed).
     ///
-    /// Accepts the service name as a positional (legacy form) or via
-    /// `--service` for parity with the rest of the CLI's flag-based API.
-    /// Pass exactly one. `--services` is accepted as a plural alias to
-    /// match the multi-service flag used by `floo logs` / `floo redeploy`.
-    Info {
+    /// Accepts the service name as a positional or via `--service` for parity
+    /// with the rest of the CLI's flag-based API. Pass exactly one.
+    /// `--services` is accepted as a plural alias to match the multi-service
+    /// flag used by `floo logs` / `floo redeploy`.
+    #[command(alias = "info")]
+    Show {
         /// Service name (positional form). Mutually exclusive with `--service`.
         service_name: Option<String>,
 
@@ -880,7 +884,8 @@ pub enum DomainsCommands {
     },
 
     /// Show detailed status for a single custom domain.
-    Status {
+    #[command(alias = "status")]
+    Show {
         /// Domain hostname.
         hostname: String,
 
@@ -1159,6 +1164,23 @@ pub enum CronCommands {
         app: Option<String>,
     },
 
+    /// Show details for a single cron job (schedule, status, last run).
+    ///
+    /// Accepts the job name positionally or as `--name` for parity with
+    /// the rest of the CLI's flag-based API. Pass exactly one.
+    Show {
+        /// Cron job name (positional form). Mutually exclusive with `--name`.
+        name: Option<String>,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Cron job name. Mutually exclusive with the positional form.
+        #[arg(long = "name", conflicts_with = "name")]
+        name_flag: Option<String>,
+    },
+
     /// Manually trigger a cron job by name.
     ///
     /// Accepts the job name positionally (legacy form) or as `--name` for
@@ -1433,7 +1455,7 @@ pub fn run() {
 
         Commands::Apps(sub) => match sub {
             AppsCommands::List { page, per_page } => commands::apps::list(page, per_page),
-            AppsCommands::Status { app_name, app } => {
+            AppsCommands::Show { app_name, app } => {
                 commands::apps::status(app_name.as_deref().or(app.as_deref()))
             }
             AppsCommands::Delete {
@@ -1503,7 +1525,7 @@ pub fn run() {
 
         Commands::Services(sub) => match sub {
             ServicesCommands::List { app, env } => commands::services::list(app.as_deref(), &env),
-            ServicesCommands::Info {
+            ServicesCommands::Show {
                 service_name,
                 app,
                 service,
@@ -1553,7 +1575,7 @@ pub fn run() {
                 services,
                 yes,
             } => commands::domains::remove(&hostname, app.as_deref(), services.as_deref(), yes),
-            DomainsCommands::Status { hostname, app } => {
+            DomainsCommands::Show { hostname, app } => {
                 commands::domains::status(&hostname, app.as_deref())
             }
             DomainsCommands::Watch {
@@ -1599,6 +1621,21 @@ pub fn run() {
 
         Commands::Cron(sub) => match sub {
             CronCommands::List { app } => commands::cron::list(app.as_deref()),
+            CronCommands::Show {
+                name,
+                app,
+                name_flag,
+            } => {
+                let resolved = name.or(name_flag).unwrap_or_else(|| {
+                    output::error(
+                        "Cron job name required.",
+                        &crate::errors::ErrorCode::InvalidFormat,
+                        Some("Pass --name <job> or supply the name positionally."),
+                    );
+                    std::process::exit(1);
+                });
+                commands::cron::show(app.as_deref(), &resolved)
+            }
             CronCommands::Run {
                 name,
                 app,

--- a/src/commands/cron.rs
+++ b/src/commands/cron.rs
@@ -58,6 +58,48 @@ pub fn list(app_flag: Option<&str>) {
     );
 }
 
+pub fn show(app_flag: Option<&str>, name: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app_flag);
+
+    let result = match client.get_cron_job(&app_id, name) {
+        Ok(r) => r,
+        Err(e) => {
+            let suggestion = if e.code == "NOT_FOUND" {
+                Some("Run `floo cron list` to see available cron jobs.")
+            } else {
+                None
+            };
+            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success("Cron job details.", Some(output::to_value(&result)));
+        return;
+    }
+
+    let status = result.last_status.as_deref().unwrap_or("-");
+    let last_run = result.last_run_at.as_deref().unwrap_or("never");
+    let enabled = if result.enabled { "yes" } else { "no" };
+
+    output::table(
+        &["Field", "Value"],
+        &[
+            vec!["Name".to_string(), result.name.clone()],
+            vec!["Schedule".to_string(), result.schedule.clone()],
+            vec!["Command".to_string(), result.command.clone()],
+            vec!["Service".to_string(), result.service_name.clone()],
+            vec!["Enabled".to_string(), enabled.to_string()],
+            vec!["Last Status".to_string(), status.to_string()],
+            vec!["Last Run".to_string(), last_run.to_string()],
+        ],
+        None,
+    );
+}
+
 pub fn run(app_flag: Option<&str>, name: &str) {
     // Dry-run is a pure echo: every other --dry-run handler in the CLI
     // (apps.rs, domains.rs, env.rs, rollbacks.rs, deploy.rs) checks

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -738,9 +738,7 @@ pub fn deploy(
         // from the connected service in the response.
         let app_url = format!("https://app.getfloo.com/{}", app_data.name);
         output::info(
-            &format!(
-                "  Next deploys: push to your default branch. Manage at {app_url}"
-            ),
+            &format!("  Next deploys: push to your default branch. Manage at {app_url}"),
             None,
         );
     }
@@ -1670,9 +1668,7 @@ fn display_preflight_human(
         // the auto-deploy contract here means they don't have to leave for
         // the docs to learn what `git push` will do next.
         eprintln!();
-        eprintln!(
-            "  Deploys: dev auto-deploys on every `git push` to your default branch."
-        );
+        eprintln!("  Deploys: dev auto-deploys on every `git push` to your default branch.");
         eprintln!("           Cut a GitHub release to promote the same build to production.");
         eprintln!(
             "           See https://getfloo.com/docs/guides/golden-path.md for the full flow."

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -49,8 +49,8 @@ fn extract_unknown_field(msg: &str) -> Option<&str> {
 #[cfg(test)]
 pub use app_config::AppServiceType;
 pub use app_config::{
-    load_app_config, write_app_config_with_header, AppAccessMode, AppAgentMode,
-    AppFileAppSection, AppFileConfig, AppServiceEntry, GitHubConfig, ReparoConfig,
+    load_app_config, write_app_config_with_header, AppAccessMode, AppAgentMode, AppFileAppSection,
+    AppFileConfig, AppServiceEntry, GitHubConfig, ReparoConfig,
 };
 pub use discover::{
     discover_managed_services, discover_services, filter_services, ManagedServiceDeclaration,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -376,9 +376,9 @@ fn test_domains_list_not_authenticated() {
 // --- Services (unauthenticated) ---
 
 #[test]
-fn test_services_info_not_authenticated() {
+fn test_services_show_not_authenticated() {
     floo()
-        .args(["services", "info", "db", "--app", "my-app"])
+        .args(["services", "show", "db", "--app", "my-app"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -386,13 +386,23 @@ fn test_services_info_not_authenticated() {
 }
 
 #[test]
-fn test_services_info_json_not_authenticated() {
+fn test_services_show_json_not_authenticated() {
     floo()
-        .args(["--json", "services", "info", "db", "--app", "my-app"])
+        .args(["--json", "services", "show", "db", "--app", "my-app"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
         .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
+}
+
+#[test]
+fn test_services_info_alias_not_authenticated() {
+    floo()
+        .args(["services", "info", "db", "--app", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
 }
 
 // --- Env format validation ---
@@ -829,9 +839,15 @@ fn test_init_writes_header_with_access_mode_and_autodeploy_signal() {
         .success();
 
     let toml = std::fs::read_to_string(project.path().join("floo.app.toml")).unwrap();
-    assert!(toml.starts_with("# floo.app.toml"), "header should lead the file");
+    assert!(
+        toml.starts_with("# floo.app.toml"),
+        "header should lead the file"
+    );
     // git push auto-deploy contract is mentioned by name.
-    assert!(toml.contains("git push"), "git push contract must be in header");
+    assert!(
+        toml.contains("git push"),
+        "git push contract must be in header"
+    );
     // access_mode is shown under [app] — the placement that actually applies
     // on push today. Per-env overrides via [environments.<name>] are parsed
     // but not applied server-side; the header discloses that gap explicitly
@@ -1416,6 +1432,46 @@ fn test_dry_run_cron_run_human_has_preview() {
         .stderr(predicate::str::contains(
             "Would trigger cron job 'myjob' on test",
         ));
+}
+
+#[test]
+fn test_cron_show_not_authenticated() {
+    floo()
+        .args(["cron", "show", "myjob", "--app", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
+}
+
+#[test]
+fn test_cron_show_json_not_authenticated() {
+    floo()
+        .args(["--json", "cron", "show", "myjob", "--app", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
+}
+
+#[test]
+fn test_cron_run_not_authenticated() {
+    floo()
+        .args(["cron", "run", "myjob", "--app", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not logged in."));
+}
+
+#[test]
+fn test_cron_run_json_not_authenticated() {
+    floo()
+        .args(["--json", "cron", "run", "myjob", "--app", "my-app"])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
 }
 
 #[test]


### PR DESCRIPTION
## What changed

Rename resource-detail subcommands to the verb agents expect (`show`) with backward-compatible aliases for the old names:

| Old | New | Alias preserved |
|---|---|---|
| `floo apps status` | `floo apps show` | `status` |
| `floo services info` | `floo services show` | `info` |
| `floo domains status` | `floo domains show` | `status` |
| `floo env remove` | `floo env remove` | adds `unset` alias |

Add `floo cron show <name>` — fetches a single cron job from `GET /v1/apps/{id}/cron/{name}` and renders schedule, command, service, enabled flag, and last run/status. Closes the read-surface gap: `list` existed but there was no way to inspect one job.

## Why

Agents are RLHF-trained on massive codebases where `show`/`describe`/`get` are the canonical verbs for single-resource detail and `unset` is canonical for env var removal. When an agent tries `floo apps show my-app` and gets "unrecognized subcommand", it loses confidence in the CLI surface and resorts to brittle workarounds (piping `list` through jq, hallucinating flags). Making the CLI match agent priors means fewer retries, less prompt engineering, and fewer bugs in agent workflows.

`cron show` closes the CRUD completeness gap — `list` without a single-resource view forces agents to filter list output rather than requesting directly.

## Risk tier

standard

## Files reviewers should scrutinize

- `src/cli.rs` — enum variant renames + new `CronCommands::Show` variant and match arm
- `src/commands/cron.rs` — new `show()` function
- `src/api_client.rs` — new `get_cron_job()` method

## Tests run

`cargo test`: 104 passed, 2 pre-existing failures (`test_dry_run_unsupported_init`, `test_preflight_warns_for_rails_cloudsql_socket_database_url`) unrelated to this change.

Added: `test_cron_show_not_authenticated`, `test_cron_show_json_not_authenticated`, `test_cron_run_not_authenticated`, `test_cron_run_json_not_authenticated`, `test_services_info_alias_not_authenticated`.

## Known non-goals

- No changes to API (endpoint already existed)
- `CronJobRunResponse` schema fix (pending PR #142) is a separate concern