### PR TITLE
fix(deps): clear 9 RustSec advisories (quinn-proto, rustls-webpki, rand, indicatif)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,15 +270,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -425,7 +424,7 @@ dependencies = [
  "once_cell",
  "open",
  "predicates",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "reqwest",
  "ring",
@@ -851,14 +850,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1010,7 +1009,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1032,12 +1031,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1204,14 +1197,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1254,9 +1247,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1265,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1448,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1881,6 +1874,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 colored = "2"
 comfy-table = "7"
-indicatif = "0.17"
+indicatif = "0.18"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 ring = "0.17"


### PR DESCRIPTION
## What

`osv-scanner` against `Cargo.lock` surfaced **9 RustSec advisories across 5 crates** (invisible because Dependabot alerts/updates are disabled on this repo). Cleared all 9 with precise minimum bumps.

| Crate | From → To | Advisory |
|---|---|---|
| `quinn-proto` | 0.11.13 → 0.11.15 | RUSTSEC-2026-0037 (8.7), RUSTSEC-2026-0185 (7.5) |
| `rustls-webpki` | 0.103.9 → 0.103.13 | RUSTSEC-2026-0104 (7.5) + 3 more — TLS cert verification path |
| `rand` | 0.8.5→0.8.6, 0.9.2→0.9.3 | RUSTSEC-2026-0097 |
| `number_prefix` | removed | RUSTSEC-2025-0119 (unmaintained; no fixed version existed) |

`number_prefix` had no fix — it's pulled by `indicatif`, and `indicatif` 0.18 dropped it. Bumping `indicatif` 0.17 → 0.18 removes it entirely and is a **clean drop-in** (no source changes). The only indicatif APIs the CLI uses (`Spinner` in `src/output.rs`) are unchanged across 0.17→0.18, and `quinn-proto` isn't in the active dep graph (reqwest is blocking + rustls-tls, no HTTP/3).

## Verification

- `osv-scanner --lockfile=Cargo.lock`: **0 issues** (was 9)
- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check`: clean
- `cargo test`: all suites pass (600+ tests)

Source diff is `Cargo.toml` (indicatif `"0.17"`→`"0.18"`) + `Cargo.lock` only.

> Part of a cross-repo dependency-CVE sweep. Root gap — GitHub vulnerability scanning is disabled on both repos, so 149 known advisories accumulated invisibly — addressed separately (enable scanning + CI audit gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)