### PR TITLE
docs: clarify floo docs auth -- /__floo/logout contract

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -621,8 +621,14 @@ exchange to implement.
     rolled forward as users stay active, revoked on sign-out
   - Identity headers (X-Floo-User-Email/Id/Name/Role) injected on
     every authenticated request
-  - GET /__floo/me            — signed-in user as JSON
-  - POST /__floo/logout       — clear session and redirect
+  - GET /__floo/me        — signed-in user JSON {user_id,email,name,role};
+                            401 if no session, 403 HTML if access-denied
+  - POST|DELETE /__floo/logout — clears floo session and 302s to login.
+                            Lands at app root / after re-auth. Other methods
+                            (including GET) return 405; SameSite=Lax + GET
+                            would have allowed cross-origin drive-by sign-out.
+                            Does NOT log the user out of WorkOS — federated
+                            SLO is not yet supported.
   - Per-app user list in the dashboard (first-seen, last-active,
     sign-in count)
 


### PR DESCRIPTION
## What changed

Updates the \`floo docs auth\` cheatsheet (\`src/commands/docs.rs\`) to clarify the \`/__floo/me\` and \`/__floo/logout\` contracts.

## Why

Customer feedback \`758c6be4\` (accounts-mode developer via CLI) asked three questions about sign-out:

1. What URL to send users to
2. What HTTP method it accepts (GET vs POST)
3. Where it redirects after (WorkOS logout? back to login?)

The CLI cheatsheet listed \`POST /__floo/logout\` with no further detail. Updates here surface the response shape for \`/__floo/me\`, document POST/DELETE as the accepted methods (with the CSRF rationale for why GET is rejected), and explicitly call out that sign-out clears the floo session only — WorkOS session stays live, federated SLO is not yet supported.

## Risk tier

exempt — \`docs.rs\` is a static \`const &str\` cheatsheet; no behavior change.

## Files reviewers should scrutinize

- \`src/commands/docs.rs\` — only the \`auth\` topic block changed.

## Tests run

\`\`\`
cargo build --release  # implicit via floo-cli CI
\`\`\`

No tests exercise the cheatsheet text directly; wording reviewed alongside the corresponding floo-monorepo PR (gateway method enforcement) and the floo-docs commit landing today.

## Known non-goals

- Updating the customer-facing Mintlify docs (handled directly on \`floo-docs\` main this morning).
- Tightening the gateway to enforce POST/DELETE on \`/__floo/logout\` (handled in floo monorepo PR landing today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)