### PR TITLE
fix(lint): clear clippy -D warnings failures from clippy 1.93 bump

### DIFF
--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn test_value_to_display_number() {
         assert_eq!(value_to_display(&json!(42)), "42");
-        assert_eq!(value_to_display(&json!(3.14)), "3.14");
+        assert_eq!(value_to_display(&json!(2.5)), "2.5");
     }
 
     #[test]

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -616,62 +616,6 @@ enum DeployOutcome {
     },
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        connect_rerun_command, repo_access_timeout_suggestion, setup_session_lost_suggestion,
-        setup_spinner_message, setup_timeout_suggestion,
-    };
-    use crate::api_types::GitHubSetupStatus;
-
-    #[test]
-    fn test_setup_spinner_message_for_org_approval() {
-        assert_eq!(
-            setup_spinner_message(&GitHubSetupStatus::AwaitingOrgApproval),
-            "Waiting for org admin approval..."
-        );
-    }
-
-    #[test]
-    fn test_setup_timeout_suggestion_mentions_repo_and_approval() {
-        let suggestion = setup_timeout_suggestion("floo apps github connect getfloo/example");
-        assert!(suggestion.contains("getfloo/example"));
-        assert!(suggestion.contains("approval"));
-    }
-
-    #[test]
-    fn test_setup_session_lost_suggestion_points_back_to_connect() {
-        let suggestion = setup_session_lost_suggestion("floo apps github connect getfloo/example");
-        assert!(suggestion.contains("floo apps github connect getfloo/example"));
-    }
-
-    #[test]
-    fn test_repo_access_timeout_suggestion_mentions_settings_url() {
-        let suggestion = repo_access_timeout_suggestion(
-            "https://github.com/organizations/getfloo/settings/installations",
-            "floo apps github connect getfloo/example",
-        );
-        assert!(suggestion.contains("settings/installations"));
-        assert!(suggestion.contains("approval"));
-    }
-
-    #[test]
-    fn test_connect_rerun_command_preserves_flags() {
-        let command = connect_rerun_command(
-            "getfloo/example",
-            Some("demo-app"),
-            Some("release"),
-            true,
-            true,
-            true,
-        );
-        assert_eq!(
-            command,
-            "floo apps github connect getfloo/example --app demo-app --branch release --skip-env-check --no-deploy --no-browser"
-        );
-    }
-}
-
 fn run_initial_deploy(
     client: &crate::api_client::FlooClient,
     app_id: &str,
@@ -753,5 +697,61 @@ fn run_initial_deploy(
         DeployOutcome::Failed {
             deploy: output::to_value(&deploy_data),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        connect_rerun_command, repo_access_timeout_suggestion, setup_session_lost_suggestion,
+        setup_spinner_message, setup_timeout_suggestion,
+    };
+    use crate::api_types::GitHubSetupStatus;
+
+    #[test]
+    fn test_setup_spinner_message_for_org_approval() {
+        assert_eq!(
+            setup_spinner_message(&GitHubSetupStatus::AwaitingOrgApproval),
+            "Waiting for org admin approval..."
+        );
+    }
+
+    #[test]
+    fn test_setup_timeout_suggestion_mentions_repo_and_approval() {
+        let suggestion = setup_timeout_suggestion("floo apps github connect getfloo/example");
+        assert!(suggestion.contains("getfloo/example"));
+        assert!(suggestion.contains("approval"));
+    }
+
+    #[test]
+    fn test_setup_session_lost_suggestion_points_back_to_connect() {
+        let suggestion = setup_session_lost_suggestion("floo apps github connect getfloo/example");
+        assert!(suggestion.contains("floo apps github connect getfloo/example"));
+    }
+
+    #[test]
+    fn test_repo_access_timeout_suggestion_mentions_settings_url() {
+        let suggestion = repo_access_timeout_suggestion(
+            "https://github.com/organizations/getfloo/settings/installations",
+            "floo apps github connect getfloo/example",
+        );
+        assert!(suggestion.contains("settings/installations"));
+        assert!(suggestion.contains("approval"));
+    }
+
+    #[test]
+    fn test_connect_rerun_command_preserves_flags() {
+        let command = connect_rerun_command(
+            "getfloo/example",
+            Some("demo-app"),
+            Some("release"),
+            true,
+            true,
+            true,
+        );
+        assert_eq!(
+            command,
+            "floo apps github connect getfloo/example --app demo-app --branch release --skip-env-check --no-deploy --no-browser"
+        );
     }
 }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -10,6 +10,7 @@ const TEST_APP_NAME: &str = "my-app";
 const TEST_ORG_ID: &str = "org-uuid-5678";
 const UPDATE_SUCCESS_SIGNATURE_B64: &str = "J6XvKzQVWSMxsnLl4sAkqMhCXAtDI7AZ/ckGf7BeD+KSiM2YtCjQlsV7cwpNypzRyCd9HU87U5sGeuG4NiJ4TqMHpLdoljLuhR9zXuyDyGgqasRSvqawmbpkrs+YsDaD7scj80uA/eUOKH0XmWu6yJA15gUXq97H+XJSXI1aciDN5jeOdqaMAgZfYhIvINzxi2O59iTnv4+EdFeBT4MHWdO5WknsAhk13kQYMLoUbbXBQmWjGTrLlJhLiNcfsub8yJvJG347It2To4/Bz6oUrfNyS8jAmxUhYoJjn+8dOOd8x8rmzHyCa7sCuUgk3UThTEzkKhHjhAieMVatm/+L8W3bE3LKIKYwQlclNmAdXcHlUmwXLxJnVBbJdf1juqqsPh8Nz0/0BqSu5WmxA4/w/WoRCXfegsiM8fUeacbpx44DjLDhye8zkc/LnXrqkL5u+x5TOwlb+GRu5x+BvyocXp4xBF8Yw/kExWk54fSPSNUkGZSFACqSSHY9CkBtqQy1";
 
+#[allow(deprecated)]
 fn floo() -> Command {
     Command::cargo_bin("floo-local").unwrap()
 }
@@ -1804,9 +1805,9 @@ fn test_deploy_new_app_json() {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(format!(
-            r#"{{"id":"deploy-001","status":"live","url":"https://test-deploy.floo.app","build_logs":""}}"#
-        ))
+        .with_body(
+            r#"{"id":"deploy-001","status":"live","url":"https://test-deploy.floo.app","build_logs":""}"#,
+        )
         .create();
 
     floo()


### PR DESCRIPTION
## What changed

`cargo clippy --all-targets -- -D warnings` — the repo's stated lint bar (CLAUDE.md) — was **red on `main`** after a clippy 1.93.0 toolchain bump surfaced new lints. All are in **test code**, unrelated to any feature work:

| File | Lint | Fix |
|------|------|-----|
| `src/commands/db.rs` | `approx_constant` | `json!(3.14)` test literal read as an approximation of π. Swapped to `2.5` (still exercises the float-display branch) rather than `#[allow]`-ing it. |
| `src/commands/github.rs` | `items_after_test_module` | `run_initial_deploy` sat *after* the `#[cfg(test)] mod tests` block. Moved it **above** the test module — pure move, no content change. |
| `tests/mock_api_tests.rs` | `useless_format` | `format!(r#"...{{...}}..."#)` with no interpolation args. Replaced with the plain `&str` literal already used by the 42 other `.with_body(...)` calls in the file. |
| `tests/mock_api_tests.rs` | `cargo_bin` deprecation (→ error under `-D warnings`) | Added `#[allow(deprecated)]` to the `floo()` helper, matching the **existing convention** in `tests/cli_tests.rs`. |

## Why the last two weren't in the original report

The first two lints fail on the **bin-test** targets, which clippy compiles first — so it aborted there and never reached the **integration-test** targets. Fixing db.rs + github.rs let clippy proceed, exposing the two `mock_api_tests.rs` issues (same toolchain-bump class). All four are needed for `--all-targets` to go green.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (exit 0)
- `cargo test` ✅ — 586 tests pass (400 unit + 109 + 77 integration)

No production code changed; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)