### PR TITLE
feat: first-class floo-dev binary (dev-stack API + isolated config)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ path = "src/main.rs"
 name = "floo-local"
 path = "src/main.rs"
 
+# Dev-stack variant. Same source; behavior diverges by binary basename
+# in src/config.rs (BinaryVariant::Dev → dev API + .floo-dev config).
+# A sanctioned, credential-isolated surface for dev-stack ops.
+[[bin]]
+name = "floo-dev"
+path = "src/main.rs"
+
 [dependencies]
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -70,6 +70,27 @@ pub fn login(api_key: Option<&str>, force: bool) {
         }
     }
 
+    // Path 3 is structurally impossible on the dev stack.
+    // api.dev.getfloo.com has no WorkOS configured, so
+    // POST /v1/auth/device returns WORKOS_NOT_CONFIGURED. Dev auth is
+    // API-key-only by design — the dev-stack seed injects a dev admin
+    // key, surfaced as the FLOO_SMOKE_KEY_DEV GitHub Actions secret.
+    // Without this guard `floo-dev auth login` runs the doomed device
+    // flow and dies mid-spinner with a misleading "check your network"
+    // suggestion (the symptom the operator reported as "nothing
+    // happening"). Fail fast with the one command that actually works.
+    if crate::config::is_dev_binary() {
+        output::error(
+            "The dev stack is API-key-only — api.dev.getfloo.com has no browser/WorkOS login.",
+            &ErrorCode::NotAuthenticated,
+            Some(
+                "Run: floo-dev auth login --api-key <FLOO_SMOKE_KEY_DEV> \
+                 (the dev admin key in the floo repo's GitHub Actions secrets).",
+            ),
+        );
+        process::exit(1);
+    }
+
     // Path 3: Device code flow
     let client = super::init_client(None);
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -24,10 +24,13 @@ fn display_tag(tag: &str) -> &str {
 /// and potentially cause infinite install→update→install loops if the
 /// update path itself is broken.
 ///
-/// Also honored for `floo-local` dev builds so local development never
-/// attempts to auto-update over the developer's working binary.
+/// Also honored for `floo-local` and `floo-dev` dev builds so local /
+/// dev-stack work never attempts to auto-update over the developer's
+/// working binary.
 fn should_skip_network_check() -> bool {
-    std::env::var("FLOO_NO_UPDATE_CHECK").is_ok() || crate::config::is_local_binary()
+    std::env::var("FLOO_NO_UPDATE_CHECK").is_ok()
+        || crate::config::is_local_binary()
+        || crate::config::is_dev_binary()
 }
 
 /// Refresh bundled skill files and echo each refreshed path in human mode.

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::constants::{CONFIG_FILE_NAME, DEFAULT_API_URL};
+use crate::constants::{CONFIG_FILE_NAME, DEFAULT_API_URL, DEV_API_URL};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlooConfig {
@@ -21,14 +21,20 @@ pub struct FlooConfig {
 }
 
 fn default_api_url() -> String {
-    DEFAULT_API_URL.to_string()
+    // Variant-aware: a fresh `floo-dev` (no config file, or a config
+    // file missing `api_url`) must default to the dev stack, not prod.
+    // FLOO_API_URL still overrides this in `load_config`.
+    match current_variant() {
+        BinaryVariant::Dev => DEV_API_URL.to_string(),
+        BinaryVariant::Local | BinaryVariant::Installed => DEFAULT_API_URL.to_string(),
+    }
 }
 
 impl Default for FlooConfig {
     fn default() -> Self {
         Self {
             api_key: None,
-            api_url: DEFAULT_API_URL.to_string(),
+            api_url: default_api_url(),
             user_email: None,
             skill_paths: Vec::new(),
             default_org: None,
@@ -47,21 +53,57 @@ impl FlooConfig {
     }
 }
 
-/// Returns true when the running binary is the locally-compiled `floo-local`.
-pub fn is_local_binary() -> bool {
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| p.file_name().map(|n| n.to_os_string()))
-        .map(|n| n == "floo-local")
-        .unwrap_or(false)
+/// Which compiled variant is running, decided by the binary's own
+/// basename. All three `[[bin]]` targets in Cargo.toml share `main.rs`;
+/// behavior diverges only here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BinaryVariant {
+    /// `floo` — installed, prod API, `.floo` config.
+    Installed,
+    /// `floo-local` — locally-compiled, prod API, `.floo-local` config.
+    Local,
+    /// `floo-dev` — dev-stack API, `.floo-dev` config. A sanctioned,
+    /// credential-isolated surface for dev-stack operations so they
+    /// never clobber prod creds or tempt raw DB access (see floo
+    /// monorepo issue #797).
+    Dev,
 }
 
-/// Config directory name: `.floo-local` for local builds, `.floo` for installed.
+/// Pure mapping from binary basename to variant — unit-testable
+/// without faking `current_exe`.
+pub(crate) fn variant_from_basename(name: &str) -> BinaryVariant {
+    match name {
+        "floo-local" => BinaryVariant::Local,
+        "floo-dev" => BinaryVariant::Dev,
+        _ => BinaryVariant::Installed,
+    }
+}
+
+pub(crate) fn current_variant() -> BinaryVariant {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .map(|n| variant_from_basename(&n))
+        .unwrap_or(BinaryVariant::Installed)
+}
+
+/// Returns true when the running binary is the locally-compiled `floo-local`.
+pub fn is_local_binary() -> bool {
+    current_variant() == BinaryVariant::Local
+}
+
+/// Returns true when the running binary is `floo-dev` (dev stack).
+pub fn is_dev_binary() -> bool {
+    current_variant() == BinaryVariant::Dev
+}
+
+/// Config directory name: `.floo-dev` for the dev binary,
+/// `.floo-local` for local builds, `.floo` for installed.
 pub fn config_dir_name() -> &'static str {
-    if is_local_binary() {
-        ".floo-local"
-    } else {
-        ".floo"
+    match current_variant() {
+        BinaryVariant::Dev => ".floo-dev",
+        BinaryVariant::Local => ".floo-local",
+        BinaryVariant::Installed => ".floo",
     }
 }
 
@@ -154,8 +196,44 @@ mod tests {
     fn test_default_config() {
         let config = FlooConfig::default();
         assert!(config.api_key.is_none());
+        // Under the test binary (basename != floo-dev) the variant is
+        // Installed, so the default stays prod. This pins that the
+        // floo-dev change did NOT regress prod/local defaulting.
         assert_eq!(config.api_url, DEFAULT_API_URL);
         assert!(config.user_email.is_none());
+    }
+
+    #[test]
+    fn test_variant_from_basename() {
+        assert_eq!(variant_from_basename("floo"), BinaryVariant::Installed);
+        assert_eq!(variant_from_basename("floo-local"), BinaryVariant::Local);
+        assert_eq!(variant_from_basename("floo-dev"), BinaryVariant::Dev);
+        // Anything unrecognized (renamed binary, symlink) falls back to
+        // the safe prod-installed behavior — never silently dev.
+        assert_eq!(variant_from_basename("floo.exe"), BinaryVariant::Installed);
+        assert_eq!(variant_from_basename("something"), BinaryVariant::Installed);
+    }
+
+    #[test]
+    fn test_dev_variant_defaults_to_dev_api_only_for_dev() {
+        // The dev binary must default to the dev stack; prod/local must
+        // not. This is the load-bearing isolation: a `floo-dev` with no
+        // config file still talks to dev, never accidentally prod.
+        assert_eq!(
+            match variant_from_basename("floo-dev") {
+                BinaryVariant::Dev => DEV_API_URL,
+                _ => DEFAULT_API_URL,
+            },
+            DEV_API_URL
+        );
+        assert_eq!(
+            match variant_from_basename("floo-local") {
+                BinaryVariant::Dev => DEV_API_URL,
+                _ => DEFAULT_API_URL,
+            },
+            DEFAULT_API_URL
+        );
+        assert_ne!(DEV_API_URL, DEFAULT_API_URL);
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,8 @@
 pub const DEFAULT_API_URL: &str = "https://api.getfloo.com";
+// Dev-stack API. The `floo-dev` binary defaults here instead of prod
+// (still overridable via FLOO_API_URL). Sourced from
+// .github/workflows/dev.yml (API_BASE) and
+// scripts/ops/reconcile-gateway-dev-env.sh in the floo monorepo.
+pub const DEV_API_URL: &str = "https://api.dev.getfloo.com";
 pub const CONFIG_FILE_NAME: &str = "config.json";
 pub const VERSION: &str = env!("FLOO_VERSION");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -118,6 +118,27 @@ fn test_auth_login_help() {
         .stdout(predicate::str::contains("Authenticate with the Floo API"));
 }
 
+/// Regression: the dev stack has no WorkOS, so `floo-dev auth login`
+/// (no --api-key) must fail FAST with the API-key instruction instead
+/// of running the doomed device flow and dying mid-spinner with a
+/// misleading "check your network" message — the symptom reported as
+/// "nothing happening". Uses an isolated empty FLOO_CONFIG_DIR so no
+/// real credential short-circuits it via Path 2.
+#[test]
+fn test_floo_dev_auth_login_without_key_fails_with_api_key_instruction() {
+    let cfg = tempfile::tempdir().unwrap();
+    #[allow(deprecated)]
+    Command::cargo_bin("floo-dev")
+        .unwrap()
+        .args(["auth", "login"])
+        .env("FLOO_NO_UPDATE_CHECK", "1")
+        .env("FLOO_CONFIG_DIR", cfg.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dev stack is API-key-only"))
+        .stderr(predicate::str::contains("--api-key <FLOO_SMOKE_KEY_DEV>"));
+}
+
 #[test]
 fn test_auth_register_help() {
     floo()


### PR DESCRIPTION
## What

Adds a third compiled variant `floo-dev` alongside `floo` (team/prod) and `floo-local` (admin/prod). Same `src/main.rs`; behavior diverges by binary basename via a new `BinaryVariant {Installed, Local, Dev}`:

- `floo-dev` → config dir `.floo-dev`, default API `https://api.dev.getfloo.com` (still overridable by `FLOO_API_URL`).
- Skips the update-check network call (dev tool, like `floo-local`).
- `floo` / `floo-local` unchanged — both still Installed/Local → prod `api.getfloo.com`.

## Why

No sanctioned dev-stack surface existed. Dev-stack ops (gw-contract fixture recovery, dev-API redeploys, dev DB debugging — see floo monorepo issue #797) required ad-hoc `FLOO_API_URL=… FLOO_CONFIG_DIR=…` env juggling that risked clobbering prod credentials and pushed operators toward forbidden raw `cloud-sql-proxy` access. Credential isolation is now **structural**: a separate config dir means `floo-dev auth login` is incapable of overwriting the prod `.floo`/`.floo-local` config.

## Tests

- `variant_from_basename` is a pure fn → unit-tested (`test_variant_from_basename`, `test_dev_variant_defaults_to_dev_api_only_for_dev`) without faking `current_exe`. Unrecognized basenames fall back to Installed (prod) — never silently dev.
- `test_default_config` pins that prod/local defaulting did not regress.
- Full suite: 382 passed, 0 failed. `cargo fmt --check` clean. All three bins build.

## Notes

The "src/main.rs present in multiple build targets" cargo warning is pre-existing (`floo` + `floo-local` already shared it) — `floo-dev` adds a third, same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)