### PR TITLE
fix: observability CLI UX — severity, tail cap, selector, latency context (#1155)

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -636,6 +636,12 @@ pub struct AnalyticsSummary {
     pub avg_latency_ms: Option<i64>,
     pub p95_latency_ms: Option<i64>,
     pub unique_users: Option<i64>,
+    // Requests the gateway answered without proxying to the backend (rejections
+    // + gateway-owned endpoints). Explains why latency is measured over fewer
+    // requests than total. `#[serde(default)]` keeps the CLI working against an
+    // API that predates the field (None = unknown).
+    #[serde(default)]
+    pub gateway_handled_requests: Option<i64>,
     pub status_code_breakdown: Option<HashMap<String, i64>>,
     pub total_apps_with_traffic: Option<i64>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,8 +40,13 @@ pub struct Cli {
 pub enum Commands {
     /// View traffic analytics for an app or org.
     Analytics {
-        /// App name or ID. Omit for org-level overview.
+        /// App name or ID (positional). Omit for org-level overview.
         app: Option<String>,
+
+        /// App name or ID — `--app` form, consistent with `floo logs`. Takes
+        /// precedence over the positional argument if both are given.
+        #[arg(short = 'a', long = "app")]
+        app_flag: Option<String>,
 
         /// Time period: 7d, 30d, or 90d.
         #[arg(short, long, default_value = "30d", value_parser = ["7d", "30d", "90d"])]
@@ -409,7 +414,7 @@ pub struct LogsOptions {
     #[arg(short, long)]
     app: Option<String>,
 
-    /// Number of log lines to show.
+    /// Number of log lines to show (max 500; higher values are capped).
     #[arg(short, long, visible_alias = "limit", default_value = "100")]
     tail: u32,
 
@@ -421,7 +426,7 @@ pub struct LogsOptions {
     #[arg(short, long)]
     error: bool,
 
-    /// Minimum severity level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+    /// Minimum severity level (DEFAULT, DEBUG, INFO, WARNING, ERROR, CRITICAL).
     #[arg(long)]
     severity: Option<String>,
 
@@ -1553,7 +1558,11 @@ pub fn run() {
     };
 
     match cli.command {
-        Commands::Analytics { app, period } => commands::analytics::analytics(app, &period),
+        Commands::Analytics {
+            app,
+            app_flag,
+            period,
+        } => commands::analytics::analytics(app_flag.or(app), &period),
 
         Commands::Init { name, path } => commands::init::init(name, path),
 
@@ -2122,5 +2131,40 @@ mod tests {
         ])
         .unwrap();
         assert!(dry_run_is_unsupported(&cli.command));
+    }
+
+    #[test]
+    fn analytics_accepts_app_flag_and_positional() {
+        // --app flag form, consistent with `floo logs`
+        let cli = Cli::try_parse_from(["floo", "analytics", "--app", "myapp"]).unwrap();
+        let Commands::Analytics { app, app_flag, .. } = cli.command else {
+            panic!("expected Analytics");
+        };
+        assert_eq!(app_flag.or(app), Some("myapp".to_string()));
+
+        // positional form still works (back-compat)
+        let cli = Cli::try_parse_from(["floo", "analytics", "myapp"]).unwrap();
+        let Commands::Analytics { app, app_flag, .. } = cli.command else {
+            panic!("expected Analytics");
+        };
+        assert_eq!(app_flag.or(app), Some("myapp".to_string()));
+    }
+
+    #[test]
+    fn analytics_app_flag_takes_precedence_over_positional() {
+        let cli = Cli::try_parse_from(["floo", "analytics", "pos", "--app", "flag"]).unwrap();
+        let Commands::Analytics { app, app_flag, .. } = cli.command else {
+            panic!("expected Analytics");
+        };
+        assert_eq!(app_flag.or(app), Some("flag".to_string()));
+    }
+
+    #[test]
+    fn analytics_omitted_app_is_org_level() {
+        let cli = Cli::try_parse_from(["floo", "analytics"]).unwrap();
+        let Commands::Analytics { app, app_flag, .. } = cli.command else {
+            panic!("expected Analytics");
+        };
+        assert_eq!(app_flag.or(app), None);
     }
 }

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -57,6 +57,22 @@ fn org_analytics(client: &crate::api_client::FlooClient, period: &str) {
     render_org_analytics(period, &data);
 }
 
+/// Print the gateway-handled count when present and non-zero. These requests
+/// (rejections + gateway-owned /__floo/* endpoints) never reached the customer
+/// backend, so they are excluded from the latency lines below — surfacing the
+/// count is what makes "100% errors, 0ms latency" legible (#1155 finding #4).
+fn render_gateway_handled(handled: Option<i64>, label_width: usize) {
+    if let Some(n) = handled {
+        if n > 0 {
+            eprintln!(
+                "  {:label_width$}{:>10}   (not proxied to backend; excluded from latency)",
+                "Gateway-handled",
+                format_number(n),
+            );
+        }
+    }
+}
+
 fn render_app_analytics(name: &str, period: &str, data: &AppAnalyticsResponse) {
     let summary = &data.summary;
     let total_requests = summary.total_requests;
@@ -73,6 +89,7 @@ fn render_app_analytics(name: &str, period: &str, data: &AppAnalyticsResponse) {
         format_number(total_errors),
         error_rate * 100.0
     );
+    render_gateway_handled(summary.gateway_handled_requests, 14);
 
     if let Some(avg) = summary.avg_latency_ms {
         eprintln!("  {:14}{:>10}", "Avg Latency", format!("{}ms", avg));
@@ -127,6 +144,7 @@ fn render_org_analytics(period: &str, data: &AppAnalyticsResponse) {
         "Apps w/ Traffic",
         format_number(apps_with_traffic)
     );
+    render_gateway_handled(summary.gateway_handled_requests, 18);
 
     // Org-level latency mirrors the per-app surface (request-weighted avg,
     // max of per-app p95s). Free-tier orgs see no latency line because the

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -13,6 +13,27 @@ use crate::resolve::resolve_app;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const MAX_TRANSIENT_RETRIES: u32 = 3;
+/// Server-side cap on `limit` for both /logs and /requests (FastAPI `le=500`).
+/// Clamp client-side so `--tail 9999` shows the most recent 500 with a clear
+/// note instead of leaking a raw Pydantic validation error (#1155 finding #5).
+const MAX_LOG_LINES: u32 = 500;
+
+/// Clamp `--tail` to the server maximum, emitting a one-line note when it caps.
+fn clamp_tail(tail: u32) -> u32 {
+    if tail > MAX_LOG_LINES {
+        if !output::is_json_mode() {
+            output::info(
+                &format!(
+                    "--tail {tail} exceeds the maximum; showing the most recent {MAX_LOG_LINES} lines."
+                ),
+                None,
+            );
+        }
+        MAX_LOG_LINES
+    } else {
+        tail
+    }
+}
 
 pub struct LogsArgs {
     pub app_flag: Option<String>,
@@ -338,6 +359,7 @@ pub fn logs(args: LogsArgs) {
 
     let app_name = &app_data.name;
     let app_id = &app_data.id;
+    let tail = clamp_tail(args.tail);
 
     let filter = LogsFilter {
         since: args.since.as_deref(),
@@ -355,13 +377,13 @@ pub fn logs(args: LogsArgs) {
     }
 
     if args.live {
-        live_logs(&client, app_id, args.tail, &filter);
+        live_logs(&client, app_id, tail, &filter);
     } else {
         batch_logs(
             &client,
             app_id,
             app_name,
-            args.tail,
+            tail,
             &filter,
             args.output_path.as_deref(),
         );
@@ -630,18 +652,20 @@ pub fn request_logs(args: RequestLogsArgs) {
         }
     };
 
+    let tail = clamp_tail(args.tail);
+
     if args.live {
         live_request_logs(
             &client,
             &app_data.id,
             &app_data.name,
-            args.tail,
+            tail,
             args.since.as_deref(),
         );
         return;
     }
 
-    let result = match client.get_request_logs(&app_data.id, args.tail, args.since.as_deref()) {
+    let result = match client.get_request_logs(&app_data.id, tail, args.since.as_deref()) {
         Ok(r) => r,
         Err(e) => {
             output::error(
@@ -664,7 +688,15 @@ pub fn request_logs(args: RequestLogsArgs) {
     }
 
     if result.requests.is_empty() {
-        output::dim_line(&format!("No requests yet for {}.", app_data.name));
+        output::dim_line(&format!(
+            "No requests in the last 7 days for {}.",
+            app_data.name
+        ));
+        output::info(
+            "Gateway request logs are retained ~7 days. For longer windows use \
+             `floo analytics` (aggregated totals up to 90 days).",
+            None,
+        );
         return;
     }
 
@@ -673,6 +705,15 @@ pub fn request_logs(args: RequestLogsArgs) {
     for entry in result.requests.iter().rev() {
         output::dim_line(&format_request_line(entry));
     }
+    // The two surfaces read different stores (raw 7-day requests vs aggregated
+    // 90-day analytics), so they legitimately differ for older traffic. Make
+    // the horizon explicit rather than leaving "analytics shows 145, requests
+    // shows fewer" a silent contradiction (#1155 finding #3).
+    output::info(
+        "Showing raw gateway requests from the last ~7 days. `floo analytics` \
+         aggregates totals over a longer window.",
+        None,
+    );
 }
 
 fn live_request_logs(
@@ -917,6 +958,15 @@ mod tests {
     #[test]
     fn test_should_show_prefix_empty_is_false() {
         assert!(!should_show_prefix(&[]));
+    }
+
+    #[test]
+    fn test_clamp_tail_caps_at_server_max() {
+        assert_eq!(clamp_tail(MAX_LOG_LINES + 1), MAX_LOG_LINES);
+        assert_eq!(clamp_tail(9999), MAX_LOG_LINES);
+        assert_eq!(clamp_tail(MAX_LOG_LINES), MAX_LOG_LINES);
+        assert_eq!(clamp_tail(100), 100);
+        assert_eq!(clamp_tail(1), 1);
     }
 
     fn make_request_entry(ts: &str) -> RequestLogEntry {


### PR DESCRIPTION
## What changed

Closes the CLI side of the remaining #1155 findings on `floo logs` / `floo analytics`:

- **#2 severity** — `--severity` help lists `DEFAULT` (the API accepts it after [getfloo/floo#1229](https://github.com/getfloo/floo/pull/1229)).
- **#5 tail cap** — `--tail` is clamped client-side to the server max (500) with a clear one-line note instead of leaking a raw Pydantic 422 array; the cap is documented in `--help`.
- **#7 selector** — `floo analytics` now accepts `--app` (consistent with `floo logs`), taking precedence over the positional arg, which stays for back-compat. One consistent selector across commands.
- **#4 latency context** — `floo analytics` surfaces `gateway_handled_requests` next to the error rate, so "100% errors, 0ms latency" is legible: those requests never reached the backend and are excluded from latency. (Reads the field added in [getfloo/floo#1226](https://github.com/getfloo/floo/pull/1226); `#[serde(default)]` keeps the CLI working against an older API.)
- **#3 requests horizon** — `logs --requests` states the ~7-day raw-request retention horizon and points to `floo analytics` for longer windows, so the two surfaces reading different stores (raw 7d vs aggregated 90d) no longer look like a silent contradiction.

## Risk tier

standard — `commands/{logs,analytics}.rs`, `cli.rs`, `api_types.rs`. No `auth.rs` / `deploy.rs`.

## Tests run

`cargo test` (430 pass), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. New tests: `clamp_tail` caps at 500; `analytics --app`/positional/precedence/omitted resolution.

## Known non-goals

The CLI `--cron` filter + attribution rendering shipped in [floo-cli#178](https://github.com/getfloo/floo-cli/pull/178). API-side findings are in getfloo/floo PRs #1224/#1226/#1229.

Part of getfloo/floo#1155 (findings 2, 3, 4, 5, 7 — CLI side).