### PR TITLE
feat: add logs query and tail commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -752,6 +752,7 @@ impl FlooClient {
         severity: Option<&str>,
         service: Option<&str>,
         search: Option<&str>,
+        deployment: Option<&str>,
         environment: Option<&str>,
     ) -> Result<LogsResponse, FlooApiError> {
         let limit_str = limit.to_string();
@@ -767,6 +768,9 @@ impl FlooClient {
         }
         if let Some(q) = search {
             params.push(("search", q));
+        }
+        if let Some(dep) = deployment {
+            params.push(("deployment", dep));
         }
         if let Some(env) = environment {
             params.push(("environment", env));

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -356,12 +356,21 @@ pub struct LogEntry {
     pub timestamp: Option<String>,
     pub severity: Option<String>,
     pub message: Option<String>,
+    pub deployment_id: Option<String>,
+    pub request_id: Option<String>,
+    pub labels: Option<serde_json::Value>,
     pub service_name: Option<String>,
+    pub cron_job_name: Option<String>,
+    pub deploy_context: Option<serde_json::Value>,
+    pub severity_class: Option<String>,
+    pub lifecycle_noise: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogsResponse {
     pub logs: Vec<LogEntry>,
+    pub total: Option<i32>,
+    pub app_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 use crate::commands;
 use crate::constants::VERSION;
@@ -265,56 +265,16 @@ Examples:
     /// View runtime logs for an app.
     #[command(after_help = "\
 Examples:
-  floo logs --app my-app                   Last 100 log lines
-  floo logs --app my-app --since 1h --error  Errors in the last hour
-  floo logs --app my-app --live            Stream logs in real-time
-  floo logs --app my-app --json            Structured JSON output")]
+  floo logs query --app my-app --since 1h         Query stored runtime logs
+  floo logs query --app my-app --deployment latest --json
+  floo logs tail --app my-app --env prod          Stream runtime logs
+  floo logs --app my-app --live                   Backwards-compatible tail")]
     Logs {
-        /// App name or ID (overrides config file).
-        #[arg(short, long)]
-        app: Option<String>,
+        #[command(subcommand)]
+        command: Option<Box<LogsSubcommands>>,
 
-        /// Number of log lines to show.
-        #[arg(short, long, default_value = "100")]
-        tail: u32,
-
-        /// Show logs since a time (e.g., 1h, 30m, 2d, or ISO timestamp).
-        #[arg(short, long)]
-        since: Option<String>,
-
-        /// Filter to errors only (shorthand for --severity ERROR).
-        #[arg(short, long)]
-        error: bool,
-
-        /// Minimum severity level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
-        #[arg(long)]
-        severity: Option<String>,
-
-        /// Filter logs to specific services (repeatable).
-        #[arg(long)]
-        services: Vec<String>,
-
-        /// Filter log messages by text (case-insensitive).
-        #[arg(long)]
-        search: Option<String>,
-
-        /// Stream logs in real-time (poll every 2s). Works with --requests too.
-        #[arg(short = 'f', long, alias = "follow", conflicts_with = "output")]
-        live: bool,
-
-        /// Write logs to a file (JSON or plain text based on --json flag).
-        #[arg(short, long)]
-        output: Option<PathBuf>,
-
-        /// Environment to query: dev or prod.
-        #[arg(long, value_parser = ["dev", "prod"])]
-        env: Option<String>,
-
-        /// Show HTTP requests captured by floo's gateway instead of app-level
-        /// log output. Each line is one proxied request with the public URL,
-        /// status, and latency.
-        #[arg(long)]
-        requests: bool,
+        #[command(flatten)]
+        options: LogsOptions,
     },
 
     /// Install agent skills for AI coding assistants.
@@ -422,6 +382,74 @@ material, no Cloud Run audit payloads. Those live on dedicated surfaces."
         /// Specific release tag to install (e.g. v0.2.0).
         #[arg(long)]
         version: Option<String>,
+    },
+}
+
+#[derive(Args, Clone)]
+pub struct LogsOptions {
+    /// App name or ID (overrides config file).
+    #[arg(short, long)]
+    app: Option<String>,
+
+    /// Number of log lines to show.
+    #[arg(short, long, default_value = "100")]
+    tail: u32,
+
+    /// Show logs since a time (e.g., 1h, 30m, 2d, or ISO timestamp).
+    #[arg(short, long)]
+    since: Option<String>,
+
+    /// Filter to errors only (shorthand for --severity ERROR).
+    #[arg(short, long)]
+    error: bool,
+
+    /// Minimum severity level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+    #[arg(long)]
+    severity: Option<String>,
+
+    /// Filter logs to specific services (repeatable).
+    #[arg(long)]
+    services: Vec<String>,
+
+    /// Filter log messages by text (case-insensitive).
+    #[arg(long)]
+    search: Option<String>,
+
+    /// Filter by deployment ID, or 'latest' for the app's latest deploy.
+    #[arg(long)]
+    deployment: Option<String>,
+
+    /// Stream logs in real-time (poll every 2s). Works with --requests too.
+    #[arg(short = 'f', long, alias = "follow", conflicts_with = "output")]
+    live: bool,
+
+    /// Write logs to a file (JSON or plain text based on --json flag).
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Environment to query: dev or prod.
+    #[arg(long, value_parser = ["dev", "prod"])]
+    env: Option<String>,
+
+    /// Show HTTP requests captured by floo's gateway instead of app-level
+    /// log output. Each line is one proxied request with the public URL,
+    /// status, and latency.
+    #[arg(long)]
+    requests: bool,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum LogsSubcommands {
+    /// Query stored runtime logs once.
+    Query {
+        #[command(flatten)]
+        options: LogsOptions,
+    },
+
+    /// Tail runtime logs continuously.
+    Tail {
+        #[command(flatten)]
+        options: LogsOptions,
     },
 }
 
@@ -1670,42 +1698,51 @@ pub fn run() {
 
         Commands::Discover => commands::command_tree::commands(),
 
-        Commands::Logs {
-            app,
-            tail,
-            since,
-            error,
-            severity,
-            services,
-            search,
-            live,
-            output,
-            env,
-            requests,
-        } => {
-            if requests {
+        Commands::Logs { command, options } => {
+            let options = match command.map(|boxed| *boxed) {
+                Some(LogsSubcommands::Query { options }) => options,
+                Some(LogsSubcommands::Tail { options }) => {
+                    if options.output.is_some() {
+                        output::error(
+                            "`floo logs tail` cannot write to --output.",
+                            &crate::errors::ErrorCode::InvalidFormat,
+                            Some(
+                                "Use `floo logs query --output <path>` for a finite log snapshot.",
+                            ),
+                        );
+                        std::process::exit(1);
+                    }
+                    let mut options = options;
+                    options.live = true;
+                    options
+                }
+                None => options,
+            };
+
+            if options.requests {
                 commands::logs::request_logs(commands::logs::RequestLogsArgs {
-                    app_flag: app,
-                    tail,
-                    since,
-                    live,
+                    app_flag: options.app,
+                    tail: options.tail,
+                    since: options.since,
+                    live: options.live,
                 });
             } else {
-                let severity = if error {
+                let severity = if options.error {
                     Some("ERROR".to_string())
                 } else {
-                    severity
+                    options.severity
                 };
                 commands::logs::logs(commands::logs::LogsArgs {
-                    app_flag: app,
-                    tail,
-                    since,
+                    app_flag: options.app,
+                    tail: options.tail,
+                    since: options.since,
                     severity,
-                    services,
-                    search,
-                    live,
-                    output_path: output,
-                    env,
+                    services: options.services,
+                    search: options.search,
+                    deployment: options.deployment,
+                    live: options.live,
+                    output_path: options.output,
+                    env: options.env,
                 });
             }
         }

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -277,9 +277,24 @@ fn command_tree() -> Vec<CommandInfo> {
         CommandInfo {
             name: "logs",
             description: "View runtime logs for an app",
-            usage: "floo logs --app <name> [OPTIONS]",
+            usage: "floo logs <query|tail> --app <name> [OPTIONS]",
             requires_auth: true,
-            subcommands: vec![],
+            subcommands: vec![
+                CommandInfo {
+                    name: "query",
+                    description: "Query stored runtime logs once",
+                    usage: "floo logs query --app <name> [--since 1h] [--service web] [--deployment latest] [--json]",
+                    requires_auth: true,
+                    subcommands: vec![],
+                },
+                CommandInfo {
+                    name: "tail",
+                    description: "Tail runtime logs continuously",
+                    usage: "floo logs tail --app <name> [--env prod] [--service web]",
+                    requires_auth: true,
+                    subcommands: vec![],
+                },
+            ],
         },
         CommandInfo {
             name: "analytics",

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -120,7 +120,7 @@ Floo Quickstart — End-to-End Walkthrough
 ## 6. Check Status
 
   floo apps show my-app
-  floo logs --app my-app
+  floo logs query --app my-app
 
 ## 7. Subsequent Deploys
 
@@ -841,7 +841,9 @@ Floo — Golden Path
 
 ## How to Debug
 
-  floo logs --app my-app --since 1h --error
+  floo logs query --app my-app --since 1h --error
+  floo logs tail --app my-app --env prod
+  floo logs query --app my-app --deployment latest --json
   floo deploys logs <deploy-id> --app my-app
 
 ## Decision Table: What Command Do I Run?
@@ -860,7 +862,7 @@ Floo — Golden Path
   Set an env var                        | floo env set KEY=val --app my-app
   Add a custom domain                   | floo domains add example.com --app my-app (then add CNAME at DNS provider)
   Verify a custom domain                | floo domains verify example.com --app my-app
-  View logs                             | floo logs --app my-app
+  View logs                             | floo logs query --app my-app
   Run locally with prod credentials     | floo dev --app my-app (requires dev_command)
 ";
 

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -21,6 +21,7 @@ pub struct LogsArgs {
     pub severity: Option<String>,
     pub services: Vec<String>,
     pub search: Option<String>,
+    pub deployment: Option<String>,
     pub live: bool,
     pub output_path: Option<PathBuf>,
     pub env: Option<String>,
@@ -31,6 +32,7 @@ struct LogsFilter<'a> {
     severity: Option<&'a str>,
     services: &'a [String],
     search: Option<&'a str>,
+    deployment: Option<&'a str>,
     environment: Option<&'a str>,
 }
 
@@ -83,6 +85,7 @@ fn fetch_logs(
             filter.severity,
             service,
             filter.search,
+            filter.deployment,
             filter.environment,
         ) {
             Ok(r) => r,
@@ -102,6 +105,7 @@ fn fetch_logs(
                 filter.severity,
                 Some(svc),
                 filter.search,
+                filter.deployment,
                 filter.environment,
             ) {
                 Ok(r) => r,
@@ -140,6 +144,7 @@ fn try_fetch_logs(
             filter.severity,
             service,
             filter.search,
+            filter.deployment,
             filter.environment,
         )?;
         Ok(result.logs)
@@ -153,6 +158,7 @@ fn try_fetch_logs(
                 filter.severity,
                 Some(svc),
                 filter.search,
+                filter.deployment,
                 filter.environment,
             )?;
             all_logs.extend(result.logs);
@@ -179,6 +185,12 @@ fn print_context_header(app_name: &str, source_label: &str, filter: &LogsFilter)
     }
     if let Some(q) = filter.search {
         eprintln!("  {} \"{}\"", "Search:".bold(), q);
+    }
+    if let Some(deployment) = filter.deployment {
+        eprintln!("  {} {}", "Deployment:".bold(), deployment);
+    }
+    if let Some(environment) = filter.environment {
+        eprintln!("  {} {}", "Environment:".bold(), environment);
     }
     eprintln!("  {}", "\u{2500}".repeat(40).dimmed());
     eprintln!();
@@ -281,6 +293,7 @@ pub fn logs(args: LogsArgs) {
         severity: args.severity.as_deref(),
         services: &args.services,
         search: args.search.as_deref(),
+        deployment: args.deployment.as_deref(),
         environment: args.env.as_deref(),
     };
 
@@ -446,6 +459,7 @@ fn live_logs(
             severity: filter.severity,
             services: filter.services,
             search: filter.search,
+            deployment: filter.deployment,
             environment: filter.environment,
         };
 
@@ -745,7 +759,14 @@ mod tests {
             timestamp: Some(ts.to_string()),
             severity: Some(sev.to_string()),
             message: Some(msg.to_string()),
+            deployment_id: None,
+            request_id: None,
+            labels: None,
             service_name: Some(svc.to_string()),
+            cron_job_name: None,
+            deploy_context: None,
+            severity_class: None,
+            lifecycle_noise: None,
         }
     }
 
@@ -775,7 +796,14 @@ mod tests {
             timestamp: Some("2024-01-01T00:00:00Z".to_string()),
             severity: Some("ERROR".to_string()),
             message: Some("something broke".to_string()),
+            deployment_id: None,
+            request_id: None,
+            labels: None,
             service_name: None,
+            cron_job_name: None,
+            deploy_context: None,
+            severity_class: None,
+            lifecycle_noise: None,
         };
 
         let line = format_log_line(&entry, true);

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -539,6 +539,25 @@ fn test_logs_help() {
 }
 
 #[test]
+fn test_logs_query_help() {
+    floo()
+        .args(["logs", "query", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Query stored runtime logs"))
+        .stdout(predicate::str::contains("--deployment"));
+}
+
+#[test]
+fn test_logs_tail_help() {
+    floo()
+        .args(["logs", "tail", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tail runtime logs continuously"));
+}
+
+#[test]
 fn test_logs_not_authenticated() {
     floo()
         .args(["logs", "--app", "my-app"])

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1137,6 +1137,49 @@ fn test_logs_json() {
 }
 
 #[test]
+fn test_logs_query_json_with_deployment_filter() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_logs = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("deployment".into(), "latest".into()),
+            Matcher::UrlEncoded("environment".into(), "prod".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"INFO","message":"Prod deploy booted","deployment_id":"deploy-123","service_name":"web","deploy_context":{"deploy_id":"deploy-123"}}],"total":1,"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "logs",
+            "query",
+            "--app",
+            TEST_APP_NAME,
+            "--deployment",
+            "latest",
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("Prod deploy booted"))
+        .stdout(predicate::str::contains(r#""deployment_id":"deploy-123""#));
+}
+
+#[test]
 fn test_logs_human() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed

- Add explicit `floo logs query` for one-shot runtime log reads and `floo logs tail` for streaming runtime logs.
- Preserve the legacy root `floo logs` behavior, including `--live` / `--follow`.
- Thread `--deployment <id|latest>` through to `/v1/apps/{app_id}/logs` so the CLI can use the deployment-aware API slice from getfloo/floo#918.
- Preserve richer runtime log response metadata in JSON output, including `deployment_id`, `request_id`, `deploy_context`, labels, cron identity, severity class, and lifecycle-noise markers.
- Update command discovery, built-in CLI docs, and mock/help coverage.

## Why

The log access epic calls out CLI and agent access as first-class surfaces. The API can already filter logs by deployment; this makes the CLI expose that contract directly with agent-friendly JSON output.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`

Refs getfloo/floo#918