### PR TITLE
fix(cli): drop backward-compat aliases, rename env remove → env unset

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -534,7 +534,6 @@ pub enum AppsCommands {
     ///
     /// Accepts either a positional name or `--app` for parity with the rest
     /// of the CLI's flag-based API. Pass exactly one.
-    #[command(alias = "status")]
     Show {
         /// App name or ID (positional form). Mutually exclusive with `--app`.
         app_name: Option<String>,
@@ -668,9 +667,8 @@ pub enum EnvCommands {
         env: String,
     },
 
-    /// Remove an environment variable from an app.
-    #[command(alias = "unset")]
-    Remove {
+    /// Remove (unset) an environment variable from an app.
+    Unset {
         /// Environment variable key to remove.
         key: String,
 
@@ -748,7 +746,6 @@ pub enum ServicesCommands {
     /// with the rest of the CLI's flag-based API. Pass exactly one.
     /// `--services` is accepted as a plural alias to match the multi-service
     /// flag used by `floo logs` / `floo redeploy`.
-    #[command(alias = "info")]
     Show {
         /// Service name (positional form). Mutually exclusive with `--service`.
         service_name: Option<String>,
@@ -884,7 +881,6 @@ pub enum DomainsCommands {
     },
 
     /// Show detailed status for a single custom domain.
-    #[command(alias = "status")]
     Show {
         /// Domain hostname.
         hostname: String,
@@ -1312,7 +1308,7 @@ const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
     "dev",
     "update",
     "env set",
-    "env remove",
+    "env unset",
     "env import",
     "apps delete",
     "domains add",
@@ -1496,7 +1492,7 @@ pub fn run() {
             EnvCommands::List { app, services, env } => {
                 commands::env::list(app.as_deref(), &services, &env)
             }
-            EnvCommands::Remove {
+            EnvCommands::Unset {
                 key,
                 app,
                 services,
@@ -1802,7 +1798,7 @@ mod tests {
             ("dev", &["floo", "dev", "--dry-run"]),
             ("update", &["floo", "update", "--dry-run"]),
             ("env set", &["floo", "env", "set", "K=V", "--dry-run"]),
-            ("env remove", &["floo", "env", "remove", "K", "--dry-run"]),
+            ("env unset", &["floo", "env", "unset", "K", "--dry-run"]),
             (
                 "env import",
                 &["floo", "env", "import", ".env", "--dry-run"],

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -322,9 +322,9 @@ fn test_env_list_not_authenticated() {
 }
 
 #[test]
-fn test_env_remove_not_authenticated() {
+fn test_env_unset_not_authenticated() {
     floo()
-        .args(["env", "remove", "MY_KEY", "--app", "test"])
+        .args(["env", "unset", "MY_KEY", "--app", "test"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -393,16 +393,6 @@ fn test_services_show_json_not_authenticated() {
         .assert()
         .failure()
         .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED"#));
-}
-
-#[test]
-fn test_services_info_alias_not_authenticated() {
-    floo()
-        .args(["services", "info", "db", "--app", "my-app"])
-        .env("HOME", "/tmp/floo-test-nonexistent")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("Not logged in."));
 }
 
 // --- Env format validation ---
@@ -1192,12 +1182,12 @@ fn test_dry_run_env_set_human_includes_services_and_prod_scope() {
 }
 
 #[test]
-fn test_dry_run_env_remove_human_includes_services_and_prod_scope() {
+fn test_dry_run_env_unset_human_includes_services_and_prod_scope() {
     floo()
         .args([
             "--dry-run",
             "env",
-            "remove",
+            "unset",
             "KEY",
             "--app",
             "test",
@@ -1235,13 +1225,13 @@ fn test_dry_run_env_set_restart_human() {
 }
 
 #[test]
-fn test_dry_run_env_remove() {
+fn test_dry_run_env_unset() {
     floo()
         .args([
             "--json",
             "--dry-run",
             "env",
-            "remove",
+            "unset",
             "KEY",
             "--app",
             "test",
@@ -1253,9 +1243,9 @@ fn test_dry_run_env_remove() {
 }
 
 #[test]
-fn test_dry_run_env_remove_human_has_preview() {
+fn test_dry_run_env_unset_human_has_preview() {
     floo()
-        .args(["--dry-run", "env", "remove", "KEY", "--app", "test"])
+        .args(["--dry-run", "env", "unset", "KEY", "--app", "test"])
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .success()


### PR DESCRIPTION
## What changed

Follows up on #143. No users yet, so clean up the surface:

- Removed `#[command(alias = "status")]` from `apps show` and `domains show`
- Removed `#[command(alias = "info")]` from `services show`
- Renamed `EnvCommands::Remove` → `EnvCommands::Unset` (so `floo env unset` is canonical, not an alias)

## Why

Adding aliases when we have zero users is dead weight — it doubles the documented surface and makes the help text confusing. Ship the clean names now.

## Risk tier

standard

## Tests run

103 passed, 2 pre-existing failures unrelated to this change.

Closes (no issue)