### PR TITLE
feat: add managed postgres backup commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -695,6 +695,54 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn create_managed_postgres_backup(
+        &self,
+        app_id: &str,
+        service_id: &str,
+        env: &str,
+    ) -> Result<ManagedPostgresBackup, FlooApiError> {
+        let resp = self.post_json(
+            &format!("/v1/apps/{app_id}/managed-services/{service_id}/postgres/backups?env={env}"),
+            &serde_json::json!({}),
+        )?;
+        self.handle_response(resp)
+    }
+
+    pub fn list_managed_postgres_backups(
+        &self,
+        app_id: &str,
+        service_id: &str,
+        env: Option<&str>,
+    ) -> Result<ManagedPostgresBackupsResponse, FlooApiError> {
+        let mut query = Vec::new();
+        if let Some(env) = env {
+            query.push(("env", env));
+        }
+        let resp = self.get_with_query(
+            &format!("/v1/apps/{app_id}/managed-services/{service_id}/postgres/backups"),
+            &query,
+        )?;
+        self.handle_response(resp)
+    }
+
+    pub fn restore_managed_postgres_backup(
+        &self,
+        app_id: &str,
+        service_id: &str,
+        backup_id: &str,
+        env: &str,
+    ) -> Result<ManagedPostgresRestoreResponse, FlooApiError> {
+        let body = serde_json::json!({
+            "backup_id": backup_id,
+            "env": env,
+        });
+        let resp = self.post_json(
+            &format!("/v1/apps/{app_id}/managed-services/{service_id}/postgres/restore"),
+            &body,
+        )?;
+        self.handle_response(resp)
+    }
+
     // --- Preflight ---
 
     pub fn preflight(

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -297,6 +297,33 @@ pub struct StorageObjectRestoreResponse {
     pub content_type: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedPostgresBackup {
+    pub id: String,
+    pub app_id: String,
+    pub managed_service_id: String,
+    pub env: String,
+    pub status: String,
+    pub size_bytes: u64,
+    pub size_human: String,
+    pub checksum_sha256: String,
+    pub created_at: String,
+    pub expires_at: String,
+    pub last_restored_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedPostgresBackupsResponse {
+    pub backups: Vec<ManagedPostgresBackup>,
+    pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedPostgresRestoreResponse {
+    pub backup: ManagedPostgresBackup,
+    pub restored_at: String,
+}
+
 // --- Preflight ---
 // Mirrors api/app/schemas/preflight.py. Keep these two in lock-step.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1196,6 +1196,62 @@ Examples:
         #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
         env: String,
     },
+
+    /// Create a restorable backup of the app's managed Postgres schema.
+    #[command(after_help = "\
+Examples:
+  floo db backup --app my-app               Back up dev (default)
+  floo db backup --app my-app --env prod    Back up prod")]
+    Backup {
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed Postgres service name.
+        #[arg(long, default_value = "default")]
+        name: String,
+
+        /// Environment to back up: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
+    },
+
+    /// List restorable managed Postgres backups.
+    Backups {
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed Postgres service name.
+        #[arg(long, default_value = "default")]
+        name: String,
+
+        /// Environment to filter by: dev or prod.
+        #[arg(long, value_parser = ["dev", "prod"])]
+        env: Option<String>,
+    },
+
+    /// Restore a managed Postgres backup into its original env schema.
+    #[command(after_help = "\
+Examples:
+  floo db restore 018f... --app my-app --env dev
+  floo db restore 018f... --app my-app --env prod")]
+    Restore {
+        /// Backup ID returned by `floo db backups`.
+        backup_id: String,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed Postgres service name.
+        #[arg(long, default_value = "default")]
+        name: String,
+
+        /// Environment to restore: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1708,6 +1764,18 @@ pub fn run() {
             DbCommands::Schema { app } => commands::db::schema(app.as_deref()),
             DbCommands::Migrate { app, env } => commands::db::migrate(app.as_deref(), &env),
             DbCommands::Connections { app, env } => commands::db::connections(app.as_deref(), &env),
+            DbCommands::Backup { app, name, env } => {
+                commands::db::backup(app.as_deref(), &name, &env)
+            }
+            DbCommands::Backups { app, name, env } => {
+                commands::db::backups(app.as_deref(), &name, env.as_deref())
+            }
+            DbCommands::Restore {
+                backup_id,
+                app,
+                name,
+                env,
+            } => commands::db::restore(app.as_deref(), &name, &env, &backup_id),
         },
 
         Commands::Cron(sub) => match sub {

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -2,6 +2,9 @@ use std::process;
 
 use serde_json::Value;
 
+use crate::api_types::{
+    ManagedPostgresBackup, ManagedPostgresRestoreResponse, ManagedServiceSummary,
+};
 use crate::errors::ErrorCode;
 use crate::output;
 
@@ -272,28 +275,7 @@ pub fn connections(app_flag: Option<&str>, env: &str) {
     super::require_auth();
     let client = super::init_client(None);
     let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
-
-    // Find the app's managed Postgres service.
-    let listing = match client.list_managed_services(&app_id) {
-        Ok(r) => r,
-        Err(e) => {
-            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-            process::exit(1);
-        }
-    };
-    let postgres_service = listing
-        .managed_services
-        .iter()
-        .find(|s| s.service_type == "postgres");
-
-    let Some(service) = postgres_service else {
-        output::error(
-            &format!("{app_name} has no managed Postgres service to inspect."),
-            &ErrorCode::Other("NO_POSTGRES_SERVICE".into()),
-            Some("Provision one with `floo services add postgres --app <name>`."),
-        );
-        process::exit(1);
-    };
+    let service = resolve_postgres_service(&client, &app_id, &app_name, "default");
 
     let usage = match client.managed_postgres_connection_usage(&app_id, &service.id, env) {
         Ok(v) => v,
@@ -345,6 +327,176 @@ pub fn connections(app_flag: Option<&str>, env: &str) {
             None,
         );
     }
+}
+
+pub fn backup(app_flag: Option<&str>, name: &str, env: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let service = resolve_postgres_service(&client, &app_id, &app_name, name);
+
+    let backup = match client.create_managed_postgres_backup(&app_id, &service.id, env) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success("Postgres backup created.", Some(output::to_value(&backup)));
+        return;
+    }
+
+    output::success(
+        &format!("Created Postgres backup for {app_name} (postgres:{name}, env={env})."),
+        None,
+    );
+    render_backup(&backup);
+}
+
+pub fn backups(app_flag: Option<&str>, name: &str, env: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let service = resolve_postgres_service(&client, &app_id, &app_name, name);
+
+    let response = match client.list_managed_postgres_backups(&app_id, &service.id, env) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Postgres backups retrieved.",
+            Some(output::to_value(&response)),
+        );
+        return;
+    }
+
+    let env_label = env.unwrap_or("all");
+    output::info(
+        &format!("Postgres backups for {app_name} (postgres:{name}, env={env_label}):"),
+        None,
+    );
+    if response.backups.is_empty() {
+        output::info("No backups found.", None);
+        return;
+    }
+
+    let rows: Vec<Vec<String>> = response
+        .backups
+        .iter()
+        .map(|backup| {
+            vec![
+                backup.id.clone(),
+                backup.env.clone(),
+                backup.status.clone(),
+                backup.size_human.clone(),
+                backup.created_at.clone(),
+                backup.expires_at.clone(),
+                backup
+                    .last_restored_at
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+            ]
+        })
+        .collect();
+    output::table(
+        &[
+            "Backup ID",
+            "Env",
+            "Status",
+            "Size",
+            "Created",
+            "Expires",
+            "Restored",
+        ],
+        &rows,
+        None,
+    );
+}
+
+pub fn restore(app_flag: Option<&str>, name: &str, env: &str, backup_id: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let service = resolve_postgres_service(&client, &app_id, &app_name, name);
+
+    let response =
+        match client.restore_managed_postgres_backup(&app_id, &service.id, backup_id, env) {
+            Ok(response) => response,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        };
+
+    if output::is_json_mode() {
+        output::success(
+            "Postgres backup restored.",
+            Some(output::to_value(&response)),
+        );
+        return;
+    }
+
+    render_restore(&response, &app_name, name, env);
+}
+
+fn resolve_postgres_service(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    app_name: &str,
+    name: &str,
+) -> ManagedServiceSummary {
+    let listing = match client.list_managed_services(app_id) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+    let service = listing
+        .managed_services
+        .into_iter()
+        .find(|service| service.service_type == "postgres" && service.name == name);
+
+    match service {
+        Some(service) => service,
+        None => {
+            output::error(
+                &format!("No managed Postgres service named '{name}' on {app_name}."),
+                &ErrorCode::ManagedServiceNotFound,
+                Some("Run 'floo services list' to see managed Postgres services."),
+            );
+            process::exit(1);
+        }
+    }
+}
+
+fn render_backup(backup: &ManagedPostgresBackup) {
+    output::info(&format!("  Backup ID: {}", backup.id), None);
+    output::info(&format!("  Env: {}", backup.env), None);
+    output::info(&format!("  Size: {}", backup.size_human), None);
+    output::info(&format!("  Expires: {}", backup.expires_at), None);
+}
+
+fn render_restore(
+    response: &ManagedPostgresRestoreResponse,
+    app_name: &str,
+    service_name: &str,
+    env: &str,
+) {
+    output::success(
+        &format!("Restored Postgres backup on {app_name} (postgres:{service_name}, env={env})."),
+        None,
+    );
+    output::info(&format!("  Backup ID: {}", response.backup.id), None);
+    output::info(&format!("  Restored at: {}", response.restored_at), None);
+    output::info(&format!("  Size: {}", response.backup.size_human), None);
 }
 
 /// Detect SQL that explicitly filters on `table_schema = 'public'` (or

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1870,6 +1870,157 @@ fn test_storage_restore_json_restores_generation() {
 }
 
 #[test]
+fn test_db_backup_json_creates_managed_postgres_backup() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"managed_services":[{"id":"ms-pg-1","app_id":"app-uuid-1234","type":"postgres","name":"default","status":"ready","env_var_keys":["DATABASE_URL"],"created_at":null,"updated_at":null}],"total":1}"#,
+        )
+        .create();
+
+    let _m_backup = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services/ms-pg-1/postgres/backups").as_str(),
+        )
+        .match_query(Matcher::UrlEncoded("env".into(), "prod".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"backup-1","app_id":"app-uuid-1234","managed_service_id":"ms-pg-1","env":"prod","status":"available","size_bytes":2048,"size_human":"2.0 KB","checksum_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created_at":"2026-06-19T12:00:00Z","expires_at":"2026-07-19T12:00:00Z","last_restored_at":null}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "backup",
+            "--env",
+            "prod",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""id":"backup-1""#))
+        .stdout(predicate::str::contains(r#""env":"prod""#));
+}
+
+#[test]
+fn test_db_backups_json_lists_managed_postgres_backups() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"managed_services":[{"id":"ms-pg-1","app_id":"app-uuid-1234","type":"postgres","name":"default","status":"ready","env_var_keys":["DATABASE_URL"],"created_at":null,"updated_at":null}],"total":1}"#,
+        )
+        .create();
+
+    let _m_backups = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services/ms-pg-1/postgres/backups").as_str(),
+        )
+        .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"backups":[{"id":"backup-1","app_id":"app-uuid-1234","managed_service_id":"ms-pg-1","env":"dev","status":"available","size_bytes":2048,"size_human":"2.0 KB","checksum_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created_at":"2026-06-19T12:00:00Z","expires_at":"2026-07-19T12:00:00Z","last_restored_at":null}],"total":1}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "backups",
+            "--env",
+            "dev",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""total":1"#))
+        .stdout(predicate::str::contains(r#""id":"backup-1""#));
+}
+
+#[test]
+fn test_db_restore_json_restores_managed_postgres_backup() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list_managed = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"managed_services":[{"id":"ms-pg-1","app_id":"app-uuid-1234","type":"postgres","name":"default","status":"ready","env_var_keys":["DATABASE_URL"],"created_at":null,"updated_at":null}],"total":1}"#,
+        )
+        .create();
+
+    let _m_restore = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services/ms-pg-1/postgres/restore").as_str(),
+        )
+        .match_body(Matcher::JsonString(
+            r#"{"backup_id":"backup-1","env":"dev"}"#.into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"backup":{"id":"backup-1","app_id":"app-uuid-1234","managed_service_id":"ms-pg-1","env":"dev","status":"available","size_bytes":2048,"size_human":"2.0 KB","checksum_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created_at":"2026-06-19T12:00:00Z","expires_at":"2026-07-19T12:00:00Z","last_restored_at":"2026-06-19T12:05:00Z"},"restored_at":"2026-06-19T12:05:00Z"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "restore",
+            "backup-1",
+            "--env",
+            "dev",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""restored_at":"2026-06-19T12:05:00Z""#,
+        ));
+}
+
+#[test]
 fn test_services_show_surfaces_api_errors() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## Summary
- add `floo db backup`, `floo db backups`, and `floo db restore` commands for managed Postgres
- wire JSON output and API client types for backup/list/restore responses
- add mock API coverage for the new command shapes

Companion to getfloo/floo#422 and the platform PR.

## Tests
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test db_ --test mock_api_tests`
