### PR TITLE
fix(docs): align embedded docs/skill with shipped surface

### DIFF
--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -200,11 +200,11 @@ floo redeploy --preflight --app my-app             # preview redeploy without ex
 
 ### Managed services (postgres, redis, storage)
 
-Managed services are **stateful** — they carry data and outlive deploys. They are CLI-managed, not TOML-declared, because destroying a database on a config edit would be catastrophic.
+Managed services are **stateful** — they carry data and outlive deploys. Provision them with `floo services add` or declare them in `floo.app.toml` via `[managed.<name>]`; either way a deploy creates what's declared-but-missing and **never destroys**. Destroying a database is always an explicit `floo services remove` — never a config side effect.
 
 ```bash
 floo services list --app my-app                    # see everything (app services + managed)
-floo services info postgres --app my-app           # inspect a managed service
+floo services show postgres --app my-app           # inspect a managed service
 ```
 
 Legacy `[postgres]`/`[redis]`/`[storage]` sections in `floo.app.toml` still auto-provision during the transition window, but emit a deprecation notice on every deploy. Prefer the CLI surface for new apps.

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -216,9 +216,9 @@ fn command_tree() -> Vec<CommandInfo> {
                     subcommands: vec![],
                 },
                 CommandInfo {
-                    name: "info",
+                    name: "show",
                     description: "Show details for a service",
-                    usage: "floo services info <service> --app <name>",
+                    usage: "floo services show <service> --app <name>",
                     requires_auth: true,
                     subcommands: vec![],
                 },

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -615,7 +615,7 @@ exchange to implement.
 
 ## What you get
 
-  - Hosted sign-in page (email magic link, Google, GitHub, SAML/OIDC)
+  - Hosted sign-in page (email magic link, Google, GitHub)
     — branded; gateway redirects unauthenticated visitors to it
   - Session cookie (__floo_session) validated on every request,
     rolled forward as users stay active, revoked on sign-out
@@ -652,7 +652,9 @@ in the dashboard or in floo.app.toml:
   public    — no auth, anyone can access (default)
   password  — shared password for simple protection (Pro+)
   accounts  — per-user auth, gateway-managed (Pro+)
-  sso       — enterprise SSO via SAML/OIDC (Enterprise, coming soon)
+
+Enterprise SSO (SAML/OIDC) is a sales-assisted setup, not a self-serve
+access_mode value — email sales@getfloo.com if your team needs it.
 
 Per-environment overrides work too:
 

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -255,7 +255,7 @@ fn recommended_permissions() -> (Vec<&'static str>, Vec<&'static str>) {
         "Bash(floo deploys watch:*)",
         "Bash(floo env list:*)",
         "Bash(floo services list:*)",
-        "Bash(floo services info:*)",
+        "Bash(floo services show:*)",
         "Bash(floo domains list:*)",
         "Bash(floo logs:*)",
         "Bash(floo analytics:*)",


### PR DESCRIPTION
## What changed
Fixes the CLI's own embedded doc/discovery surfaces so they match shipped behavior.

- **`floo services info` → `floo services show`** — `info` errors with *"unrecognized subcommand 'info'"*. Fixed in three places that point agents at it:
  - `command_tree.rs` (the `floo commands` / discover tree agents read)
  - `skills.rs` (the permission allowlist the installed skill writes — was pre-approving a non-existent command)
  - `skills/floo/SKILL.md` (the agent skill shipped by `floo skills install`)
- **SSO** — dropped SAML/OIDC from the hosted sign-in provider list and removed `sso` from the access_mode list in `floo docs auth`; reframed enterprise SSO as a sales-assisted setup (the platform rejects `access_mode='sso'`).
- **`[managed.<name>]`** — noted the config-declarative provisioning surface in the skill, preserving the deploy-never-destroys invariant.

## Why
The discover tree, the installed permission allowlist, and the agent skill all told agents to run `floo services info`, which fails — a "tools that succeed" (AX) regression. SSO copy advertised a retired feature.

## Tests
`cargo build`, `cargo test --bin floo` (388 passed), `cargo fmt --check`, `cargo clippy` — all clean. Branched from `origin/main` (independent of the in-flight `feat/managed-config-blocks`).

## Known non-goals
- `floo docs config` should gain a `[managed.<name>]` example; that belongs with `feat/managed-config-blocks` (which adds the CLI-side validation), so it lands there, not here.
- Per-environment `access_mode` "works too" copy in `floo docs auth` is left for the access-mode-autodeploy effort.
- Sibling PRs: getfloo/floo-docs#18 and getfloo/floo `docs/kb-managed-services-align`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)