### PR TITLE
feat: add managed storage restore commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -648,6 +648,41 @@ impl FlooClient {
         Ok(())
     }
 
+    pub fn list_storage_object_versions(
+        &self,
+        app_id: &str,
+        service_id: &str,
+        object_path: &str,
+        env: &str,
+    ) -> Result<StorageObjectVersionsResponse, FlooApiError> {
+        let limit = "75";
+        let query = [("object_path", object_path), ("env", env), ("limit", limit)];
+        let resp = self.get_with_query(
+            &format!("/v1/apps/{app_id}/managed-services/{service_id}/storage/versions"),
+            &query,
+        )?;
+        self.handle_response(resp)
+    }
+
+    pub fn restore_storage_object_generation(
+        &self,
+        app_id: &str,
+        service_id: &str,
+        object_path: &str,
+        generation: &str,
+        env: &str,
+    ) -> Result<StorageObjectRestoreResponse, FlooApiError> {
+        let body = serde_json::json!({
+            "object_path": object_path,
+            "generation": generation,
+        });
+        let resp = self.post_json(
+            &format!("/v1/apps/{app_id}/managed-services/{service_id}/storage/restore?env={env}"),
+            &body,
+        )?;
+        self.handle_response(resp)
+    }
+
     pub fn managed_postgres_connection_usage(
         &self,
         app_id: &str,

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -264,6 +264,39 @@ pub struct ManagedServiceDetail {
     pub updated_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageObjectVersion {
+    pub object_path: String,
+    pub generation: String,
+    pub is_live: bool,
+    pub size_bytes: u64,
+    pub size_human: String,
+    pub updated_at: Option<String>,
+    pub created_at: Option<String>,
+    pub content_type: Option<String>,
+    pub etag: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageObjectVersionsResponse {
+    pub bucket_name: String,
+    pub object_path: String,
+    pub versions: Vec<StorageObjectVersion>,
+    pub total_returned: u32,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageObjectRestoreResponse {
+    pub bucket_name: String,
+    pub object_path: String,
+    pub restored_generation: String,
+    pub live_generation: String,
+    pub size_bytes: u64,
+    pub size_human: String,
+    pub content_type: Option<String>,
+}
+
 // --- Preflight ---
 // Mirrors api/app/schemas/preflight.py. Keep these two in lock-step.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,6 +254,10 @@ Examples:
     #[command(subcommand)]
     Services(ServicesCommands),
 
+    /// Recover objects from floo-managed storage.
+    #[command(subcommand)]
+    Storage(StorageCommands),
+
     /// Manage custom domains.
     #[command(subcommand)]
     Domains(DomainsCommands),
@@ -851,6 +855,49 @@ pub enum ServicesCommands {
         /// Project directory containing floo.app.toml.
         #[arg(default_value = ".")]
         path: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum StorageCommands {
+    /// List restorable versions for a managed storage object.
+    Versions {
+        /// Object path inside the bucket.
+        object_path: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed storage service name.
+        #[arg(long, default_value = "default")]
+        name: String,
+
+        /// Environment to inspect: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
+    },
+
+    /// Restore a managed storage object generation over the live object.
+    Restore {
+        /// Object path inside the bucket.
+        object_path: String,
+
+        /// GCS generation id to restore.
+        #[arg(long)]
+        generation: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed storage service name.
+        #[arg(long, default_value = "default")]
+        name: String,
+
+        /// Environment to restore into: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
     },
 }
 
@@ -1583,6 +1630,22 @@ pub fn run() {
             ServicesCommands::Migrate { app, path } => {
                 commands::services::migrate(app.as_deref(), &path)
             }
+        },
+
+        Commands::Storage(sub) => match sub {
+            StorageCommands::Versions {
+                object_path,
+                app,
+                name,
+                env,
+            } => commands::storage::versions(app.as_deref(), &name, &env, &object_path),
+            StorageCommands::Restore {
+                object_path,
+                generation,
+                app,
+                name,
+                env,
+            } => commands::storage::restore(app.as_deref(), &name, &env, &object_path, &generation),
         },
 
         Commands::Domains(sub) => match sub {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -37,6 +37,7 @@ never uploads code.
   floo docs express    — build and deploy an Express app on floo (end-to-end)
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services
+  floo docs storage    — managed Storage restore commands
   floo docs config     — config file formats with examples
   floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
   floo docs deploy     — detailed deploy flow and runtime detection
@@ -197,6 +198,15 @@ confirmation. See also: floo docs state-model.
     postgres → DATABASE_URL + PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD
     redis    → REDIS_URL
     storage  → STORAGE_BUCKET + STORAGE_URL (use STORAGE_URL for signed URLs)
+
+  Managed Storage buckets keep noncurrent object versions for 30 days.
+  To recover an overwritten or deleted object:
+
+    floo storage versions uploads/report.json --app <name>
+    floo storage restore uploads/report.json --generation <generation> --app <name>
+
+  Add --env prod for the production bucket. Restores copy the selected
+  generation back to the live object path and are audited.
 
   Postgres ships with pgvector enabled. The `vector` type resolves
   unqualified: use it in migrations and queries with no CREATE EXTENSION
@@ -1624,6 +1634,7 @@ const TOPICS: &[(&str, &str)] = &[
     ("django", DJANGO),
     ("express", EXPRESS),
     ("services", SERVICES),
+    ("storage", SERVICES),
     ("config", CONFIG),
     ("app-toml", CONFIG), // alias — agents can run `floo docs app-toml` after `floo init`
     ("cron", CRON),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -32,6 +32,7 @@ pub mod run;
 
 pub mod services;
 pub mod skills;
+pub mod storage;
 pub mod update;
 
 pub(crate) fn init_client(config: Option<FlooConfig>) -> FlooClient {

--- a/src/commands/storage.rs
+++ b/src/commands/storage.rs
@@ -1,0 +1,158 @@
+use std::process;
+
+use crate::api_types::{ManagedServiceSummary, StorageObjectRestoreResponse};
+use crate::errors::ErrorCode;
+use crate::output;
+
+pub fn versions(app: Option<&str>, name: &str, env: &str, object_path: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+    let service = resolve_storage_service(&client, &app_id, &app_name, name);
+
+    let response = match client.list_storage_object_versions(&app_id, &service.id, object_path, env)
+    {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            &format!("Storage versions for {object_path} on {app_name}"),
+            Some(output::to_value(&response)),
+        );
+        return;
+    }
+
+    output::info(
+        &format!(
+            "Storage versions for {} on {} (storage:{}, env={}):",
+            response.object_path, app_name, service.name, env
+        ),
+        None,
+    );
+    output::info(&format!("  Bucket: {}", response.bucket_name), None);
+
+    let rows: Vec<Vec<String>> = response
+        .versions
+        .iter()
+        .map(|version| {
+            vec![
+                version.generation.clone(),
+                if version.is_live {
+                    "live".to_string()
+                } else {
+                    "noncurrent".to_string()
+                },
+                version.size_human.clone(),
+                version
+                    .content_type
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+                version
+                    .updated_at
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+            ]
+        })
+        .collect();
+    output::table(
+        &["Generation", "State", "Size", "Content type", "Updated"],
+        &rows,
+        None,
+    );
+
+    if response.truncated {
+        output::warn("Version list truncated. Narrow the object path and retry.");
+    }
+}
+
+pub fn restore(app: Option<&str>, name: &str, env: &str, object_path: &str, generation: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+    let service = resolve_storage_service(&client, &app_id, &app_name, name);
+
+    let response = match client.restore_storage_object_generation(
+        &app_id,
+        &service.id,
+        object_path,
+        generation,
+        env,
+    ) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            &format!("Restored storage object {object_path} on {app_name}"),
+            Some(output::to_value(&response)),
+        );
+        return;
+    }
+
+    render_restore(&response, &app_name, &service.name, env);
+}
+
+fn resolve_storage_service(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    app_name: &str,
+    name: &str,
+) -> ManagedServiceSummary {
+    let managed_services = match client.list_managed_services(app_id) {
+        Ok(response) => response.managed_services,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let service = managed_services
+        .into_iter()
+        .find(|service| service.service_type == "storage" && service.name == name);
+
+    match service {
+        Some(service) => service,
+        None => {
+            output::error(
+                &format!("No managed storage service named '{name}' on {app_name}."),
+                &ErrorCode::ManagedServiceNotFound,
+                Some("Run 'floo services list' to see managed storage services."),
+            );
+            process::exit(1);
+        }
+    }
+}
+
+fn render_restore(
+    response: &StorageObjectRestoreResponse,
+    app_name: &str,
+    service_name: &str,
+    env: &str,
+) {
+    output::info(
+        &format!(
+            "Restored {} on {} (storage:{}, env={}).",
+            response.object_path, app_name, service_name, env
+        ),
+        None,
+    );
+    output::info(
+        &format!("  Restored generation: {}", response.restored_generation),
+        None,
+    );
+    output::info(
+        &format!("  New live generation: {}", response.live_generation),
+        None,
+    );
+    output::info(&format!("  Bucket: {}", response.bucket_name), None);
+    output::info(&format!("  Size: {}", response.size_human), None);
+}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1755,6 +1755,121 @@ fn test_services_show_app_not_found() {
 }
 
 #[test]
+fn test_storage_versions_json_lists_object_generations() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"managed_services":[{"id":"ms-storage-1","app_id":"app-uuid-1234","type":"storage","name":"default","status":"ready","env_var_keys":["STORAGE_BUCKET","STORAGE_URL"],"created_at":null,"updated_at":null}],"total":1}"#,
+        )
+        .create();
+
+    let _m_versions = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services/ms-storage-1/storage/versions")
+                .as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("object_path".into(), "uploads/report.json".into()),
+            Matcher::UrlEncoded("env".into(), "dev".into()),
+            Matcher::UrlEncoded("limit".into(), "75".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"bucket_name":"floo-app-bucket","object_path":"uploads/report.json","versions":[{"object_path":"uploads/report.json","generation":"1700000000000001","is_live":true,"size_bytes":256,"size_human":"256 B","updated_at":null,"created_at":null,"content_type":"application/json","etag":"abc"},{"object_path":"uploads/report.json","generation":"1700000000000000","is_live":false,"size_bytes":128,"size_human":"128 B","updated_at":null,"created_at":null,"content_type":"application/json","etag":"def"}],"total_returned":2,"truncated":false}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "storage",
+            "versions",
+            "uploads/report.json",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""generation":"1700000000000001""#,
+        ))
+        .stdout(predicate::str::contains(r#""is_live":false"#));
+}
+
+#[test]
+fn test_storage_restore_json_restores_generation() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"managed_services":[{"id":"ms-storage-1","app_id":"app-uuid-1234","type":"storage","name":"default","status":"ready","env_var_keys":["STORAGE_BUCKET","STORAGE_URL"],"created_at":null,"updated_at":null}],"total":1}"#,
+        )
+        .create();
+
+    let _m_restore = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services/ms-storage-1/storage/restore")
+                .as_str(),
+        )
+        .match_query(Matcher::UrlEncoded("env".into(), "prod".into()))
+        .match_body(Matcher::JsonString(
+            r#"{"object_path":"uploads/report.json","generation":"1700000000000000"}"#.into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"bucket_name":"floo-app-bucket-prod","object_path":"uploads/report.json","restored_generation":"1700000000000000","live_generation":"1700000000000002","size_bytes":128,"size_human":"128 B","content_type":"application/json"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "storage",
+            "restore",
+            "uploads/report.json",
+            "--generation",
+            "1700000000000000",
+            "--env",
+            "prod",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""restored_generation":"1700000000000000""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""live_generation":"1700000000000002""#,
+        ));
+}
+
+#[test]
 fn test_services_show_surfaces_api_errors() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## Summary
- add `floo storage versions` for listing restorable managed-storage generations
- add `floo storage restore` for copying a selected generation back to the live object path
- wire JSON/human output and mock API coverage for the new storage commands

## Verification
- `cargo fmt --check && cargo test test_storage_ && cargo clippy -- -D warnings`
- `cargo test`

Companion platform API/docs PR: getfloo/floo#1067
Refs getfloo/floo#972
Refs getfloo/floo#890