### PR TITLE
fix(cron): validate cron run --dry-run; harden CLI not-found handling (#152)

### DIFF
--- a/src/commands/cron.rs
+++ b/src/commands/cron.rs
@@ -1,7 +1,71 @@
+use std::path::Path;
 use std::process;
 
-use crate::errors::ErrorCode;
+use crate::errors::{ErrorCode, FlooApiError, FlooError};
 use crate::output;
+
+/// Help text to attach when a cron API call comes back not-found.
+///
+/// Keyed on the HTTP 404 *status* (`FlooApiError::is_not_found`), not a
+/// hard-coded `code` string. The API emits `CRON_JOB_NOT_FOUND`
+/// (getfloo/floo `api/app/routes/cron.py`), but this gate used to read
+/// `e.code == "NOT_FOUND"`, so it never matched and the hint silently never
+/// fired (issue #152). Matching on status keeps CLI↔API code-string drift
+/// from disabling the hint again.
+fn not_found_suggestion(e: &FlooApiError) -> Option<&'static str> {
+    if e.is_not_found() {
+        Some("Run `floo cron list` to see available cron jobs.")
+    } else {
+        None
+    }
+}
+
+/// Validate a cron job name against the locally-declared cron set for
+/// `floo cron run --dry-run` (the config-resolved, no-`--app` path only).
+///
+/// A `--dry-run` preview should reflect what the real run would do instead of
+/// echoing a confident "Would trigger" for a name that doesn't exist (issue
+/// #152). When the app is resolved from local config, the real run is driven
+/// by that same `floo.app.toml` — its `[cron.<name>]` blocks are what a deploy
+/// pushes — so the declared set is the best offline proxy for the cron names
+/// the run will accept. It is only a proxy: a job declared but not yet deployed
+/// (or deleted server-side) can still skew local vs. live, but that's the most
+/// a no-network, no-auth preview can check.
+///
+/// The `--app` path is deliberately NOT routed here: with `--app`, the real run
+/// resolves the app via the API and never reads `floo.app.toml`, so the local
+/// cron set may belong to a different app entirely — validating against it
+/// would reject names the real run accepts. The caller skips this for `--app`.
+fn validate_dry_run_target(cwd: &Path, name: &str) -> Result<(), FlooError> {
+    // Resolve config the same way the no-flag real run does (walk up from cwd).
+    // No network, no auth — this is a local file read.
+    let resolved = crate::project_config::resolve_app_context(cwd, None)?;
+    let cron = resolved.app_config.map(|c| c.cron).unwrap_or_default();
+    if cron.contains_key(name) {
+        return Ok(());
+    }
+
+    let mut declared: Vec<&str> = cron.keys().map(String::as_str).collect();
+    declared.sort_unstable();
+    let suggestion = if declared.is_empty() {
+        format!(
+            "No cron jobs are declared in {}. Add a [cron.{name}] block, or check the name.",
+            crate::project_config::APP_CONFIG_FILE
+        )
+    } else {
+        format!("Declared cron jobs: {}.", declared.join(", "))
+    };
+    Err(FlooError::with_suggestion(
+        // Mirror the API's emitted contract so the preview's error shape
+        // matches the real run's 404 (api/app/routes/cron.py).
+        ErrorCode::Other("CRON_JOB_NOT_FOUND".to_string()),
+        format!(
+            "Cron job '{name}' is not declared in {}.",
+            crate::project_config::APP_CONFIG_FILE
+        ),
+        suggestion,
+    ))
+}
 
 pub fn list(app_flag: Option<&str>) {
     super::require_auth();
@@ -66,12 +130,11 @@ pub fn show(app_flag: Option<&str>, name: &str) {
     let result = match client.get_cron_job(&app_id, name) {
         Ok(r) => r,
         Err(e) => {
-            let suggestion = if e.code == "NOT_FOUND" {
-                Some("Run `floo cron list` to see available cron jobs.")
-            } else {
-                None
-            };
-            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
+            output::error(
+                &e.message,
+                &ErrorCode::from_api(&e.code),
+                not_found_suggestion(&e),
+            );
             process::exit(1);
         }
     };
@@ -101,13 +164,33 @@ pub fn show(app_flag: Option<&str>, name: &str) {
 }
 
 pub fn run(app_flag: Option<&str>, name: &str) {
-    // Dry-run is a pure echo: every other --dry-run handler in the CLI
-    // (apps.rs, domains.rs, env.rs, rollbacks.rs, deploy.rs) checks
-    // is_dry_run_mode() BEFORE require_auth() / resolve_app_from_config(),
-    // so previewing a mutating command never requires a live API key or
-    // an existing app row. Keep that contract here so logged-out users
-    // and offline agents get a consistent preview shape across commands.
+    // Dry-run stays offline: like every other --dry-run handler in the CLI
+    // (apps.rs, domains.rs, env.rs, rollbacks.rs, deploy.rs) it runs BEFORE
+    // require_auth() / the API call, so previewing never needs a live API key.
+    // A preview should reflect what the real run would do — the real run 404s
+    // on an unknown name and exits 1 — so on the config-resolved path we
+    // validate the name against the locally-declared [cron.<name>] set instead
+    // of echoing a confident "Would trigger" for a job that doesn't exist
+    // (#152). We skip this when --app is given: that path resolves the app
+    // server-side and never reads floo.app.toml, so the local cron set isn't
+    // the right thing to check (it may belong to a different app) and there's
+    // nothing we can validate offline.
     if output::is_dry_run_mode() {
+        if app_flag.is_none() {
+            let cwd = std::env::current_dir().unwrap_or_else(|e| {
+                output::error(
+                    &format!("Failed to read current directory: {e}"),
+                    &ErrorCode::CwdError,
+                    Some("Ensure the current directory exists and you have read permission."),
+                );
+                process::exit(1);
+            });
+            if let Err(e) = validate_dry_run_target(&cwd, name) {
+                output::error(&e.message, &e.code, e.suggestion.as_deref());
+                process::exit(1);
+            }
+        }
+
         let target = app_flag.unwrap_or("(reads from config)");
         let preview = format!("Would trigger cron job '{name}' on {target}.");
         output::dry_run_preview(
@@ -133,12 +216,11 @@ pub fn run(app_flag: Option<&str>, name: &str) {
         }
         Err(e) => {
             spinner.finish();
-            let suggestion = if e.code == "NOT_FOUND" {
-                Some("Run `floo cron list` to see available cron jobs.")
-            } else {
-                None
-            };
-            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
+            output::error(
+                &e.message,
+                &ErrorCode::from_api(&e.code),
+                not_found_suggestion(&e),
+            );
             process::exit(1);
         }
     };
@@ -153,4 +235,108 @@ pub fn run(app_flag: Option<&str>, name: &str) {
         .as_deref()
         .unwrap_or("Cron job triggered successfully.");
     output::success(msg, None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_app_toml(dir: &TempDir, body: &str) {
+        fs::write(
+            dir.path().join(crate::project_config::APP_CONFIG_FILE),
+            format!("[app]\nname = \"my-app\"\n\n{body}"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn not_found_suggestion_fires_on_404() {
+        // Regression for #152: the API returns CRON_JOB_NOT_FOUND (not
+        // NOT_FOUND), so a code-string gate never matched. Keyed on status,
+        // the hint must fire regardless of the code string.
+        let err = FlooApiError::new(404, "CRON_JOB_NOT_FOUND", "Cron job not found");
+        let suggestion = not_found_suggestion(&err).expect("404 must surface the list hint");
+        assert!(suggestion.contains("floo cron list"), "got: {suggestion}");
+    }
+
+    #[test]
+    fn not_found_suggestion_silent_for_non_404() {
+        let err = FlooApiError::new(500, "INTERNAL_ERROR", "boom");
+        assert!(not_found_suggestion(&err).is_none());
+    }
+
+    #[test]
+    fn dry_run_target_ok_for_declared_name() {
+        let dir = TempDir::new().unwrap();
+        write_app_toml(
+            &dir,
+            "[cron.daily-report]\nschedule = \"0 9 * * *\"\ncommand = \"./report.sh\"\nservice = \"web\"\n",
+        );
+        assert!(validate_dry_run_target(dir.path(), "daily-report").is_ok());
+    }
+
+    #[test]
+    fn dry_run_target_errors_for_unknown_name() {
+        // The core of bug #1: a preview of a name that isn't declared must
+        // fail (the real run 404s), not echo "Would trigger".
+        let dir = TempDir::new().unwrap();
+        write_app_toml(
+            &dir,
+            "[cron.daily-report]\nschedule = \"0 9 * * *\"\ncommand = \"./report.sh\"\nservice = \"web\"\n",
+        );
+        let err = validate_dry_run_target(dir.path(), "does-not-exist").unwrap_err();
+        // Dry-run error code mirrors the API's emitted contract so the preview
+        // reflects the real run.
+        assert_eq!(err.code, ErrorCode::Other("CRON_JOB_NOT_FOUND".to_string()));
+        assert!(
+            err.message.contains("does-not-exist"),
+            "message should name the missing job: {}",
+            err.message
+        );
+        // The suggestion should point at the declared job(s) for discovery.
+        let suggestion = err.suggestion.expect("not-found error must carry a hint");
+        assert!(
+            suggestion.contains("daily-report"),
+            "suggestion should list declared jobs: {suggestion}"
+        );
+    }
+
+    #[test]
+    fn dry_run_target_errors_when_no_cron_declared() {
+        let dir = TempDir::new().unwrap();
+        write_app_toml(&dir, "[services.web]\ntype = \"web\"\npath = \"./web\"\n");
+        let err = validate_dry_run_target(dir.path(), "anything").unwrap_err();
+        assert_eq!(err.code, ErrorCode::Other("CRON_JOB_NOT_FOUND".to_string()));
+        let suggestion = err.suggestion.expect("not-found error must carry a hint");
+        assert!(
+            suggestion.contains(crate::project_config::APP_CONFIG_FILE),
+            "suggestion should point at the config file when nothing is declared: {suggestion}"
+        );
+    }
+
+    #[test]
+    fn dry_run_target_walks_up_from_subdirectory() {
+        // The no-flag real run finds config by walking up from cwd; the preview
+        // must resolve the same way so it works from a nested project dir.
+        let dir = TempDir::new().unwrap();
+        write_app_toml(
+            &dir,
+            "[cron.nightly]\nschedule = \"0 0 * * *\"\ncommand = \"./n.sh\"\nservice = \"web\"\n",
+        );
+        let nested = dir.path().join("services/web");
+        fs::create_dir_all(&nested).unwrap();
+        assert!(validate_dry_run_target(&nested, "nightly").is_ok());
+        assert!(validate_dry_run_target(&nested, "missing").is_err());
+    }
+
+    #[test]
+    fn dry_run_target_errors_when_no_config_found() {
+        // No floo.app.toml / floo.service.toml anywhere: resolve_app_context
+        // surfaces NoConfigFound, same as the real no-flag run would.
+        let dir = TempDir::new().unwrap();
+        let err = validate_dry_run_target(dir.path(), "anything").unwrap_err();
+        assert_eq!(err.code, ErrorCode::NoConfigFound);
+    }
 }

--- a/src/commands/cron.rs
+++ b/src/commands/cron.rs
@@ -177,14 +177,7 @@ pub fn run(app_flag: Option<&str>, name: &str) {
     // nothing we can validate offline.
     if output::is_dry_run_mode() {
         if app_flag.is_none() {
-            let cwd = std::env::current_dir().unwrap_or_else(|e| {
-                output::error(
-                    &format!("Failed to read current directory: {e}"),
-                    &ErrorCode::CwdError,
-                    Some("Ensure the current directory exists and you have read permission."),
-                );
-                process::exit(1);
-            });
+            let cwd = super::read_cwd_or_exit();
             if let Err(e) = validate_dry_run_target(&cwd, name) {
                 output::error(&e.message, &e.code, e.suggestion.as_deref());
                 process::exit(1);

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -295,7 +295,9 @@ pub fn deploy(
         let app_data = match resolve_app(&client, app_name) {
             Ok(a) => a,
             Err(e) => {
-                if e.code == "APP_NOT_FOUND" {
+                // 404 from resolving the app == app not found; gate on status,
+                // not a code string that can drift (see is_not_found).
+                if e.is_not_found() {
                     output::error(
                         &format!("App '{app_name}' not found."),
                         &ErrorCode::AppNotFound,
@@ -1171,11 +1173,17 @@ fn validate_preflight(
                         warnings.push(serde_json::json!({
                             "path": svc.path,
                             "code": "RAILS_DATABASE_URL_SOCKET_DSN",
+                            // The illustrative DSNs deliberately omit `user:pass@`
+                            // userinfo: this string flows through print_json's
+                            // redactor, and an embedded `scheme://u:p@` literal
+                            // would be scrubbed to ***REDACTED***, hiding the very
+                            // warning we're trying to surface. Show the host shape,
+                            // not credential-shaped text.
                             "message": format!(
-                                "Service '{}' looks like Rails and {env_label} contains a Cloud SQL socket-style DATABASE_URL. Rails parses DATABASE_URL with Ruby's URI parser before app code runs, so postgresql://user:pass@/db?host=/cloudsql/... can fail at boot. Remove the stale local override or use floo's framework-compatible managed Postgres URL.",
+                                "Service '{}' looks like Rails and {env_label} contains a Cloud SQL socket-style DATABASE_URL. Rails parses DATABASE_URL with Ruby's URI parser before app code runs, so a host-less DSN like postgresql:///db?host=/cloudsql/... can fail at boot. Remove the stale local override or use floo's framework-compatible managed Postgres URL.",
                                 svc.name
                             ),
-                            "hint": "Managed Postgres now injects DATABASE_URL plus PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD. The DATABASE_URL value should have a normal host, for example postgresql://user:pass@127.0.0.1:5432/db.",
+                            "hint": "Managed Postgres now injects DATABASE_URL plus PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD. The DATABASE_URL value should have a normal host, for example postgresql://127.0.0.1:5432/db.",
                         }));
                         break;
                     }

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -80,14 +80,7 @@ pub fn dev(args: DevArgs) {
     let client = super::init_client(Some(config));
 
     // --- Resolve app from config ---
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::CwdError,
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
+    let cwd = super::read_cwd_or_exit();
 
     let resolved = match project_config::resolve_app_context(&cwd, app_flag.as_deref()) {
         Ok(r) => r,

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -478,14 +478,7 @@ pub fn import_vars(
     service_names: &[String],
     env: &str,
 ) {
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::FileError,
-            None,
-        );
-        process::exit(1);
-    });
+    let cwd = super::read_cwd_or_exit();
 
     // Resolve config — used for env_file default path. Missing config is OK.
     // When --app is provided, config errors in the current dir are irrelevant
@@ -593,14 +586,7 @@ pub fn import_vars(
 pub fn import_all_services(app_flag: Option<&str>, env: &str) {
     super::require_auth();
 
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::FileError,
-            None,
-        );
-        process::exit(1);
-    });
+    let cwd = super::read_cwd_or_exit();
 
     let resolved = match project_config::resolve_app_context(&cwd, app_flag) {
         Ok(r) => r,

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -29,21 +29,15 @@ pub fn connect(
     let rerun_command =
         connect_rerun_command(repo, app, branch, skip_env_check, no_deploy, no_browser);
 
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::FileError,
-            None,
-        );
-        process::exit(1);
-    });
+    let cwd = super::read_cwd_or_exit();
 
     // Resolve app — skip config file reads when --app is provided
     let (app_data, resolved) = if let Some(app_flag) = app {
         // --app provided: look up directly, no local config needed
         let app_data = match crate::resolve::resolve_app(&client, app_flag) {
             Ok(a) => a,
-            Err(e) if e.code == "APP_NOT_FOUND" => {
+            // 404 == app doesn't exist yet → create it (status, not code string).
+            Err(e) if e.is_not_found() => {
                 // Create new app — try local detection for runtime, fall back to "unknown"
                 let runtime = detect(&cwd).runtime;
                 let spinner = output::Spinner::new(&format!("Creating app {app_flag}..."));
@@ -80,7 +74,8 @@ pub fn connect(
 
         let app_data = match crate::resolve::resolve_app(&client, &app_name) {
             Ok(a) => a,
-            Err(e) if e.code == "APP_NOT_FOUND" => {
+            // 404 == app doesn't exist yet → create it (status, not code string).
+            Err(e) if e.is_not_found() => {
                 let detection = detect(&cwd);
                 let spinner = output::Spinner::new(&format!("Creating app {app_name}..."));
                 match client.create_app(&app_name, Some(&detection.runtime)) {

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -225,7 +225,8 @@ pub fn logs(args: LogsArgs) {
         let app = match resolve_app(&client, app_flag) {
             Ok(a) => a,
             Err(e) => {
-                if e.code == "APP_NOT_FOUND" {
+                // 404 == app not found; gate on status, not a code string.
+                if e.is_not_found() {
                     output::error(
                         &format!("App '{app_flag}' not found."),
                         &ErrorCode::AppNotFound,
@@ -241,14 +242,7 @@ pub fn logs(args: LogsArgs) {
         (app, label)
     } else {
         // No --app: resolve from local config files
-        let cwd = std::env::current_dir().unwrap_or_else(|e| {
-            output::error(
-                &format!("Failed to read current directory: {e}"),
-                &ErrorCode::FileError,
-                None,
-            );
-            process::exit(1);
-        });
+        let cwd = super::read_cwd_or_exit();
 
         let resolved = match project_config::resolve_app_context(&cwd, None) {
             Ok(r) => r,
@@ -262,7 +256,8 @@ pub fn logs(args: LogsArgs) {
         let app = match resolve_app(&client, &resolved.app_name) {
             Ok(a) => a,
             Err(e) => {
-                if e.code == "APP_NOT_FOUND" {
+                // 404 == app not found; gate on status, not a code string.
+                if e.is_not_found() {
                     output::error(
                         &format!("App '{}' not found.", resolved.app_name),
                         &ErrorCode::AppNotFound,
@@ -565,14 +560,7 @@ pub fn request_logs(args: RequestLogsArgs) {
             }
         }
     } else {
-        let cwd = std::env::current_dir().unwrap_or_else(|e| {
-            output::error(
-                &format!("Failed to read current directory: {e}"),
-                &ErrorCode::FileError,
-                None,
-            );
-            process::exit(1);
-        });
+        let cwd = super::read_cwd_or_exit();
         let resolved = match project_config::resolve_app_context(&cwd, None) {
             Ok(r) => r,
             Err(e) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -48,6 +48,24 @@ pub(crate) fn init_client(config: Option<FlooConfig>) -> FlooClient {
     }
 }
 
+/// Read the current working directory, or print a `CwdError` and `exit(1)`.
+///
+/// Every command that resolves the app from local config (`dev`, `run`, env
+/// import, logs, github connect, cron `--dry-run`, and `resolve_app_from_config`
+/// itself) needs cwd before walking up for `floo.app.toml`. This is the single
+/// place that turns a failed read into the user-facing error, so the
+/// code/message/suggestion can't drift across call sites.
+pub(crate) fn read_cwd_or_exit() -> std::path::PathBuf {
+    std::env::current_dir().unwrap_or_else(|e| {
+        output::error(
+            &format!("Failed to read current directory: {e}"),
+            &ErrorCode::CwdError,
+            Some("Ensure the current directory exists and you have read permission."),
+        );
+        process::exit(1);
+    })
+}
+
 pub(crate) fn require_auth() {
     let config = load_config();
     if config.api_key.is_none() {
@@ -64,7 +82,9 @@ pub(crate) fn resolve_app_or_exit(client: &FlooClient, app_name: &str) -> App {
     match crate::resolve::resolve_app(client, app_name) {
         Ok(a) => a,
         Err(e) => {
-            if e.code == "APP_NOT_FOUND" {
+            // A 404 from resolving a single app means the app doesn't exist;
+            // match on status, not a drift-prone code string (see is_not_found).
+            if e.is_not_found() {
                 output::error(
                     &format!("App '{app_name}' not found."),
                     &ErrorCode::AppNotFound,
@@ -88,14 +108,7 @@ pub(crate) fn resolve_app_from_config(
         return (app.id.clone(), app.name.clone());
     }
 
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::CwdError,
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
+    let cwd = read_cwd_or_exit();
     let resolved = match crate::project_config::resolve_app_context(&cwd, None) {
         Ok(r) => r,
         Err(e) => {

--- a/src/commands/releases.rs
+++ b/src/commands/releases.rs
@@ -117,7 +117,9 @@ pub fn show(release_id: &str, app: Option<&str>) {
     let release = match client.get_release(app_id, release_id) {
         Ok(r) => r,
         Err(e) => {
-            if e.code == "RELEASE_NOT_FOUND" {
+            // app_id is already resolved, so a 404 here is the release, not the
+            // app — gate on status rather than a drift-prone code string.
+            if e.is_not_found() {
                 output::error(
                     &format!("Release '{release_id}' not found."),
                     &ErrorCode::ReleaseNotFound,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -21,14 +21,7 @@ pub fn run(service: &str, app_flag: Option<String>, command: Vec<String>) {
     let config = load_config();
     let client = super::init_client(Some(config));
 
-    let cwd = std::env::current_dir().unwrap_or_else(|e| {
-        output::error(
-            &format!("Failed to read current directory: {e}"),
-            &ErrorCode::CwdError,
-            Some("Ensure the current directory exists and you have read permission."),
-        );
-        process::exit(1);
-    });
+    let cwd = super::read_cwd_or_exit();
 
     let resolved = match project_config::resolve_app_context(&cwd, app_flag.as_deref()) {
         Ok(r) => r,

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -233,6 +233,9 @@ mod tests {
     /// network response to key off of.
     #[test]
     fn test_version_skip_network_is_stable() {
+        let _guard = crate::output::GLOBAL_MODE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("FLOO_NO_UPDATE_CHECK", "1");
         output::set_json_mode(true);
         super::version();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -282,6 +282,18 @@ impl FlooApiError {
             extra: None,
         }
     }
+
+    /// True when the server returned HTTP 404.
+    ///
+    /// Prefer this over matching a hard-coded `code` string. The API's
+    /// not-found code has drifted across endpoints (`NOT_FOUND`,
+    /// `CRON_JOB_NOT_FOUND`, `APP_NOT_FOUND`, …), so a `code == "NOT_FOUND"`
+    /// gate silently stops matching the moment the server renames the code —
+    /// disabling any user-help path hung off it. The 404 *status* is the
+    /// stable wire contract; key not-found detection on it instead.
+    pub fn is_not_found(&self) -> bool {
+        self.status_code == 404
+    }
 }
 
 #[cfg(test)]
@@ -308,6 +320,30 @@ mod tests {
         assert_eq!(err.status_code, 404);
         assert_eq!(err.code, "NOT_FOUND");
         assert_eq!(err.to_string(), "App not found.");
+    }
+
+    #[test]
+    fn test_is_not_found_true_for_404() {
+        let err = FlooApiError::new(404, "NOT_FOUND", "missing");
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_not_found_keyed_on_status_not_code() {
+        // The whole point of the helper: a 404 is not-found regardless of the
+        // server's code string. The cron endpoint emits CRON_JOB_NOT_FOUND, not
+        // NOT_FOUND — a code-string match would miss it; the status must not.
+        let err = FlooApiError::new(404, "CRON_JOB_NOT_FOUND", "Cron job not found");
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_not_found_false_for_non_404() {
+        assert!(!FlooApiError::new(500, "INTERNAL_ERROR", "boom").is_not_found());
+        assert!(!FlooApiError::new(403, "FORBIDDEN", "nope").is_not_found());
+        // A non-404 status must stay not-found=false even if some unrelated
+        // payload happened to carry a NOT_FOUND-ish code.
+        assert!(!FlooApiError::new(400, "NOT_FOUND", "weird").is_not_found());
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,6 +14,14 @@ use crate::redact;
 static JSON_MODE: AtomicBool = AtomicBool::new(false);
 static DRY_RUN: AtomicBool = AtomicBool::new(false);
 
+/// Serializes the handful of unit tests that mutate the process-global
+/// JSON/dry-run mode (here and in `update.rs`). They share one `AtomicBool`
+/// each, so running in parallel they intermittently clobber one another's
+/// assertions — a test asserting `!is_json_mode()` can observe a `true` set by
+/// a concurrent test. Each such test takes this lock for its duration.
+#[cfg(test)]
+pub(crate) static GLOBAL_MODE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub fn set_json_mode(enabled: bool) {
     JSON_MODE.store(enabled, Ordering::SeqCst);
 }
@@ -286,6 +294,7 @@ mod tests {
 
     #[test]
     fn test_json_mode_toggle() {
+        let _guard = GLOBAL_MODE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         set_json_mode(false);
         assert!(!is_json_mode());
         set_json_mode(true);
@@ -295,6 +304,7 @@ mod tests {
 
     #[test]
     fn test_is_interactive_false_in_json_mode() {
+        let _guard = GLOBAL_MODE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         set_json_mode(true);
         assert!(!is_interactive());
         set_json_mode(false);
@@ -302,6 +312,7 @@ mod tests {
 
     #[test]
     fn test_dry_run_mode_toggle() {
+        let _guard = GLOBAL_MODE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         set_dry_run_mode(false);
         assert!(!is_dry_run_mode());
         set_dry_run_mode(true);

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1446,6 +1446,46 @@ fn test_dry_run_cron_run_human_has_preview() {
         ));
 }
 
+// Without --app, the dry-run resolves the app from local config and validates
+// the cron name against the declared [cron.<name>] set (#152). An undeclared
+// name must fail the preview instead of echoing "Would trigger".
+#[test]
+fn test_dry_run_cron_run_unknown_name_errors_from_config() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        "[app]\nname = \"my-app\"\n\n[cron.daily]\nschedule = \"0 9 * * *\"\ncommand = \"./r.sh\"\nservice = \"web\"\n",
+    )
+    .unwrap();
+
+    floo()
+        .args(["--json", "--dry-run", "cron", "run", "does-not-exist"])
+        .current_dir(project.path())
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"CRON_JOB_NOT_FOUND"#));
+}
+
+// A declared name still previews (and exits 0) on the config-resolved path.
+#[test]
+fn test_dry_run_cron_run_declared_name_previews_from_config() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        "[app]\nname = \"my-app\"\n\n[cron.daily]\nschedule = \"0 9 * * *\"\ncommand = \"./r.sh\"\nservice = \"web\"\n",
+    )
+    .unwrap();
+
+    floo()
+        .args(["--dry-run", "cron", "run", "daily"])
+        .current_dir(project.path())
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would trigger cron job 'daily'"));
+}
+
 #[test]
 fn test_cron_show_not_authenticated() {
     floo()

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1643,12 +1643,16 @@ fn test_dry_run_db_migrate_human_has_preview() {
 }
 
 #[test]
-fn test_dry_run_unsupported_init() {
+fn test_dry_run_init_emits_preview() {
+    // `floo init --dry-run` is a supported, non-interactive preview that lists
+    // the files it would create (see init::init_dry_run; "init" is in
+    // DRY_RUN_SUPPORTED_COMMANDS). It must succeed and emit a structured plan,
+    // not be rejected as unsupported.
     floo()
         .args(["--json", "--dry-run", "init", "my-app"])
         .assert()
-        .failure()
-        .stdout(predicate::str::contains("not supported"));
+        .success()
+        .stdout(predicate::str::contains(r#""action":"init"#));
 }
 
 /// Regression for the prior contract bug: human dry-run output was

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -205,13 +205,13 @@ fn test_apps_list_human() {
 }
 
 #[test]
-fn test_apps_status_json() {
+fn test_apps_show_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
 
     floo()
-        .args(["--json", "apps", "status", TEST_APP_NAME])
+        .args(["--json", "apps", "show", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -220,16 +220,16 @@ fn test_apps_status_json() {
 }
 
 #[test]
-fn test_apps_status_with_app_flag() {
+fn test_apps_show_with_app_flag() {
     // Parity with the rest of the CLI's flag-based API: `--app` is
     // accepted in addition to the legacy positional form. Closes
-    // feedback 4419e7d3 (2026-05-01) for the `apps status` surface.
+    // feedback 4419e7d3 (2026-05-01) for the `apps show` surface.
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
 
     floo()
-        .args(["--json", "apps", "status", "--app", TEST_APP_NAME])
+        .args(["--json", "apps", "show", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -238,7 +238,7 @@ fn test_apps_status_with_app_flag() {
 }
 
 #[test]
-fn test_apps_status_json_surfaces_runtime_url() {
+fn test_apps_show_json_surfaces_runtime_url() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let runtime_url = "https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app";
@@ -257,7 +257,7 @@ fn test_apps_status_json_surfaces_runtime_url() {
         .create();
 
     floo()
-        .args(["--json", "apps", "status", TEST_APP_NAME])
+        .args(["--json", "apps", "show", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -266,7 +266,7 @@ fn test_apps_status_json_surfaces_runtime_url() {
 }
 
 #[test]
-fn test_apps_status_human_includes_runtime_url() {
+fn test_apps_show_human_includes_runtime_url() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let runtime_url = "https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app";
@@ -286,7 +286,7 @@ fn test_apps_status_human_includes_runtime_url() {
     let _m_org = mock_org_me(&mut server);
 
     floo()
-        .args(["apps", "status", TEST_APP_NAME])
+        .args(["apps", "show", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -502,7 +502,7 @@ fn test_env_list_json() {
 }
 
 #[test]
-fn test_env_remove_json() {
+fn test_env_unset_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -521,7 +521,7 @@ fn test_env_remove_json() {
         .create();
 
     floo()
-        .args(["--json", "env", "remove", "my_key", "--app", TEST_APP_NAME])
+        .args(["--json", "env", "unset", "my_key", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -860,7 +860,7 @@ fn test_domains_list_multi_service_with_services_flag() {
 }
 
 #[test]
-fn test_domains_status_json() {
+fn test_domains_show_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -881,7 +881,7 @@ fn test_domains_status_json() {
         .args([
             "--json",
             "domains",
-            "status",
+            "show",
             "app.example.com",
             "--app",
             TEST_APP_NAME,
@@ -894,7 +894,7 @@ fn test_domains_status_json() {
 }
 
 #[test]
-fn test_domains_status_not_found() {
+fn test_domains_show_not_found() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -910,7 +910,7 @@ fn test_domains_status_not_found() {
         .args([
             "--json",
             "domains",
-            "status",
+            "show",
             "missing.example.com",
             "--app",
             TEST_APP_NAME,
@@ -1529,14 +1529,14 @@ fn test_services_list_empty_when_no_services_of_either_kind() {
 }
 
 #[test]
-fn test_services_info_user_managed() {
+fn test_services_show_user_managed() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
     let _services = mock_services_single(&mut server);
 
     floo()
-        .args(["--json", "services", "info", "web", "--app", TEST_APP_NAME])
+        .args(["--json", "services", "show", "web", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()
@@ -1546,7 +1546,7 @@ fn test_services_info_user_managed() {
 }
 
 #[test]
-fn test_services_info_routes_to_managed_service_by_type() {
+fn test_services_show_routes_to_managed_service_by_type() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -1590,7 +1590,7 @@ fn test_services_info_routes_to_managed_service_by_type() {
         .args([
             "--json",
             "services",
-            "info",
+            "show",
             "postgres",
             "--app",
             TEST_APP_NAME,
@@ -1606,7 +1606,7 @@ fn test_services_info_routes_to_managed_service_by_type() {
 }
 
 #[test]
-fn test_services_info_nothing_matches_lists_available() {
+fn test_services_show_nothing_matches_lists_available() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -1633,7 +1633,7 @@ fn test_services_info_nothing_matches_lists_available() {
         .create();
 
     floo()
-        .args(["--json", "services", "info", "nope", "--app", TEST_APP_NAME])
+        .args(["--json", "services", "show", "nope", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .failure()
@@ -1643,7 +1643,7 @@ fn test_services_info_nothing_matches_lists_available() {
 }
 
 #[test]
-fn test_services_info_app_not_found() {
+fn test_services_show_app_not_found() {
     let mut server = Server::new();
     let home = setup_config(&server);
 
@@ -1659,7 +1659,7 @@ fn test_services_info_app_not_found() {
         .create();
 
     floo()
-        .args(["--json", "services", "info", "db", "--app", "missing-app"])
+        .args(["--json", "services", "show", "db", "--app", "missing-app"])
         .env("HOME", home.path())
         .assert()
         .failure()
@@ -1667,7 +1667,7 @@ fn test_services_info_app_not_found() {
 }
 
 #[test]
-fn test_services_info_surfaces_api_errors() {
+fn test_services_show_surfaces_api_errors() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
@@ -1687,7 +1687,7 @@ fn test_services_info_surfaces_api_errors() {
         .args([
             "--json",
             "services",
-            "info",
+            "show",
             "postgres",
             "--app",
             TEST_APP_NAME,
@@ -2009,7 +2009,7 @@ fn test_app_not_found_json() {
         .create();
 
     floo()
-        .args(["--json", "apps", "status", "nonexistent"])
+        .args(["--json", "apps", "show", "nonexistent"])
         .env("HOME", home.path())
         .assert()
         .failure()
@@ -2017,7 +2017,7 @@ fn test_app_not_found_json() {
 }
 
 #[test]
-fn test_apps_status_uuid_surfaces_get_app_api_error() {
+fn test_apps_show_uuid_surfaces_get_app_api_error() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let app_id = "11111111-1111-1111-1111-111111111111";
@@ -2030,7 +2030,7 @@ fn test_apps_status_uuid_surfaces_get_app_api_error() {
         .create();
 
     floo()
-        .args(["--json", "apps", "status", app_id])
+        .args(["--json", "apps", "show", app_id])
         .env("HOME", home.path())
         .assert()
         .failure()
@@ -2039,7 +2039,7 @@ fn test_apps_status_uuid_surfaces_get_app_api_error() {
 }
 
 #[test]
-fn test_apps_status_name_surfaces_list_apps_api_error() {
+fn test_apps_show_name_surfaces_list_apps_api_error() {
     let mut server = Server::new();
     let home = setup_config(&server);
 
@@ -2055,7 +2055,7 @@ fn test_apps_status_name_surfaces_list_apps_api_error() {
         .create();
 
     floo()
-        .args(["--json", "apps", "status", TEST_APP_NAME])
+        .args(["--json", "apps", "show", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .failure()


### PR DESCRIPTION
## Summary

Closes #152, plus review-driven CLI-wide hardening and a cleanup of pre-existing test breakage so the **entire suite is green**. Rebased onto `main` — the unrelated `[domains."<host>"]` commit it was previously stacked on was dropped (it lands via its own branch).

### 1. `floo cron run` (#152)
- **`--dry-run` validated nothing.** It echoed `Would trigger …` before any existence check. Now, on the config-resolved path (no `--app`), it loads the local `floo.app.toml` the way the real run does and errors if the name isn't in the declared `[cron.<name>]` set. The `--app` path resolves server-side and never reads local config, so it stays an offline echo rather than a false rejection.
- **Not-found help never fired.** The hint was gated on `e.code == "NOT_FOUND"`, but the API emits `CRON_JOB_NOT_FOUND`. Added `FlooApiError::is_not_found()` (HTTP **404**, the stable contract) and routed the cron sites through it.

### 2. CLI-wide hardening (review follow-up)
- **Adopted `is_not_found()` everywhere safe**: app resolution in `mod`/`deploy`/`github`(×2)/`logs`(×2) and release lookup in `releases` (its `app_id` is pre-resolved, so a 404 is the release). Non-404 business codes (`DEVICE_*`/`EMAIL_TAKEN`/`WAITLISTED`/`GITHUB_*`) intentionally left as code-string checks.
- **De-duplicated the cwd reader** into `commands::read_cwd_or_exit()` across all 8 call sites (the inline copies had drifted between `CwdError`+hint and `FileError`+none).

### 3. Pre-existing `main` failures fixed (so CI is green)
All failed on `origin/main`, independent of this change:
- **`preflight` Rails Cloud SQL warning** was scrubbed to `***REDACTED***` because its illustrative DSN embedded `user:pass@`; reworded the hardcoded examples to non-credential shapes.
- **`init --dry-run`** is a supported preview; replaced the stale `test_dry_run_unsupported_init` with `test_dry_run_init_emits_preview`.
- **15 `mock_api_tests`** drove subcommands renamed away in #143/#144 (`apps status`→`apps show`, `services info`→`services show`, `domains status`→`domains show`, `env remove`→`env unset`). Pure alias renames, so only the invocations changed; the mocks/assertions and the only mock-API coverage these commands have are preserved.
- **Parallel-test flake**: 4 in-process tests mutating the global `JSON_MODE`/`DRY_RUN` raced under parallel `cargo test`. Serialized them with a shared `#[cfg(test)]` mutex (dependency-free).

## Verification
- **Full `cargo test` green in parallel and single-threaded**: 400 unit (×3 bins), 109 `cli_tests`, 75 `mock_api_tests` — **0 failures**. Flake fix confirmed over 8/8 parallel runs.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)