### PR TITLE
docs(cli): note pgvector resolves unqualified in `floo docs services`

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -198,6 +198,11 @@ confirmation. See also: floo docs state-model.
     redis    → REDIS_URL
     storage  → STORAGE_BUCKET + STORAGE_URL (use STORAGE_URL for signed URLs)
 
+  Postgres ships with pgvector enabled. The `vector` type resolves
+  unqualified: use it in migrations and queries with no CREATE EXTENSION
+  and no schema prefix. Rails (`t.vector`), Django, SQLAlchemy, and Prisma
+  all emit the bare type. Full guide: https://docs.getfloo.com/guides/databases
+
   In multi-service apps, attach those credentials per service:
     [services.api.env]
     managed = [\"postgres\", \"redis\"]


### PR DESCRIPTION
## What

Adds a short note to the `SERVICES` cheatsheet (`floo docs services`) that managed Postgres ships with pgvector enabled and the `vector` type resolves **unqualified** (no `CREATE EXTENSION`, no schema prefix; Rails/Django/SQLAlchemy/Prisma all emit the bare type), linking to the full guide.

## Why

Keeps the offline CLI doc mirror aligned with the customer docs (getfloo/floo-docs#19) and the platform fix getfloo/floo#1016, which set the app-role `search_path` to `"<schema>", public` so a bare `vector` actually resolves.

Cheatsheet-text-only; `cargo build` + `cargo fmt --check` pass, no test/snapshot affected.