### PR TITLE
feat(env): env set --stdin / --value-file to keep secrets out of argv (#1152)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -667,8 +667,11 @@ pub enum GitHubCommands {
 #[derive(Subcommand)]
 pub enum EnvCommands {
     /// Set an environment variable on an app.
+    ///
+    /// Pass `KEY=VALUE` inline, or `KEY` alone with `--stdin` / `--value-file`
+    /// to keep a secret value out of argv, shell history, and `ps`.
     Set {
-        /// KEY=VALUE pair to set.
+        /// KEY=VALUE pair to set. With --stdin or --value-file, pass the KEY only.
         key_value: String,
 
         /// App name or ID (reads from config if omitted).
@@ -686,6 +689,16 @@ pub enum EnvCommands {
         /// Environment: dev or prod.
         #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
         env: String,
+
+        /// Read the value from stdin instead of the command line, keeping the
+        /// secret out of argv / shell history / `ps`. A single trailing newline
+        /// is stripped (so `echo "$SECRET" | floo env set KEY --stdin` works).
+        #[arg(long, conflicts_with = "value_file")]
+        stdin: bool,
+
+        /// Read the value from a file. A single trailing newline is stripped.
+        #[arg(long, value_name = "PATH", conflicts_with = "stdin")]
+        value_file: Option<PathBuf>,
     },
 
     /// List environment variables for an app.
@@ -1624,7 +1637,17 @@ pub fn run() {
                 services,
                 restart,
                 env,
-            } => commands::env::set(&key_value, app.as_deref(), &services, restart, &env),
+                stdin,
+                value_file,
+            } => commands::env::set(
+                &key_value,
+                app.as_deref(),
+                &services,
+                restart,
+                &env,
+                stdin,
+                value_file.as_deref(),
+            ),
             EnvCommands::List { app, services, env } => {
                 commands::env::list(app.as_deref(), &services, &env)
             }

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -237,6 +237,59 @@ fn parse_env_file(path: &Path) -> Vec<(String, String)> {
     vars
 }
 
+/// Strip a single trailing newline (`\n` or `\r\n`) from a value read off a
+/// side channel. `echo "$SECRET"` and most editors append one; stripping
+/// exactly one keeps the common case ergonomic without mangling a value whose
+/// content genuinely contains newlines. Documented on the `--stdin` /
+/// `--value-file` flags so the behavior is not a surprise.
+fn strip_one_trailing_newline(mut s: String) -> String {
+    if s.ends_with('\n') {
+        s.pop();
+        if s.ends_with('\r') {
+            s.pop();
+        }
+    }
+    s
+}
+
+/// Read an env-var value from stdin (`--stdin`). Used to keep secrets out of
+/// argv / shell history / `ps`.
+fn read_stdin_value() -> String {
+    use std::io::Read;
+    let mut buf = String::new();
+    if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+        output::error(
+            &format!("Failed to read value from stdin: {e}"),
+            &ErrorCode::FileError,
+            Some("Pipe the value in, e.g. printf %s \"$SECRET\" | floo env set KEY --stdin"),
+        );
+        process::exit(1);
+    }
+    strip_one_trailing_newline(buf)
+}
+
+/// Read an env-var value from a file (`--value-file PATH`).
+fn read_value_file(path: &Path) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(c) => strip_one_trailing_newline(c),
+        Err(e) => {
+            let msg = match e.kind() {
+                std::io::ErrorKind::NotFound => format!("Value file not found: {}", path.display()),
+                std::io::ErrorKind::PermissionDenied => {
+                    format!("Permission denied reading: {}", path.display())
+                }
+                _ => format!("Failed to read {}: {e}", path.display()),
+            };
+            output::error(
+                &msg,
+                &ErrorCode::FileError,
+                Some("Check the file path and permissions."),
+            );
+            process::exit(1);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -247,24 +300,50 @@ pub fn set(
     service_names: &[String],
     restart: bool,
     env: &str,
+    read_stdin: bool,
+    value_file: Option<&Path>,
 ) {
-    if !key_value.contains('=') {
-        output::error(
-            "Invalid format. Use KEY=VALUE.",
-            &ErrorCode::InvalidFormat,
-            Some("Example: floo env set DATABASE_URL=postgres://..."),
-        );
-        process::exit(1);
-    }
+    let from_side_channel = read_stdin || value_file.is_some();
 
-    let (key, value) = key_value.split_once('=').unwrap();
-    let key = key.to_uppercase();
+    // Resolve the key. With `--stdin` / `--value-file` the positional is the
+    // bare KEY and the value arrives off the command line, keeping secrets out
+    // of argv, shell history, and `ps` (#1152). Otherwise it is `KEY=VALUE`.
+    let key = if from_side_channel {
+        if key_value.contains('=') {
+            output::error(
+                "With --stdin or --value-file, pass the key only (no =VALUE).",
+                &ErrorCode::InvalidFormat,
+                Some("Example: printf %s \"$SECRET\" | floo env set API_KEY --stdin"),
+            );
+            process::exit(1);
+        }
+        key_value.to_uppercase()
+    } else {
+        if !key_value.contains('=') {
+            output::error(
+                "Invalid format. Use KEY=VALUE (or KEY with --stdin / --value-file).",
+                &ErrorCode::InvalidFormat,
+                Some("Example: floo env set DATABASE_URL=postgres://..."),
+            );
+            process::exit(1);
+        }
+        key_value.split_once('=').unwrap().0.to_uppercase()
+    };
 
     if output::is_dry_run_mode() {
+        // Dry-run mutates nothing, so it must NOT consume stdin or read the
+        // file — it previews the key/target only.
         let target = app_flag.unwrap_or("(reads from config)");
         let scope = format_env_scope(service_names, env);
         let restart_clause = if restart { " and restart" } else { "" };
-        let preview = format!("Would set {key} on {target}{scope}{restart_clause}.");
+        let source = if read_stdin {
+            " (value from stdin)"
+        } else if value_file.is_some() {
+            " (value from file)"
+        } else {
+            ""
+        };
+        let preview = format!("Would set {key} on {target}{scope}{restart_clause}{source}.");
         output::dry_run_preview(
             &preview,
             serde_json::json!({
@@ -274,6 +353,7 @@ pub fn set(
                 "services": service_names,
                 "env": env,
                 "will_restart": restart,
+                "value_source": if read_stdin { "stdin" } else if value_file.is_some() { "file" } else { "inline" },
             }),
         );
         return;
@@ -285,9 +365,22 @@ pub fn set(
     let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
 
+    // Read the side-channel value only AFTER every "this set can't run" check
+    // (auth, app/target resolution) has passed. Reading first would block an
+    // interactive `--stdin` on EOF — or consume a secret file/FIFO — for a
+    // logged-out user or a multi-service app with no `--services`, then error
+    // anyway (codex #1152). Dry-run already returned above without reading.
+    let value: String = if read_stdin {
+        read_stdin_value()
+    } else if let Some(path) = value_file {
+        read_value_file(path)
+    } else {
+        key_value.split_once('=').unwrap().1.to_string()
+    };
+
     let mut last_env_result = serde_json::Value::Null;
     for (service_id, service_name) in &targets {
-        match client.set_env_var(&app_id, &key, value, service_id.as_deref(), env) {
+        match client.set_env_var(&app_id, &key, &value, service_id.as_deref(), env) {
             Ok(result) => {
                 let target = format_target(&app_name, service_name.as_deref());
                 last_env_result = output::to_value(&result);
@@ -842,5 +935,27 @@ mod tests {
         let vars = parse_env_file(&path);
         assert_eq!(vars[0].0, "DATABASE_URL");
         assert_eq!(vars[0].1, "postgres://user:pass@host/db?opt=val");
+    }
+
+    #[test]
+    fn test_strip_one_trailing_newline() {
+        assert_eq!(strip_one_trailing_newline("secret\n".to_string()), "secret");
+        assert_eq!(
+            strip_one_trailing_newline("secret\r\n".to_string()),
+            "secret"
+        );
+        assert_eq!(strip_one_trailing_newline("secret".to_string()), "secret");
+        // Only ONE trailing newline is stripped — a value that genuinely ends in
+        // a blank line keeps the rest.
+        assert_eq!(
+            strip_one_trailing_newline("secret\n\n".to_string()),
+            "secret\n"
+        );
+        // Interior newlines (multi-line values) are preserved.
+        assert_eq!(
+            strip_one_trailing_newline("line1\nline2\n".to_string()),
+            "line1\nline2"
+        );
+        assert_eq!(strip_one_trailing_newline(String::new()), "");
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -436,7 +436,7 @@ fn test_env_set_invalid_format() {
         .env("HOME", home.path().to_str().unwrap())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Invalid format. Use KEY=VALUE."));
+        .stderr(predicate::str::contains("Invalid format. Use KEY=VALUE"));
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -474,6 +474,163 @@ fn test_env_set_json() {
         .stdout(predicate::str::contains("MY_KEY"));
 }
 
+fn set_env_response_body() -> &'static str {
+    r#"{
+        "id":"00000000-0000-0000-0000-000000000001",
+        "app_id":"00000000-0000-0000-0000-0000000000aa",
+        "environment_id":"00000000-0000-0000-0000-0000000000ee",
+        "service_id":null,
+        "key":"API_KEY",
+        "masked_value":"********",
+        "created_at":"2026-04-24T00:00:00Z",
+        "updated_at":"2026-04-24T00:00:00Z"
+    }"#
+}
+
+#[test]
+fn test_env_set_stdin() {
+    // #1152: a secret value piped on stdin keeps it out of argv / shell history.
+    // The trailing newline from `echo` is stripped before it reaches the API.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+
+    let _m_set = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
+        .match_body(Matcher::Regex(r#""value":"supersecret""#.to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(set_env_response_body())
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "API_KEY",
+            "--stdin",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .write_stdin("supersecret\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#));
+}
+
+#[test]
+fn test_env_set_value_file() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+
+    let dir = TempDir::new().unwrap();
+    let secret_path = dir.path().join("secret.txt");
+    std::fs::write(&secret_path, "filesecret\n").unwrap();
+
+    let _m_set = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
+        .match_body(Matcher::Regex(r#""value":"filesecret""#.to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(set_env_response_body())
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "API_KEY",
+            "--value-file",
+            secret_path.to_str().unwrap(),
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#));
+}
+
+#[test]
+fn test_env_set_stdin_rejects_inline_value() {
+    // KEY=VALUE alongside --stdin is ambiguous (value given two ways) — refuse.
+    let server = Server::new();
+    let home = setup_config(&server);
+
+    floo()
+        .args([
+            "env",
+            "set",
+            "API_KEY=inline",
+            "--stdin",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .write_stdin("piped")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("key only"));
+}
+
+#[test]
+fn test_env_set_dry_run_stdin_does_not_read() {
+    // Dry-run mutates nothing and must not consume stdin; it previews the key
+    // and names the value source. No POST mock is registered, so a real call
+    // would surface as an error — the test passing proves none was made.
+    let server = Server::new();
+    let home = setup_config(&server);
+
+    floo()
+        .args([
+            "env",
+            "set",
+            "API_KEY",
+            "--stdin",
+            "--dry-run",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("value from stdin"));
+}
+
+#[test]
+fn test_env_set_stdin_and_value_file_mutually_exclusive() {
+    // The value must come from exactly one source. clap's reciprocal
+    // conflicts_with rejects --stdin together with --value-file at parse time;
+    // this pins that wiring against accidental removal.
+    let server = Server::new();
+    let home = setup_config(&server);
+
+    floo()
+        .args([
+            "env",
+            "set",
+            "API_KEY",
+            "--stdin",
+            "--value-file",
+            "/tmp/whatever",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .write_stdin("x")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
 #[test]
 fn test_env_list_json() {
     let mut server = Server::new();


### PR DESCRIPTION
## What changed

Add two side-channel value inputs to `env set` so a secret value never has to go in argv:

- `env set KEY --stdin` — read the value from stdin (e.g. `printf %s "$SECRET" | floo env set API_KEY --stdin`).
- `env set KEY --value-file PATH` — read the value from a file.

The inline `KEY=VALUE` form is retained. `--stdin` and `--value-file` are mutually exclusive (clap `conflicts_with`) and require the bare `KEY`; passing `KEY=VALUE` alongside them is rejected as ambiguous. A single trailing newline is stripped (so `echo "$SECRET" | …` works) while interior newlines in multi-line values are preserved. Dry-run never consumes stdin or reads the file — it previews the key and names the value source.

## Why

`env set KEY=VALUE` puts the secret in argv, where it leaks via shell history and `ps` — the write-side half of the env secret-protection surface (#1152, finding #3). stdin/file input keeps the value off the command line entirely.

## Risk tier

standard (floo-cli `env.rs`/`cli.rs` are not in the sensitive floo-cli path list). Reviewed anyway given the security motivation: Claude code-reviewer (correctness + security + silent-failure) → "clean, ship it" (both `.split_once('=').unwrap()` calls proven contract-guarded; read errors fail loud; dry-run doesn't consume stdin); codex (cross-family).

## Files reviewers should scrutinize

- `src/commands/env.rs` — `set()` key/value resolution + `read_stdin_value` / `read_value_file` / `strip_one_trailing_newline`.
- `src/cli.rs` — `Set` clap def (`--stdin` / `--value-file`, `conflicts_with`) + dispatch.

## Tests run

- `cargo test` (full), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all green.
- New: set via stdin (newline stripped, asserted on the request body), via file, inline-value-with-stdin rejected, dry-run-does-not-read, `--stdin`/`--value-file` mutual-exclusion; unit coverage of trailing-newline stripping (single `\n`, `\r\n`, none, double, interior, empty).

## Known non-goals

- Secret zeroization in process memory — out of scope for #1152 (which targets argv/history/`ps`) and would be inconsistent applied to this one path; the CLI doesn't zeroize elsewhere.

Part of #1152 (finding #3). The issue closes once PR-1 (getfloo/floo #1168), PR-2 (floo-cli #169), and this PR all merge; finding #4 (write-only secret storage) is #1018.
