### PR TITLE
feat(notifications): floo notifications list/set (#1182)

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -238,6 +238,23 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_notification_preferences(
+        &self,
+    ) -> Result<NotificationPreferencesResponse, FlooApiError> {
+        let resp = self.get("/v1/notification-preferences")?;
+        self.handle_response(resp)
+    }
+
+    pub fn set_notification_preference(
+        &self,
+        category: &str,
+        enabled: bool,
+    ) -> Result<NotificationPreferencesResponse, FlooApiError> {
+        let body = serde_json::json!({ "category": category, "enabled": enabled });
+        let resp = self.patch_json("/v1/notification-preferences", &body)?;
+        self.handle_response(resp)
+    }
+
     pub fn update_member_role(
         &self,
         org_id: &str,

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -681,3 +681,20 @@ pub struct AppAnalyticsEntry {
     pub error_rate: f64,
     pub avg_latency_ms: Option<i64>,
 }
+
+// --- Notification preferences ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationPreference {
+    pub category: String,
+    pub label: String,
+    pub description: String,
+    pub enabled: bool,
+    // True while inheriting the system default; false once the user has chosen.
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationPreferencesResponse {
+    pub preferences: Vec<NotificationPreference>,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -250,6 +250,20 @@ Examples:
     )]
     Env(EnvCommands),
 
+    /// View and tune which emails floo sends you.
+    #[command(
+        subcommand,
+        after_help = "\
+Examples:
+  floo notifications list                     Show your email settings
+  floo notifications list --json              Machine-readable for agents
+  floo notifications set deploy_success on    Email me on every successful deploy
+  floo notifications set billing off          Stop spend-cap warning emails
+
+Run `floo notifications list` to see the available categories."
+    )]
+    Notifications(NotificationsCommands),
+
     /// Manage services for an app.
     #[command(subcommand)]
     Services(ServicesCommands),
@@ -783,6 +797,22 @@ pub enum EnvCommands {
         /// Environment: dev or prod.
         #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
         env: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum NotificationsCommands {
+    /// Show which emails floo sends you, and whether each is on or off.
+    List,
+
+    /// Turn one category of email on or off.
+    Set {
+        /// Category to change (run `floo notifications list` to see them).
+        category: String,
+
+        /// Whether to receive this category.
+        #[arg(value_parser = ["on", "off"])]
+        value: String,
     },
 }
 
@@ -1685,6 +1715,13 @@ pub fn run() {
                 } else {
                     commands::env::import_vars(file.as_deref(), app.as_deref(), &services, &env);
                 }
+            }
+        },
+
+        Commands::Notifications(sub) => match sub {
+            NotificationsCommands::List => commands::notifications::list(),
+            NotificationsCommands::Set { category, value } => {
+                commands::notifications::set(&category, &value)
             }
         },
 

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -203,6 +203,28 @@ fn command_tree() -> Vec<CommandInfo> {
             ],
         },
         CommandInfo {
+            name: "notifications",
+            description: "View and tune which emails floo sends you",
+            usage: "floo notifications <subcommand>",
+            requires_auth: true,
+            subcommands: vec![
+                CommandInfo {
+                    name: "list",
+                    description: "Show your email settings and whether each is on or off",
+                    usage: "floo notifications list",
+                    requires_auth: true,
+                    subcommands: vec![],
+                },
+                CommandInfo {
+                    name: "set",
+                    description: "Turn one category of email on or off",
+                    usage: "floo notifications set <category> <on|off>",
+                    requires_auth: true,
+                    subcommands: vec![],
+                },
+            ],
+        },
+        CommandInfo {
             name: "services",
             description: "Manage services for an app",
             usage: "floo services <subcommand>",
@@ -637,6 +659,7 @@ mod tests {
             "feedback",
             "init",
             "logs",
+            "notifications",
             "orgs",
             "preflight",
             "redeploy",

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -805,6 +805,37 @@ the CLI. Feedback is routed to the Floo team in real-time.
   floo feedback --category bug \"deploy fails\" --context \"error: no Dockerfile found\"
 ";
 
+const NOTIFICATIONS: &str = "\
+Email Notifications — control which emails floo sends you
+
+floo emails you about things that happen to your apps. You choose which
+categories land in your inbox; account and security messages always send.
+
+## List your settings
+
+  floo notifications list
+  floo notifications list --json     (machine-readable, for agents)
+
+Shows every category, whether it is on or off, and what it covers.
+
+## Turn a category on or off
+
+  floo notifications set deploy_success on    Email me on every successful deploy
+  floo notifications set deploy_success off   Stop those (this is the default)
+  floo notifications set billing off          Stop spend-cap warning emails
+
+## Categories
+
+  Run `floo notifications list` to see the current categories and their state.
+  deploy_success is OFF by default (it is the noisy one); the rest are ON.
+
+## Notes
+
+  Preferences are per-user and account-wide — they apply to your inbox, not to a
+  single app. Always-send emails (invites, verification, security approvals,
+  and destructive-action warnings) are not configurable.
+";
+
 const HOWTO: &str = "\
 Floo — Golden Path
 
@@ -1658,6 +1689,7 @@ const TOPICS: &[(&str, &str)] = &[
     ("deploy", DEPLOY),
     ("auth", AUTH),
     ("feedback", FEEDBACK),
+    ("notifications", NOTIFICATIONS),
     ("templates", TEMPLATES),
 ];
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod feedback;
 pub mod github;
 pub mod init;
 pub mod logs;
+pub mod notifications;
 pub mod orgs;
 pub mod releases;
 pub mod reparo;

--- a/src/commands/notifications.rs
+++ b/src/commands/notifications.rs
@@ -1,0 +1,78 @@
+use std::process;
+
+use crate::errors::ErrorCode;
+use crate::output;
+
+/// List the current user's email notification preferences.
+pub fn list() {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let result = match client.get_notification_preferences() {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let rows: Vec<Vec<String>> = result
+        .preferences
+        .iter()
+        .map(|p| {
+            vec![
+                p.category.clone(),
+                if p.enabled {
+                    "on".to_string()
+                } else {
+                    "off".to_string()
+                },
+                p.label.clone(),
+            ]
+        })
+        .collect();
+
+    output::table(
+        &["CATEGORY", "EMAILS", "WHAT"],
+        &rows,
+        Some(output::to_value(&result)),
+    );
+}
+
+/// Turn one category of email on or off for the current user.
+pub fn set(category: &str, value: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let enabled = match value {
+        "on" => true,
+        "off" => false,
+        _ => {
+            output::error(
+                &format!("Invalid value '{value}'. Use 'on' or 'off'."),
+                &ErrorCode::InvalidFormat,
+                None,
+            );
+            process::exit(1);
+        }
+    };
+
+    match client.set_notification_preference(category, enabled) {
+        Ok(result) => {
+            let label = result
+                .preferences
+                .iter()
+                .find(|p| p.category == category)
+                .map(|p| p.label.clone())
+                .unwrap_or_else(|| category.to_string());
+            output::success(
+                &format!("{label} emails turned {value}."),
+                Some(output::to_value(&result)),
+            );
+        }
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -3782,3 +3782,71 @@ fn test_db_query_json_passthrough_exposes_contract() {
         .stdout(predicate::str::contains(r#""columns":["id","email"]"#))
         .stdout(predicate::str::contains("alice@example.com"));
 }
+
+const NOTIF_PREFS_DEFAULTS: &str = r#"{"preferences":[{"category":"deploy_success","label":"Deploy succeeded","description":"When a deploy finishes successfully.","enabled":false,"is_default":true},{"category":"billing","label":"Spend cap warnings","description":"When your org approaches its spend cap.","enabled":true,"is_default":true}]}"#;
+
+#[test]
+fn test_notifications_list_json() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m = server
+        .mock("GET", "/v1/notification-preferences")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(NOTIF_PREFS_DEFAULTS)
+        .create();
+
+    floo()
+        .args(["--json", "notifications", "list"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains("deploy_success"))
+        .stdout(predicate::str::contains(r#""enabled":false"#));
+}
+
+#[test]
+fn test_notifications_list_human_shows_category_and_label() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m = server
+        .mock("GET", "/v1/notification-preferences")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(NOTIF_PREFS_DEFAULTS)
+        .create();
+
+    floo()
+        .args(["notifications", "list"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("deploy_success"))
+        .stderr(predicate::str::contains("Deploy succeeded"));
+}
+
+#[test]
+fn test_notifications_set_json() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m = server
+        .mock("PATCH", "/v1/notification-preferences")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"preferences":[{"category":"deploy_success","label":"Deploy succeeded","description":"d","enabled":true,"is_default":false}]}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "notifications", "set", "deploy_success", "on"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""enabled":true"#));
+}


### PR DESCRIPTION
## What changed

Adds the **`floo notifications`** command — the CLI surface to view and tune which emails floo sends you, over the `/v1/notification-preferences` API. This is the AX half of #1182 ("agents tune their own inbox").

- **`floo notifications list [--json]`** — a table of every category, whether it's on/off, and what it covers. `--json` emits the full payload for agents.
- **`floo notifications set <category> <on|off>`** — turns one category on or off; clap validates `on|off`, the API validates the category.
- `api_client`: `get_notification_preferences` + `set_notification_preference`.

## Why

v1 (API + dashboard) made email preferences viewable and tunable for humans. This completes the surface so agents and CLI users can do the same — `floo notifications set deploy_success off` and the spam stops.

## Discoverability (the "make it clear" goal)

- `floo notifications --help` (clap, with examples).
- `floo docs notifications` — offline cheatsheet.
- `floo commands` lists it (`command_tree` entry); the completeness test pins the new command so the tree can't drift.
- Category **labels and descriptions come from the API response** — no duplicated list in the CLI; the dashboard and CLI render identical wording.

## Tests run

`cargo test` (420 unit + 234 integration, 0 failures), `cargo clippy -- -D warnings`, `cargo fmt --check` — all green. New: 3 mock-API integration tests (`notifications list` JSON + human, `notifications set` JSON).

## Depends on

The API `/v1/notification-preferences` (getfloo/floo#1207, merged).

Part of #1182.
