### PR TITLE
fix(preflight): run config-only migrate warning for external-repo services

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1544,11 +1544,26 @@ fn validate_preflight(
             );
         }
 
+        // Managed-injection keys this service receives (DATABASE_URL, REDIS_URL,
+        // …) — config-only, derived from the env injection plan, no disk access.
+        let managed_keys = managed_keys_for_service(env_plan, &svc.name);
+
         // A service sourced from an external `repo` builds from THAT repo, not
-        // the local checkout — its `path` is relative to the external repo and
-        // won't exist locally. None of the local-disk checks below apply, and
-        // erroring on the missing local path would false-block a valid config.
+        // the local checkout — its `path`/Dockerfile/env files live in the
+        // referenced repo, so the local-disk checks below don't apply and the
+        // local env-file-based required-env check would be a false-positive
+        // flood (we can't see the external repo's env). But a `migrate_command`
+        // still needs a database floo provides — a config-only check (no disk) —
+        // so it runs here (with an empty local env_file set, since an
+        // external-repo service imports no local env file) before we skip the
+        // rest.
         if service_is_external_repo(resolved, &svc.name) {
+            check_migrate_command_no_database(
+                svc,
+                &managed_keys,
+                &std::collections::HashSet::new(),
+                &mut findings,
+            );
             continue;
         }
 
@@ -1585,7 +1600,6 @@ fn validate_preflight(
         // inline floo.app.toml env_file is declared but never imported, so it
         // must not count. Server-side `floo env set` vars are invisible here,
         // which is why the consumers below warn rather than error.
-        let managed_keys = managed_keys_for_service(env_plan, &svc.name);
         let imported_env_file = imported_env_files.get(&svc.name);
         let env_file_keys = match imported_env_file {
             Some((env_file, base)) => env_file_keys_for_service(base, Some(env_file.as_str())),
@@ -1617,27 +1631,10 @@ fn validate_preflight(
             }
         }
 
-        // A migrate_command needs a database to run against. floo's database is
-        // managed Postgres; if none is reachable from anything local preflight
-        // can see (no managed Postgres attached, no DATABASE_URL in an env
-        // file), the migration step will fail. Warn rather than error because
-        // DATABASE_URL may legitimately be set server-side via `floo env set`.
-        if svc.migrate_command.is_some()
-            && !managed_keys.contains("DATABASE_URL")
-            && !env_file_keys.contains("DATABASE_URL")
-        {
-            findings.push(
-                PreflightFinding::warning(
-                    "MIGRATE_COMMAND_NO_DATABASE",
-                    format!(
-                        "Service '{}' declares migrate_command but no database is reachable from local config — no managed Postgres is attached and no DATABASE_URL is set in a local env file. The migration step will fail unless DATABASE_URL is set another way.",
-                        svc.name
-                    ),
-                )
-                .with_path(&svc.path)
-                .with_hint("Add `[postgres]` to floo.app.toml (or `floo services add postgres`), or set DATABASE_URL with `floo env set`."),
-            );
-        }
+        // A migrate_command needs a database to run against (config-only check;
+        // see the helper). Local services pass the keys from their imported
+        // env_file so a locally-declared DATABASE_URL satisfies it.
+        check_migrate_command_no_database(svc, &managed_keys, &env_file_keys, &mut findings);
 
         // Required env vars the deploy can't satisfy from local config.
         let svc_plan = env_plan.services.iter().find(|p| p.service == svc.name);
@@ -1913,6 +1910,37 @@ fn configured_env_file_for_service(
         .ok()
         .flatten()
         .and_then(|cfg| cfg.service.env_file)
+}
+
+/// Emit `MIGRATE_COMMAND_NO_DATABASE` if a service declares a `migrate_command`
+/// but no database is reachable from local config. This is a CONFIG-ONLY check —
+/// it reads the managed-injection keys plus whatever keys the service's imported
+/// env_file declares, with no service-source disk access — so it applies to
+/// external-repo services too: a migrate step with no DB fails wherever the
+/// service's source lives. Callers pass an empty `env_file_keys` for
+/// external-repo services (they import no local env file).
+fn check_migrate_command_no_database(
+    svc: &ServiceConfig,
+    managed_keys: &std::collections::HashSet<String>,
+    env_file_keys: &std::collections::HashSet<String>,
+    findings: &mut Vec<PreflightFinding>,
+) {
+    if svc.migrate_command.is_some()
+        && !managed_keys.contains("DATABASE_URL")
+        && !env_file_keys.contains("DATABASE_URL")
+    {
+        findings.push(
+            PreflightFinding::warning(
+                "MIGRATE_COMMAND_NO_DATABASE",
+                format!(
+                    "Service '{}' declares migrate_command but no database is reachable from local config — no managed Postgres is attached and no DATABASE_URL is set in a local env file. The migration step will fail unless DATABASE_URL is set another way.",
+                    svc.name
+                ),
+            )
+            .with_path(&svc.path)
+            .with_hint("Add `[postgres]` to floo.app.toml (or `floo services add postgres`), or set DATABASE_URL with `floo env set`."),
+        );
+    }
 }
 
 /// The managed-injection keys a service receives, per the env injection plan

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1506,6 +1506,77 @@ ingress = "public"
         .stdout(predicate::str::contains("contains_secrets").not());
 }
 
+/// The config-only `MIGRATE_COMMAND_NO_DATABASE` warning STILL runs for an
+/// external-`repo` service (it reads managed keys, not disk) — a migrate step
+/// with no DB fails wherever the source lives. It stays a warning (valid:true).
+#[test]
+fn test_preflight_external_repo_service_still_warns_migrate_without_db() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        r#"[app]
+name = "myapp"
+
+[services.api]
+type = "api"
+repo = "getfloo/external-api"
+path = "services/api"
+port = 8000
+ingress = "public"
+migrate_command = "alembic upgrade head"
+"#,
+    )
+    .unwrap();
+    // No local `services/api` dir and no [postgres] — external-repo source, but
+    // the migrate step still has no reachable database.
+
+    floo()
+        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""valid":true"#))
+        .stdout(predicate::str::contains(
+            r#""code":"MIGRATE_COMMAND_NO_DATABASE""#,
+        ))
+        // The disk checks are still skipped for external-repo.
+        .stdout(predicate::str::contains("SERVICE_PATH_NOT_FOUND").not())
+        .stdout(predicate::str::contains("REQUIRED_ENV_UNSATISFIED").not());
+}
+
+/// An external-`repo` service WITH managed Postgres does not warn — the migrate
+/// check is satisfied by the managed DATABASE_URL injection.
+#[test]
+fn test_preflight_external_repo_service_migrate_satisfied_by_postgres() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        r#"[app]
+name = "myapp"
+
+[postgres]
+tier = "basic"
+
+[services.api]
+type = "api"
+repo = "getfloo/external-api"
+path = "services/api"
+port = 8000
+ingress = "public"
+migrate_command = "alembic upgrade head"
+"#,
+    )
+    .unwrap();
+
+    floo()
+        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""valid":true"#))
+        .stdout(predicate::str::contains("MIGRATE_COMMAND_NO_DATABASE").not());
+}
+
 /// An IMPORTED env_file (declared in floo.service.toml) that doesn't exist is a
 /// hard ERROR — the deploy's own `validate_env_file_path` exits on it, so
 /// preflight must not greenlight a config `floo deploy` always rejects.


### PR DESCRIPTION
## What changed

Follow-up to #173 (getfloo/floo#1154). codex flagged that `validate_preflight`'s early `continue` for external-`repo` services skipped the **config-only** `MIGRATE_COMMAND_NO_DATABASE` warning, not just the local-disk checks. A migrate step with no reachable database fails regardless of where the service source lives, so that warning should still fire.

- Extracts the migrate check into `check_migrate_command_no_database` (config-only: reads managed-injection keys + imported env_file keys, no service-source disk access).
- Runs it for external-`repo` services with an empty local env_file set, before the `continue` that skips the disk checks (`SERVICE_PATH_NOT_FOUND`, `ENV_FILE_NOT_FOUND`, Dockerfile/Rails) and the local-env-file-based `REQUIRED_ENV_UNSATISFIED` (which would be a false-positive flood for a service whose env lives in the referenced repo, invisible to local preflight).
- Behavior-preserving for local (non-external) services — same condition, message, and loop position; `managed_keys` is now computed once above the gate.

## Why

`floo preflight` stayed silent for an external-`repo` service declaring `migrate_command` with no managed Postgres / DATABASE_URL. The migrate would still fail. This restores that advisory.

## Risk tier

sensitive (CLI preflight). **Warning-severity only — never gates `valid`, never blocks a deploy.**

## Tests run

`cargo test --bin floo` (420) + `cargo test --test cli_tests` (137), all green. clippy `-D warnings` + fmt clean. New tests: external-repo + `migrate_command` without DB → `MIGRATE_COMMAND_NO_DATABASE` warning + `valid:true` + disk checks still skipped; external-repo + `[postgres]` → no warning.

## Review

Combined Claude reviewer + codex (floo SDLC pipeline) — both clean, confirmed a behavior-preserving extraction plus the intended external-repo config-only addition.

## Known non-goals

- `REQUIRED_ENV_UNSATISFIED` stays skipped for external-`repo` services (their env lives in the referenced repo + managed + server, unverifiable locally — running it would be a false-positive flood).

Refs getfloo/floo#1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)