### PR TITLE
fix(version): suppress transient warning when release assets not yet uploaded

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -71,6 +71,15 @@ pub fn version() {
             refresh_and_announce_skills();
             emit_version(None);
         }
+        // Release assets not yet uploaded (race between release creation and
+        // the CI workflow finishing). Transient — silently skip so `floo version`
+        // stays clean during the ~3-minute publish window.
+        Err(err)
+            if err.code == ErrorCode::ReleaseAssetMissing
+                || err.code == ErrorCode::ChecksumMissing =>
+        {
+            emit_version(None);
+        }
         Err(err) => {
             // Network/checksum/permission failure. Surface the reason so
             // debugging is possible, then print the current version. Never

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -676,6 +676,25 @@ mod tests {
     }
 
     #[test]
+    fn test_release_asset_missing_when_no_assets_uploaded() {
+        // Simulates a race: GitHub release object exists but the CI workflow
+        // hasn't finished uploading binaries yet (~3-minute window).
+        let asset_name = target_asset_name().unwrap();
+        let release = serde_json::json!({
+            "tag_name": "v0.2.0",
+            "assets": []
+        });
+
+        let result = release_asset_from_json(&release, &asset_name);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().code,
+            crate::errors::ErrorCode::ReleaseAssetMissing
+        );
+    }
+
+    #[test]
     fn test_run_update_with_checksum_mismatch() {
         let asset_name = target_asset_name().unwrap();
         let binary_bytes = b"fake-binary-content";

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use mockito::Server;
 use predicates::prelude::*;
 
 #[allow(deprecated)]
@@ -1657,6 +1658,30 @@ fn test_no_update_check_env_var() {
         .success()
         .stderr(predicate::str::contains("Update").not())
         .stderr(predicate::str::contains("downloaded").not());
+}
+
+#[test]
+fn test_version_no_warning_when_release_assets_not_yet_uploaded() {
+    // Regression: during the ~3-minute window between a GitHub release being
+    // created and the CI workflow finishing the binary uploads, `floo version`
+    // was showing "Update check failed: No binary asset found for ..." to the
+    // user. ReleaseAssetMissing is a transient race — silently skip it.
+    let mut server = Server::new();
+    let _mock = server
+        .mock("GET", "/latest")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"tag_name":"v9999.99.99","assets":[]}"#)
+        .create();
+
+    floo()
+        .args(["version"])
+        .env("HOME", "/tmp/floo-test-version-no-asset-warning")
+        .env("FLOO_UPDATE_API_BASE", format!("{}/", server.url()))
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Update check failed").not())
+        .stderr(predicate::str::contains("No binary asset").not());
 }
 
 // --- Deploy --sync-env ---


### PR DESCRIPTION
## What changed

`floo version` no longer shows a warning during the ~3-minute window between a GitHub release being created and CI finishing the binary uploads.

**Before:**
```
⚠ Update check failed: No binary asset found for 'floo-aarch64-apple-darwin'.
⚠ Check https://github.com/getfloo/floo-cli/releases for available artifacts.
0.0.0-dev
```

**After:**
```
0.0.0-dev
```

## Why

`ReleaseAssetMissing` is a transient race condition — the release object exists on GitHub but the CI workflow hasn't finished uploading binaries yet. The user can't act on this warning, it resolves on its own in minutes, and it pollutes every `floo version` call during a release window. Treat it the same as `AlreadyUpToDate`: silently emit the current version.

`ChecksumMissing` gets the same treatment for symmetry — same race, same transience.

## Risk tier

standard

## Tests run

104 passed, 2 pre-existing failures unrelated to this change.

New: `test_version_no_warning_when_release_assets_not_yet_uploaded` — uses a mock server returning a release with empty assets, asserts no "Update check failed" or "No binary asset" text on stderr.