### PR TITLE
feat: add preview database branch commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -760,6 +760,63 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    // --- Preview database branches ---
+
+    pub fn list_previews(
+        &self,
+        app_id: &str,
+    ) -> Result<PreviewEnvironmentListResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/previews"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn get_preview(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+    ) -> Result<PreviewEnvironment, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/previews/{preview_slug}"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn list_preview_database_branches(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+    ) -> Result<PreviewDatabaseBranchListResponse, FlooApiError> {
+        let resp = self.get(&format!(
+            "/v1/apps/{app_id}/previews/{preview_slug}/database-branches"
+        ))?;
+        self.handle_response(resp)
+    }
+
+    pub fn get_preview_database_branch(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+        branch_name: &str,
+    ) -> Result<PreviewDatabaseBranch, FlooApiError> {
+        let resp = self.get(&format!(
+            "/v1/apps/{app_id}/previews/{preview_slug}/database-branches/{branch_name}"
+        ))?;
+        self.handle_response(resp)
+    }
+
+    pub fn reset_preview_database_branch(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+        branch_name: &str,
+    ) -> Result<PreviewDatabaseBranch, FlooApiError> {
+        let resp = self.post_json(
+            &format!(
+                "/v1/apps/{app_id}/previews/{preview_slug}/database-branches/{branch_name}/reset"
+            ),
+            &serde_json::json!({}),
+        )?;
+        self.handle_response(resp)
+    }
+
     // --- Preflight ---
 
     pub fn preflight(

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -329,6 +329,70 @@ pub struct ManagedPostgresRestoreResponse {
     pub restored_at: String,
 }
 
+// --- Preview database branches ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewDatabaseBranch {
+    pub id: Option<String>,
+    pub managed_service_id: Option<String>,
+    pub name: String,
+    pub source_environment: String,
+    pub preview_slug: String,
+    pub resource_status: String,
+    pub hydration_mode: String,
+    pub schema_name: Option<String>,
+    pub role_name: Option<String>,
+    pub base_schema_name: Option<String>,
+    pub base_role_name: Option<String>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub reset_eligible: bool,
+    pub reset_blocked_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewDatabaseBranchListResponse {
+    pub database_branches: Vec<PreviewDatabaseBranch>,
+    pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewResource {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub resource_type: String,
+    pub name: String,
+    pub status: String,
+    pub external_resource_id: Option<String>,
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewEnvironment {
+    pub id: String,
+    pub app_id: String,
+    pub slug: String,
+    pub source_branch: Option<String>,
+    pub pr_number: Option<u32>,
+    pub url: Option<String>,
+    pub latest_deploy_id: Option<String>,
+    pub latest_deploy_status: Option<String>,
+    pub latest_commit_sha: Option<String>,
+    pub ttl_hours: Option<u32>,
+    pub expires_at: Option<String>,
+    #[serde(default)]
+    pub resources: Vec<PreviewResource>,
+    #[serde(default)]
+    pub database_branches: Vec<PreviewDatabaseBranch>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewEnvironmentListResponse {
+    pub previews: Vec<PreviewEnvironment>,
+    pub total: u32,
+}
+
 // --- Preflight ---
 // Mirrors api/app/schemas/preflight.py. Keep these two in lock-step.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1314,6 +1314,73 @@ Examples:
         #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
         env: String,
     },
+
+    /// Inspect and reset preview database branches.
+    #[command(subcommand)]
+    Branches(DbBranchesCommands),
+}
+
+#[derive(Subcommand)]
+pub enum DbBranchesCommands {
+    /// List managed Postgres branches backing one preview.
+    #[command(after_help = "\
+Examples:
+  floo db branches list feat-db-abcde --app my-app
+  floo db branches list feat-db-abcde --app my-app --json
+
+Preview database branches are preview-owned. Dev and prod databases are not
+listed or reset by this surface.")]
+    List {
+        /// Preview slug from PR preview URLs or `floo previews` surfaces.
+        preview: String,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Show one preview database branch.
+    #[command(after_help = "\
+Examples:
+  floo db branches show feat-db-abcde --app my-app
+  floo db branches show feat-db-abcde --app my-app --name analytics")]
+    Show {
+        /// Preview slug from PR preview URLs or `floo previews` surfaces.
+        preview: String,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed Postgres branch name.
+        #[arg(long, default_value = "default")]
+        name: String,
+    },
+
+    /// Reset one preview database branch.
+    #[command(after_help = "\
+Examples:
+  floo db branches reset feat-db-abcde --app my-app --name default
+  floo db branches reset feat-db-abcde --app my-app --yes --json
+
+Reset drops and recreates preview-owned state only. It does not touch dev or
+prod databases.")]
+    Reset {
+        /// Preview slug from PR preview URLs or `floo previews` surfaces.
+        preview: String,
+
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Managed Postgres branch name.
+        #[arg(long, default_value = "default")]
+        name: String,
+
+        /// Skip the y/N prompt. Required in non-interactive contexts.
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1514,6 +1581,7 @@ const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
     "deploys rollback",
     "db migrate",
     "db query",
+    "db branches reset",
 ];
 
 fn reject_unsupported_dry_run(command: &Commands) {
@@ -1930,6 +1998,20 @@ pub fn run() {
                 name,
                 env,
             } => commands::db::restore(app.as_deref(), &name, &env, &backup_id),
+            DbCommands::Branches(sub) => match sub {
+                DbBranchesCommands::List { preview, app } => {
+                    commands::db::branches_list(app.as_deref(), &preview)
+                }
+                DbBranchesCommands::Show { preview, app, name } => {
+                    commands::db::branches_show(app.as_deref(), &preview, &name)
+                }
+                DbBranchesCommands::Reset {
+                    preview,
+                    app,
+                    name,
+                    yes,
+                } => commands::db::branches_reset(app.as_deref(), &preview, &name, yes),
+            },
         },
 
         Commands::Cron(sub) => match sub {
@@ -2159,6 +2241,19 @@ mod tests {
                     "db",
                     "query",
                     "SELECT 1",
+                    "--app",
+                    "myapp",
+                    "--dry-run",
+                ],
+            ),
+            (
+                "db branches reset",
+                &[
+                    "floo",
+                    "db",
+                    "branches",
+                    "reset",
+                    "feat-db-abcde",
                     "--app",
                     "myapp",
                     "--dry-run",

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -504,6 +504,35 @@ fn command_tree() -> Vec<CommandInfo> {
                     requires_auth: true,
                     subcommands: vec![],
                 },
+                CommandInfo {
+                    name: "branches",
+                    description: "Inspect and reset preview database branches",
+                    usage: "floo db branches <list|show|reset> <preview> --app <name>",
+                    requires_auth: true,
+                    subcommands: vec![
+                        CommandInfo {
+                            name: "list",
+                            description: "List managed Postgres branches backing one preview",
+                            usage: "floo db branches list <preview> --app <name>",
+                            requires_auth: true,
+                            subcommands: vec![],
+                        },
+                        CommandInfo {
+                            name: "show",
+                            description: "Show one preview database branch",
+                            usage: "floo db branches show <preview> --app <name> [--name default]",
+                            requires_auth: true,
+                            subcommands: vec![],
+                        },
+                        CommandInfo {
+                            name: "reset",
+                            description: "Reset one preview database branch without touching dev/prod",
+                            usage: "floo db branches reset <preview> --app <name> [--name default] --yes",
+                            requires_auth: true,
+                            subcommands: vec![],
+                        },
+                    ],
+                },
             ],
         },
         CommandInfo {

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 
 use crate::api_types::{
     ManagedPostgresBackup, ManagedPostgresRestoreResponse, ManagedServiceSummary,
+    PreviewDatabaseBranch, PreviewEnvironment,
 };
 use crate::errors::{ErrorCode, FlooError};
 use crate::output;
@@ -529,6 +530,199 @@ pub fn restore(app_flag: Option<&str>, name: &str, env: &str, backup_id: &str) {
     render_restore(&response, &app_name, name, env);
 }
 
+pub fn branches_list(app_flag: Option<&str>, preview_identifier: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview_slug = resolve_preview_slug(&client, &app_id, &app_name, preview_identifier);
+
+    let preview = match client.get_preview(&app_id, &preview_slug) {
+        Ok(preview) => preview,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+    let branches = match client.list_preview_database_branches(&app_id, &preview_slug) {
+        Ok(response) => response.database_branches,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview database branches retrieved.",
+            Some(serde_json::json!({
+                "app": {
+                    "id": app_id,
+                    "name": app_name,
+                },
+                "preview": preview_json(&preview),
+                "database_branches": output::to_value(&branches),
+                "total": branches.len(),
+            })),
+        );
+        return;
+    }
+
+    output::info(
+        &format!(
+            "Preview database branches for {app_name} (preview: {}):",
+            preview.slug
+        ),
+        None,
+    );
+    render_preview_context(&preview);
+    if branches.is_empty() {
+        output::info(
+            "No preview database branches. This preview has no managed Postgres attachment.",
+            None,
+        );
+        return;
+    }
+    render_branch_table(&branches);
+}
+
+pub fn branches_show(app_flag: Option<&str>, preview_identifier: &str, name: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview_slug = resolve_preview_slug(&client, &app_id, &app_name, preview_identifier);
+
+    let branch = match client.get_preview_database_branch(&app_id, &preview_slug, name) {
+        Ok(branch) => branch,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview database branch retrieved.",
+            Some(serde_json::json!({
+                "app": {
+                    "id": app_id,
+                    "name": app_name,
+                },
+                "preview": {
+                    "slug": preview_slug,
+                    "environment_name": "preview",
+                },
+                "database_branch": output::to_value(&branch),
+            })),
+        );
+        return;
+    }
+
+    output::info(
+        &format!(
+            "Preview database branch {} for {app_name} (preview: {preview_slug}):",
+            branch.name
+        ),
+        None,
+    );
+    render_branch_detail(&branch);
+}
+
+pub fn branches_reset(app_flag: Option<&str>, preview_identifier: &str, name: &str, yes: bool) {
+    use crate::confirm::{confirm_tier2, ConfirmOutcome, RiskMetadata, Tier};
+
+    if output::is_dry_run_mode() {
+        let risk: RiskMetadata = Tier::Two.into();
+        let preview_slug = normalize_preview_identifier(preview_identifier)
+            .unwrap_or_else(|| preview_identifier.trim().to_string());
+        output::dry_run_preview(
+            &format!(
+                "Would reset preview database branch '{name}' on preview '{preview_slug}'. Dev and prod are untouched."
+            ),
+            serde_json::json!({
+                "action": "preview_database_branch_reset",
+                "app": app_flag,
+                "preview": preview_slug,
+                "branch": name,
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+                "scope": "preview",
+                "dev_prod_untouched": true,
+            }),
+        );
+        return;
+    }
+
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview_slug = resolve_preview_slug(&client, &app_id, &app_name, preview_identifier);
+
+    match confirm_tier2(
+        "Reset preview database branch",
+        &format!("{name} on {app_name}/{preview_slug} (dev/prod untouched)"),
+        yes,
+    ) {
+        ConfirmOutcome::Proceed => {}
+        ConfirmOutcome::Aborted => {
+            if output::is_json_mode() {
+                output::success("Cancelled.", Some(serde_json::json!({"cancelled": true})));
+            } else {
+                output::info("Cancelled.", None);
+            }
+            process::exit(0);
+        }
+        ConfirmOutcome::Refused { suggestion } => {
+            crate::confirm::exit_refused(
+                &format!(
+                    "Refusing to reset preview database branch '{name}' on {app_name}/{preview_slug} without explicit confirmation; dev/prod untouched."
+                ),
+                &suggestion,
+            );
+        }
+    }
+
+    let branch = match client.reset_preview_database_branch(&app_id, &preview_slug, name) {
+        Ok(branch) => branch,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let risk: RiskMetadata = Tier::Two.into();
+    if output::is_json_mode() {
+        output::success(
+            "Preview database branch reset.",
+            Some(serde_json::json!({
+                "app": {
+                    "id": app_id,
+                    "name": app_name,
+                },
+                "preview": {
+                    "slug": preview_slug,
+                    "environment_name": "preview",
+                },
+                "database_branch": output::to_value(&branch),
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+                "scope": "preview",
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    output::success(
+        &format!(
+            "Reset preview database branch {name} for {app_name}/{preview_slug}. Dev and prod were untouched."
+        ),
+        None,
+    );
+    render_branch_detail(&branch);
+}
+
 fn resolve_postgres_service(
     client: &crate::api_client::FlooClient,
     app_id: &str,
@@ -557,6 +751,186 @@ fn resolve_postgres_service(
             );
             process::exit(1);
         }
+    }
+}
+
+fn resolve_preview_slug(
+    client: &crate::api_client::FlooClient,
+    app_id: &str,
+    app_name: &str,
+    preview_identifier: &str,
+) -> String {
+    if let Some(slug) = normalize_preview_identifier(preview_identifier) {
+        return slug;
+    }
+
+    let listing = match client.list_previews(app_id) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let matches: Vec<&PreviewEnvironment> = listing
+        .previews
+        .iter()
+        .filter(|preview| {
+            preview.slug == preview_identifier
+                || preview.source_branch.as_deref() == Some(preview_identifier)
+                || preview
+                    .pr_number
+                    .map(|pr_number| format!("#{pr_number}") == preview_identifier)
+                    .unwrap_or(false)
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [preview] => preview.slug.clone(),
+        [] => {
+            output::error(
+                &format!("Preview '{preview_identifier}' not found on {app_name}."),
+                &ErrorCode::Other("PREVIEW_NOT_FOUND".to_string()),
+                Some("Pass the preview slug from the preview URL, or run the list command with a known slug."),
+            );
+            process::exit(1);
+        }
+        _ => {
+            output::error(
+                &format!("Preview identifier '{preview_identifier}' is ambiguous on {app_name}."),
+                &ErrorCode::Other("AMBIGUOUS_PREVIEW_IDENTIFIER".to_string()),
+                Some("Pass the exact preview slug, e.g. the part after '-preview-' in the preview URL."),
+            );
+            process::exit(1);
+        }
+    }
+}
+
+fn normalize_preview_identifier(identifier: &str) -> Option<String> {
+    let trimmed = identifier.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let host = without_scheme.split('/').next().unwrap_or(without_scheme);
+    if let Some(prefix_start) = host.find("-preview-") {
+        let after_prefix = &host[prefix_start + "-preview-".len()..];
+        let label = after_prefix.split('.').next().unwrap_or(after_prefix);
+        return Some(label.to_string());
+    }
+    if trimmed.contains("://")
+        || trimmed.contains(".")
+        || trimmed.contains('/')
+        || trimmed.starts_with('#')
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn preview_json(preview: &PreviewEnvironment) -> serde_json::Value {
+    serde_json::json!({
+        "id": preview.id,
+        "slug": preview.slug,
+        "environment_name": "preview",
+        "source_branch": preview.source_branch,
+        "pr_number": preview.pr_number,
+        "url": preview.url,
+        "latest_deploy_id": preview.latest_deploy_id,
+        "latest_deploy_status": preview.latest_deploy_status,
+        "latest_commit_sha": preview.latest_commit_sha,
+        "ttl_hours": preview.ttl_hours,
+        "expires_at": preview.expires_at,
+        "resources": output::to_value(&preview.resources),
+    })
+}
+
+fn render_preview_context(preview: &PreviewEnvironment) {
+    if let Some(source_branch) = &preview.source_branch {
+        output::info(&format!("  Source:  {source_branch}"), None);
+    }
+    if let Some(url) = &preview.url {
+        output::info(&format!("  URL:     {url}"), None);
+    }
+    if let Some(expires_at) = &preview.expires_at {
+        output::info(&format!("  Expires: {expires_at}"), None);
+    }
+}
+
+fn render_branch_table(branches: &[PreviewDatabaseBranch]) {
+    let rows: Vec<Vec<String>> = branches
+        .iter()
+        .map(|branch| {
+            vec![
+                branch.name.clone(),
+                branch.source_environment.clone(),
+                branch.resource_status.clone(),
+                branch.hydration_mode.clone(),
+                branch
+                    .schema_name
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+                branch.expires_at.clone().unwrap_or_else(|| "-".to_string()),
+                reset_status(branch),
+            ]
+        })
+        .collect();
+    output::table(
+        &[
+            "Name",
+            "Source",
+            "Status",
+            "Hydration",
+            "Schema",
+            "Expires",
+            "Reset",
+        ],
+        &rows,
+        None,
+    );
+}
+
+fn render_branch_detail(branch: &PreviewDatabaseBranch) {
+    output::info(&format!("  Name:      {}", branch.name), None);
+    output::info(&format!("  Preview:   {}", branch.preview_slug), None);
+    output::info(&format!("  Source:    {}", branch.source_environment), None);
+    output::info(&format!("  Status:    {}", branch.resource_status), None);
+    output::info(&format!("  Hydration: {}", branch.hydration_mode), None);
+    output::info(
+        &format!(
+            "  Schema:    {}",
+            branch.schema_name.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "  Role:      {}",
+            branch.role_name.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "  Expires:   {}",
+            branch.expires_at.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+    output::info(&format!("  Reset:     {}", reset_status(branch)), None);
+}
+
+fn reset_status(branch: &PreviewDatabaseBranch) -> String {
+    if branch.reset_eligible {
+        "eligible".to_string()
+    } else {
+        branch
+            .reset_blocked_reason
+            .clone()
+            .unwrap_or_else(|| "blocked".to_string())
     }
 }
 

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -213,6 +213,16 @@ confirmation. See also: floo docs state-model.
   and no schema prefix. Rails (`t.vector`), Django, SQLAlchemy, and Prisma
   all emit the bare type. Full guide: https://docs.getfloo.com/guides/databases
 
+  Preview database branches are preview-owned managed Postgres branches.
+  Inspect them from the terminal:
+
+    floo db branches list <preview-slug> --app <name>
+    floo db branches show <preview-slug> --app <name> --name default
+    floo db branches reset <preview-slug> --app <name> --yes
+
+  Reset drops and recreates only the preview branch. Dev and prod databases
+  are untouched, and JSON output never includes plaintext credentials.
+
   In multi-service apps, attach those credentials per service:
     [services.api.env]
     managed = [\"postgres\", \"redis\"]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -147,6 +147,54 @@ fn mock_services_multi(server: &mut Server) -> Mock {
         .create()
 }
 
+fn preview_branch_json(name: &str, status: &str, reset_eligible: bool) -> String {
+    let blocked = if reset_eligible {
+        "null".to_string()
+    } else {
+        r#""latest deploy is building""#.to_string()
+    };
+    format!(
+        r#"{{
+            "id":"resource-{name}",
+            "managed_service_id":"ms-{name}",
+            "name":"{name}",
+            "source_environment":"dev",
+            "preview_slug":"feat-db-abcde",
+            "resource_status":"{status}",
+            "hydration_mode":"clone-dev",
+            "schema_name":"app_default_preview_feat_db_abcde",
+            "role_name":"floo_app_default_preview_feat_db_abcde",
+            "base_schema_name":"app_default_dev",
+            "base_role_name":"floo_app_default_dev",
+            "created_at":"2026-06-24T10:00:00Z",
+            "updated_at":"2026-06-24T10:01:00Z",
+            "expires_at":"2026-06-27T10:00:00Z",
+            "reset_eligible":{reset_eligible},
+            "reset_blocked_reason":{blocked}
+        }}"#
+    )
+}
+
+fn preview_detail_json(branches: &str) -> String {
+    format!(
+        r#"{{
+            "id":"env-preview-1",
+            "app_id":"{TEST_APP_ID}",
+            "slug":"feat-db-abcde",
+            "source_branch":"feat/db-branch",
+            "pr_number":42,
+            "url":"https://my-app-preview-feat-db-abcde.on.getfloo.com",
+            "latest_deploy_id":"deploy-preview-1",
+            "latest_deploy_status":"live",
+            "latest_commit_sha":"abc123",
+            "ttl_hours":72,
+            "expires_at":"2026-06-27T10:00:00Z",
+            "resources":[],
+            "database_branches":[{branches}]
+        }}"#
+    )
+}
+
 // ───────────────────────── Apps ─────────────────────────
 
 #[test]
@@ -1904,6 +1952,229 @@ fn test_services_list_json_returns_both_app_and_managed_services() {
         .stdout(predicate::str::contains("managed_services"))
         .stdout(predicate::str::contains("web"))
         .stdout(predicate::str::contains("postgres"));
+}
+
+#[test]
+fn test_db_branches_list_json_returns_preview_context_and_branch_contract() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let branch = preview_branch_json("default", "ready", true);
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(&branch))
+        .create();
+    let _branches = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde/database-branches").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"database_branches":[{branch}],"total":1}}"#))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "branches",
+            "list",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""environment_name":"preview""#))
+        .stdout(predicate::str::contains(r#""source_environment":"dev""#))
+        .stdout(predicate::str::contains(r#""hydration_mode":"clone-dev""#))
+        .stdout(predicate::str::contains(r#""resource_status":"ready""#))
+        .stdout(predicate::str::contains(
+            "app_default_preview_feat_db_abcde",
+        ))
+        .stdout(predicate::str::contains("postgresql://").not())
+        .stdout(predicate::str::contains("password").not());
+}
+
+#[test]
+fn test_db_branches_list_empty_state_names_missing_managed_postgres() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(""))
+        .create();
+    let _branches = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde/database-branches").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"database_branches":[],"total":0}"#)
+        .create();
+
+    floo()
+        .args([
+            "db",
+            "branches",
+            "list",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "This preview has no managed Postgres attachment",
+        ));
+}
+
+#[test]
+fn test_db_branches_show_surfaces_branch_not_found_code() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _branch = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde/database-branches/analytics")
+                .as_str(),
+        )
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"PREVIEW_DATABASE_BRANCH_NOT_FOUND","message":"Preview database branch not found."}}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "branches",
+            "show",
+            "feat-db-abcde",
+            "--name",
+            "analytics",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "PREVIEW_DATABASE_BRANCH_NOT_FOUND",
+        ));
+}
+
+#[test]
+fn test_db_branches_source_branch_identifier_reports_ambiguous_preview() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let branch = preview_branch_json("default", "ready", true);
+    let preview_a = preview_detail_json(&branch);
+    let preview_b = preview_a.replace("feat-db-abcde", "feat-db-f00ba");
+    let _previews = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/previews").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"previews":[{preview_a},{preview_b}],"total":2}}"#
+        ))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "branches",
+            "list",
+            "feat/db-branch",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("AMBIGUOUS_PREVIEW_IDENTIFIER"));
+}
+
+#[test]
+fn test_db_branches_reset_refuses_without_confirmation_in_json_mode() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "branches",
+            "reset",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("CONFIRMATION_REQUIRED"))
+        .stdout(predicate::str::contains("dev/prod untouched"))
+        .stdout(predicate::str::contains("--yes"));
+}
+
+#[test]
+fn test_db_branches_reset_with_yes_calls_preview_scoped_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _reset = server
+        .mock(
+            "POST",
+            format!(
+                "/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde/database-branches/default/reset"
+            )
+            .as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_branch_json("default", "ready", true))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "db",
+            "branches",
+            "reset",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+            "--yes",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""dev_prod_untouched":true"#))
+        .stdout(predicate::str::contains(r#""scope":"preview""#))
+        .stdout(predicate::str::contains(r#""database_branch":{"#))
+        .stdout(predicate::str::contains("postgresql://").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `floo db branches list|show|reset` for preview database branches.
- Mirrors the backend preview branch contract with JSON-safe app/preview/branch fields and no plaintext credentials.
- Uses tier-2 confirmation for preview-only reset and documents that dev/prod are untouched.

## Issue Closure (Required)
Closes getfloo/floo#1235

## Changes
- Adds preview environment and preview database branch API client/types.
- Adds clap commands, command-tree discovery, dry-run support for reset, and offline `floo docs services` guidance.
- Adds mock API coverage for success, empty managed-Postgres state, missing branch errors, ambiguous preview identifiers, and reset confirmation/non-interactive behavior.

## Test Plan
- [x] `cargo test --test mock_api_tests db_branches -- --nocapture`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`

## Discovered Issues
- `floo-docs` was not present under `/Users/espeerascend`, so this PR updates the CLI offline docs but not the Mintlify customer docs checkout.
- This CLI surface depends on the backend preview database branch endpoints from getfloo/floo#1234.
