### PR TITLE
fix(deploy): key app-not-found on 404 status; drop dead --app resolution branch

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -510,58 +510,41 @@ pub fn deploy(
 
     let client = super::init_client(Some(config));
 
-    // Resolve or create app via API
-    let app_data = if matches!(resolved.source, AppSource::Flag) {
-        // --app flag: look up existing app
-        let app_ident = &resolved.app_name;
-        let spinner = output::Spinner::new("Looking up app...");
-        let result = match resolve_app(&client, app_ident) {
-            Ok(app_data) => app_data,
-            Err(error) => {
-                spinner.finish();
-                if error.code == "APP_NOT_FOUND" {
-                    output::error(
-                        &format!("App '{app_ident}' not found."),
-                        &ErrorCode::AppNotFound,
-                        Some("Check the app name or ID and try again."),
-                    );
-                } else {
-                    output::error(&error.message, &ErrorCode::from_api(&error.code), None);
+    // Resolve or create app via API.
+    //
+    // Path 3 only runs without --app — the early Some(app) block (Path 1 & 2)
+    // always returns first — so the app is resolved from local config here:
+    // look it up by name and create it if the API reports it doesn't exist yet.
+    let spinner = output::Spinner::new(&format!("Looking up app {}...", resolved.app_name));
+    let app_data = match resolve_app(&client, &resolved.app_name) {
+        Ok(app_data) => {
+            spinner.finish();
+            app_data
+        }
+        // 404 == app doesn't exist yet → create it (gate on status, not a
+        // drift-prone code string; see is_not_found). resolve_app hits
+        // GET /v1/apps/{id} for UUID-shaped names, so the server's own code
+        // flows through verbatim and a code-string match would miss a 404
+        // carrying anything other than APP_NOT_FOUND.
+        Err(error) if error.is_not_found() => {
+            spinner.finish();
+            let spinner = output::Spinner::new(&format!("Creating app {}...", resolved.app_name));
+            match client.create_app(&resolved.app_name, Some(&detection.runtime)) {
+                Ok(a) => {
+                    spinner.finish();
+                    a
                 }
-                process::exit(1);
-            }
-        };
-        spinner.finish();
-        result
-    } else {
-        // Config file: look up by name, create if not found
-        let spinner = output::Spinner::new(&format!("Looking up app {}...", resolved.app_name));
-        match resolve_app(&client, &resolved.app_name) {
-            Ok(app_data) => {
-                spinner.finish();
-                app_data
-            }
-            Err(error) if error.code == "APP_NOT_FOUND" => {
-                spinner.finish();
-                let spinner =
-                    output::Spinner::new(&format!("Creating app {}...", resolved.app_name));
-                match client.create_app(&resolved.app_name, Some(&detection.runtime)) {
-                    Ok(a) => {
-                        spinner.finish();
-                        a
-                    }
-                    Err(e) => {
-                        spinner.finish();
-                        output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-                        process::exit(1);
-                    }
+                Err(e) => {
+                    spinner.finish();
+                    output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                    process::exit(1);
                 }
             }
-            Err(error) => {
-                spinner.finish();
-                output::error(&error.message, &ErrorCode::from_api(&error.code), None);
-                process::exit(1);
-            }
+        }
+        Err(error) => {
+            spinner.finish();
+            output::error(&error.message, &ErrorCode::from_api(&error.code), None);
+            process::exit(1);
         }
     };
     let app_id = app_data.id.clone();

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1878,6 +1878,116 @@ fn test_deploy_existing_app_by_name_json() {
         .stdout(predicate::str::contains(r#""deploy""#));
 }
 
+// ───────── Deploy not-found keyed on HTTP 404 status (#152 follow-up) ─────────
+//
+// #157 hardened resolve_app_or_exit / logs / releases / github / the deploy()
+// --app restart path onto FlooApiError::is_not_found(), but the config-resolved
+// create path (deploy.rs ~544) still read the drift-prone `code ==
+// "APP_NOT_FOUND"` string. These tests pin not-found detection to the 404
+// status: when resolve_app hits GET /v1/apps/{id} (UUID identifiers) the
+// server's own 404 + code flow through unchanged, so a code-string gate misses
+// a 404 carrying any other code. Keyed on status, the path fires regardless.
+
+// Guards the live `--app` resolution path (deploy.rs ~300, migrated by #157):
+// `floo deploy --app <missing>` must surface the friendly app-not-found error +
+// suggestion even when the server's 404 carries a non-APP_NOT_FOUND code. The
+// `--app` early-return block handles every Some(app) case, so this is the only
+// reachable `--app` not-found path (the unreachable AppSource::Flag branch in
+// Path 3 was removed in this change).
+#[test]
+fn test_deploy_app_flag_not_found_keyed_on_status() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    // A UUID --app routes resolve_app to GET /v1/apps/{id}, so the server code
+    // (here NOT_FOUND, not APP_NOT_FOUND) reaches the gate verbatim.
+    let missing = "11111111-1111-1111-1111-111111111111";
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    write_service_config(&project, TEST_APP_NAME);
+
+    let _m_get = server
+        .mock("GET", format!("/v1/apps/{missing}").as_str())
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"NOT_FOUND","message":"Not found"}}"#)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "redeploy",
+            project.path().to_str().unwrap(),
+            "--app",
+            missing,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        // The friendly app-not-found error + suggestion only fire on the
+        // is_not_found() branch; the old string gate fell through to the raw
+        // NOT_FOUND error with no suggestion.
+        .stdout(predicate::str::contains("APP_NOT_FOUND"))
+        .stdout(predicate::str::contains(
+            "Check the app name or ID and try again.",
+        ));
+}
+
+#[test]
+fn test_deploy_config_not_found_keyed_on_status_creates() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    // Config-resolved (no --app): a UUID app name in floo.service.toml routes
+    // resolve_app to GET /v1/apps/{id}, so a 404 carrying a drifted code must
+    // still be treated as "app doesn't exist yet" → create it, not surfaced as
+    // a hard error.
+    let missing = "22222222-2222-2222-2222-222222222222";
+
+    let project = TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    write_service_config(&project, missing);
+
+    let _m_get = server
+        .mock("GET", format!("/v1/apps/{missing}").as_str())
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"NOT_FOUND","message":"Not found"}}"#)
+        .create();
+
+    let _m_create = server
+        .mock("POST", "/v1/apps")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"{TEST_APP_ID}","name":"web","status":"created","runtime":"nodejs"}}"#
+        ))
+        .create();
+
+    let _m_deploy = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"deploy-001","status":"live","url":"https://web.floo.app","build_logs":""}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "redeploy", project.path().to_str().unwrap()])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#));
+}
+
 #[test]
 fn test_deploy_fails_with_invalid_response_when_app_id_missing() {
     let mut server = Server::new();


### PR DESCRIPTION
## What

Completes the not-found error-code drift hardening started in #157 (issue #152) by migrating the **last two** app-resolution gates in `deploy()` off the drift-prone `code == "APP_NOT_FOUND"` string and onto `FlooApiError::is_not_found()` (the HTTP-404 wire contract).

## Why

`FlooApiError::handle_error` reads `code` from the server's JSON body but `status_code` from the real HTTP status, so a hard-coded `code` string silently stops matching the moment the API renames it. #157 fixed this class CLI-wide, but two gates inside `deploy()` were left behind:

- **Config-resolved create path** (was `deploy.rs:544`) — **reachable**. `resolve_app` hits `GET /v1/apps/{id}` for UUID-shaped names, so the server's own code flows through verbatim. If the API's `APP_NOT_FOUND` drifted, deploy would stop creating not-yet-existing apps and surface a raw error instead. Now keyed on the 404 status.
- **`AppSource::Flag` branch** (was `deploy.rs:522`) — **dead code**. `deploy()`'s early `Some(app)` block (Path 1 & 2) returns before Path 3, so `resolved.source` is never `Flag` there. Rather than leave a never-executed path carrying a drift gate, the dead branch is removed entirely; Path 3 now has a single, linear config-resolution path.

## Scope notes

- The `github.rs` semantic codes were checked against `getfloo/floo` and **deliberately left alone**: `GITHUB_APP_NOT_INSTALLED` and `GITHUB_REPO_NOT_IN_INSTALLATION` are **422**, and `GITHUB_NOT_CONNECTED` is **404 in one route but 400 in three others** — so the code-string match is actually *more* correct there than a status match. `auth.rs` device-flow/email codes are not status-based and are untouched.
- The live `--app` deploy not-found path (`deploy.rs ~300`, migrated by #157) had no integration coverage; this PR adds it.

## Tests

- `test_deploy_config_not_found_keyed_on_status_creates` — proves the config create path fires (and creates the app) when the server 404s with a **non-`APP_NOT_FOUND`** code (`NOT_FOUND`). Written red against the old string gate, green after.
- `test_deploy_app_flag_not_found_keyed_on_status` — guards the live `--app` not-found path surfaces the friendly error + suggestion under a drifted 404 code.

## Verification

- `cargo test` — 400 (unit ×3) + 109 (cli) + 77 (mock-api) passing
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

Follow-up to #152 / #157. (#152 was already closed by #157; this finishes the residual gates that PR missed.)
