### PR TITLE
feat(config): #185 per-service production command + worker-misboot preflight gate

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -784,6 +784,7 @@ mod tests {
             min_instances: None,
             dev_command: dev_command.map(String::from),
             migrate_command: None,
+            command: None,
             env: None,
         }
     }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -335,6 +335,25 @@ Floo Config Files
   port = 3000
   ingress = \"public\"
 
+  Background worker (Sidekiq / Celery / Active Job) sharing the web codebase:
+
+  [services.web]
+  type = \"web\"
+  path = \".\"
+  port = 3000
+  dev_command = \"bin/dev\"
+
+  [services.worker]
+  type = \"worker\"
+  path = \".\"                          # same build as web -> same Dockerfile + CMD
+  port = 3000                          # required even for workers (Cloud Run needs a port)
+  ingress = \"internal\"                # no public HTTP
+  command = \"bundle exec sidekiq\"     # REQUIRED: without it the worker boots the web command
+
+  Without `command` on a shared-build worker, preflight fails: in production every
+  service at the same path runs the same Dockerfile CMD, so the worker would boot
+  the web process and silently never drain its queue.
+
 ## floo.service.toml — Legacy Single-Service Format
 
   Still supported for backward compatibility. Single-service apps may use:
@@ -361,6 +380,14 @@ Floo Config Files
                      (against the prod schema). Non-fatal: a failure is logged
                      but does not block the deploy from going live.
                      e.g., \"alembic upgrade head\", \"npx prisma migrate deploy\"
+
+  command          — optional PRODUCTION start command; overrides the image's
+                     Dockerfile CMD. Omit it to run the Dockerfile CMD (default).
+                     REQUIRED on a worker that shares a build (same path) with a
+                     web/api service, so the worker runs its own process instead
+                     of the web command. Runs via `sh -c <command>` as written;
+                     prefix `exec` for SIGTERM/graceful shutdown (Docker pattern).
+                     e.g., \"bundle exec sidekiq\", \"celery -A app worker\"
 
   domain           — optional custom domain for this service
                      e.g., \"api.example.com\"

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -435,18 +435,23 @@ fn validate_worker_command_collision(config: &AppFileConfig) -> Result<(), FlooE
     use std::collections::HashMap;
     // Group services by their resolved build identity. `path` defaults to "." when
     // omitted (server behavior), so two services with no explicit path collide.
-    let mut builds: HashMap<(Option<&str>, &str), ServiceBuildGroup> = HashMap::new();
+    let mut builds: HashMap<(Option<&str>, String), ServiceBuildGroup> = HashMap::new();
     for (name, entry) in &config.services {
-        // Normalize the build path exactly as the API does (tarball.py: strip one
-        // leading "./", strip trailing slashes, treat empty/"." as "."). Keying on
-        // the raw string would let a worker at "./" miss grouping with a web at "."
-        // — under-reporting a collision the API still blocks, breaking the mirror.
+        // Canonicalize the build path the way the API gate does (tarball.py's
+        // posixpath.normpath): collapse a leading "./", trailing/duplicate slashes,
+        // and interior "." segments, so "api", "api/", "./api", "api/." and "././api"
+        // all bucket as "api". A partial strip (just leading "./" + trailing "/")
+        // would leave "api/." distinct and under-report a collision the API still
+        // blocks, breaking the mirror.
         let raw = entry.path.as_deref().unwrap_or(".");
-        let trimmed = raw.strip_prefix("./").unwrap_or(raw).trim_end_matches('/');
-        let path = if trimmed.is_empty() || trimmed == "." {
-            "."
+        let parts: Vec<&str> = raw
+            .split('/')
+            .filter(|c| !c.is_empty() && *c != ".")
+            .collect();
+        let path = if parts.is_empty() {
+            ".".to_string()
         } else {
-            trimmed
+            parts.join("/")
         };
         builds
             .entry((entry.repo.as_deref(), path))
@@ -1212,6 +1217,37 @@ port = 3000
 [services.worker]
 type = "worker"
 path = "./"
+port = 3000
+"#,
+        )
+        .unwrap();
+
+        let err = load_app_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("worker"));
+        assert!(err.message.contains("command"));
+    }
+
+    #[test]
+    fn test_worker_collision_normalizes_interior_dot_segments() {
+        // web at "api" and a command-less worker at "api/." are the SAME build dir.
+        // A partial strip would leave "api/." distinct and slip the gate; canonicalizing
+        // interior "." segments (mirroring the API's posixpath.normpath) catches it.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.web]
+type = "web"
+path = "api"
+port = 3000
+
+[services.worker]
+type = "worker"
+path = "api/."
 port = 3000
 "#,
         )

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -289,6 +289,11 @@ pub struct AppServiceEntry {
     pub dev_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_command: Option<String>,
+    /// Production start command (overrides the image's Dockerfile CMD). Lets a worker
+    /// that shares a build with web declare its own production process in
+    /// version-controlled config (#185). Absent → run the Dockerfile CMD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub env: Option<ServiceEnvContract>,
 }
@@ -346,6 +351,7 @@ impl AppServiceEntry {
             min_instances: None,
             dev_command: None,
             migrate_command: None,
+            command: None,
             env: None,
         }
     }
@@ -411,6 +417,72 @@ fn validate_app_config(config: &AppFileConfig) -> Result<(), FlooError> {
     }
     validate_managed_blocks(config)?;
     validate_domain_blocks(&config.domains)?;
+    validate_worker_command_collision(config)?;
+    Ok(())
+}
+
+/// Reject the silent worker-misboot class (#185 / #1009): a `worker` that shares a
+/// build with a non-worker service — the same `(repo, path)` resolves to one
+/// Dockerfile and therefore one CMD — but declares no production `command`. In
+/// production it would boot that service's CMD instead of its own queue processor,
+/// a silent failure (the queue is never drained). `command` is the version-controlled
+/// differentiator. Mirrors the API gate in api/app/utils/tarball.py. No prod app uses
+/// the legacy FLOO_PROCESS entrypoint switch, so there is no transitional case to
+/// grandfather — clean hard error.
+type ServiceBuildGroup<'a> = Vec<(&'a str, &'a AppServiceEntry)>;
+
+fn validate_worker_command_collision(config: &AppFileConfig) -> Result<(), FlooError> {
+    use std::collections::HashMap;
+    // Group services by their resolved build identity. `path` defaults to "." when
+    // omitted (server behavior), so two services with no explicit path collide.
+    let mut builds: HashMap<(Option<&str>, &str), ServiceBuildGroup> = HashMap::new();
+    for (name, entry) in &config.services {
+        // Normalize the build path exactly as the API does (tarball.py: strip one
+        // leading "./", strip trailing slashes, treat empty/"." as "."). Keying on
+        // the raw string would let a worker at "./" miss grouping with a web at "."
+        // — under-reporting a collision the API still blocks, breaking the mirror.
+        let raw = entry.path.as_deref().unwrap_or(".");
+        let trimmed = raw.strip_prefix("./").unwrap_or(raw).trim_end_matches('/');
+        let path = if trimmed.is_empty() || trimmed == "." {
+            "."
+        } else {
+            trimmed
+        };
+        builds
+            .entry((entry.repo.as_deref(), path))
+            .or_default()
+            .push((name.as_str(), entry));
+    }
+    for ((_, path), members) in &builds {
+        let worker = members
+            .iter()
+            .find(|(_, e)| e.service_type == AppServiceType::Worker && e.command.is_none());
+        let Some((worker_name, _)) = worker else {
+            continue;
+        };
+        let mut others: Vec<&str> = members
+            .iter()
+            .filter(|(_, e)| e.service_type != AppServiceType::Worker)
+            .map(|(n, _)| *n)
+            .collect();
+        if others.is_empty() {
+            continue;
+        }
+        others.sort_unstable();
+        return Err(FlooError::with_suggestion(
+            ErrorCode::InvalidProjectConfig,
+            format!(
+                "Worker service '{worker_name}' shares build path '{path}' with [{}] \
+                 — one Dockerfile, one CMD — but declares no production 'command'. In \
+                 production it would run the same command as those services instead of \
+                 its own worker process, so its queue is never drained (a silent failure).",
+                others.join(", ")
+            ),
+            format!(
+                "Add a production command to the worker, e.g. command = \"bundle exec sidekiq\" under [services.{worker_name}]."
+            ),
+        ));
+    }
     Ok(())
 }
 
@@ -1058,6 +1130,124 @@ path = "./frontend"
         assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
         assert!(err.message.contains("web"));
         assert!(err.message.contains("port"));
+    }
+
+    #[test]
+    fn test_worker_sharing_build_without_command_rejected() {
+        // The floo-artifact shape: web + worker share path "." (one Dockerfile/CMD)
+        // and the worker declares no command — it would boot the web process (#185/#1009).
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.web]
+type = "web"
+path = "."
+port = 3000
+
+[services.worker]
+type = "worker"
+path = "."
+port = 3000
+"#,
+        )
+        .unwrap();
+
+        let err = load_app_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("worker"));
+        assert!(err.message.contains("command"));
+    }
+
+    #[test]
+    fn test_worker_with_command_accepted() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.web]
+type = "web"
+path = "."
+port = 3000
+
+[services.worker]
+type = "worker"
+path = "."
+port = 3000
+command = "bundle exec sidekiq"
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert_eq!(
+            config.services["worker"].command.as_deref(),
+            Some("bundle exec sidekiq")
+        );
+    }
+
+    #[test]
+    fn test_worker_collision_normalizes_equivalent_paths() {
+        // web at "." and a command-less worker at "./" are the SAME build — the gate
+        // must catch it (mirroring the API's path normalization), not be fooled by the
+        // spelling. Without normalization the API blocks this but `floo preflight` passes.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.web]
+type = "web"
+path = "."
+port = 3000
+
+[services.worker]
+type = "worker"
+path = "./"
+port = 3000
+"#,
+        )
+        .unwrap();
+
+        let err = load_app_config(dir.path()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidProjectConfig);
+        assert!(err.message.contains("worker"));
+        assert!(err.message.contains("command"));
+    }
+
+    #[test]
+    fn test_worker_distinct_build_path_accepted() {
+        // The floo-crm shape: each service its own path → its own Dockerfile/CMD.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::APP_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[services.web]
+type = "web"
+path = "./web"
+port = 3000
+
+[services.worker]
+type = "worker"
+path = "./worker"
+port = 3000
+"#,
+        )
+        .unwrap();
+
+        let config = load_app_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.services.len(), 2);
     }
 
     #[test]

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -497,6 +497,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -518,6 +519,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -620,6 +622,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -751,6 +754,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -819,6 +823,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -911,6 +916,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1016,6 +1022,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1216,6 +1223,7 @@ ingress = "public"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1309,6 +1317,7 @@ ingress = "internal"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1330,6 +1339,7 @@ ingress = "internal"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1407,6 +1417,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1485,6 +1496,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1553,6 +1565,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1574,6 +1587,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1648,6 +1662,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1724,6 +1739,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1789,6 +1805,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1810,6 +1827,7 @@ domain = "svc.example.com"
                 min_instances: None,
                 dev_command: None,
                 migrate_command: None,
+                command: None,
                 env: None,
             },
         );
@@ -1938,6 +1956,7 @@ domain = "svc.example.com"
                         min_instances: None,
                         dev_command: None,
                         migrate_command: None,
+                        command: None,
                         env: None,
                     },
                 );
@@ -2001,6 +2020,7 @@ domain = "svc.example.com"
                         min_instances: None,
                         dev_command: None,
                         migrate_command: None,
+                        command: None,
                         env: None,
                     },
                 );


### PR DESCRIPTION
## Summary
- Adds the per-service production `command` field + `worker` service type to `floo.app.toml` parsing/validation, and a local `floo check` / preflight gate (`validate_worker_command_collision`) that rejects a command-less `worker` sharing a build with a `web`/`api` service — so the silent worker-misboot class (worker boots the web `CMD`, queue never drains) fails locally before deploy, mirroring the API gate.
- The gate buckets services by their **normalized** build path (`.`/`./`/`api`/`api/` collapse to one build), byte-for-byte equivalent to the API's `_assert_no_worker_command_collision`, so `floo check` predicts exactly what the deploy accepts.
- Adds `floo docs` coverage: a worker golden-path example and the `command` field reference.

## Issue Closure (Required)
Closes #185

This is the CLI half of getfloo/floo#185; the API half (per-service `command` + the deploy-time gate) lands in getfloo/floo. The API accepts and ignores-or-honors `command` independently, so this CLI change is safe to land alongside it.

## Changes
- `src/project_config/app_config.rs` — `command` field on `AppServiceEntry`, `worker` service type, `validate_worker_command_collision` gate. The gate canonicalizes build paths with `posixpath.normpath` semantics (collapsing `./`, trailing/duplicate slashes, and interior `.` segments) so `api`, `api/`, `./api`, `api/.`, `././api` all bucket as one build — matching the API gate exactly (codex flagged the partial-strip version as alias-bypassable).
- `src/project_config/discover.rs` — worker inline-mode discovery (defaults `ingress = internal`), tests.
- `src/commands/docs.rs` — worker golden-path + `command` field reference in offline docs.
- `src/commands/dev.rs` — worker handling in the dev surface.

## Test Plan
- [x] `cargo test` (405 unit + 111 + 78 integration passed) — includes `test_worker_sharing_build_without_command_rejected`, `test_worker_with_command_accepted`, `test_worker_collision_normalizes_equivalent_paths`, `test_worker_collision_normalizes_interior_dot_segments`, `test_worker_distinct_build_path_accepted`.
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

## Discovered Issues
None — the API half (getfloo/floo#185 + #1009) is the authoritative deploy-blocking gate; this mirrors it so `floo check` predicts the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
