### PR TITLE
fix: make deploy list json compact

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -422,7 +422,10 @@ impl FlooClient {
     }
 
     pub fn list_deploys(&self, app_id: &str) -> Result<ListDeploysResponse, FlooApiError> {
-        let resp = self.get(&format!("/v1/apps/{app_id}/deploys"))?;
+        let resp = self.get_with_query(
+            &format!("/v1/apps/{app_id}/deploys"),
+            &[("include_build_logs", "false")],
+        )?;
         self.handle_response(resp)
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1101,7 +1101,7 @@ pub enum ReleasesCommands {
 
 #[derive(Subcommand)]
 pub enum DeploysSubcommands {
-    /// List deploy history for an app.
+    /// List compact deploy history for an app (no build logs).
     List {
         /// App name or ID (uses config file if omitted).
         #[arg(short, long)]

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -51,7 +51,7 @@ fn command_tree() -> Vec<CommandInfo> {
             subcommands: vec![
                 CommandInfo {
                     name: "list",
-                    description: "List deploy history for an app",
+                    description: "List compact deploy history for an app (no build logs)",
                     usage: "floo deploys list --app <name>",
                     requires_auth: true,
                     subcommands: vec![],

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -144,6 +144,26 @@ fn derive_next_command(deploy_status: &str, host_bound: bool) -> &'static str {
     }
 }
 
+fn deploy_list_payload(result: &crate::api_types::ListDeploysResponse) -> serde_json::Value {
+    let deploys: Vec<serde_json::Value> = result
+        .deploys
+        .iter()
+        .map(|d| {
+            serde_json::json!({
+                "id": &d.id,
+                "status": &d.status,
+                "url": &d.url,
+                "runtime": &d.runtime,
+                "created_at": &d.created_at,
+                "triggered_by": &d.triggered_by,
+                "commit_sha": &d.commit_sha,
+                "environment_name": &d.environment_name,
+            })
+        })
+        .collect();
+    serde_json::json!({ "deploys": deploys })
+}
+
 pub fn list(app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
@@ -204,7 +224,7 @@ pub fn list(app: Option<&str>) {
             "Created",
         ],
         &rows,
-        Some(output::to_value(&result)),
+        Some(deploy_list_payload(&result)),
     );
 }
 

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -639,7 +639,7 @@ Floo Deploy Flow
 
 ## Deploy History
 
-  floo deploys list --app <name>    — list past deploys
+  floo deploys list --app <name>    — list past deploys without build logs
   floo deploys logs <id> --app <n>  — build logs for a specific deploy
   floo deploys watch --app <name>   — stream deploy progress in real-time
   floo deploys rollback <app> <id>  — rollback to a previous deploy

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -522,7 +522,7 @@ fn test_deploy_list_help() {
         .args(["deploys", "list", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("List deploy history"));
+        .stdout(predicate::str::contains("List compact deploy history"));
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1442,10 +1442,14 @@ fn test_deploy_list_json() {
             "GET",
             format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
         )
+        .match_query(Matcher::UrlEncoded(
+            "include_build_logs".into(),
+            "false".into(),
+        ))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            r#"{"deploys":[{"id":"deploy-123","status":"live","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z"}]}"#,
+            r#"{"deploys":[{"id":"deploy-123","status":"live","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z","build_logs":"massive-build-log"}]}"#,
         )
         .create();
 
@@ -1456,7 +1460,9 @@ fn test_deploy_list_json() {
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains("deploys"))
-        .stdout(predicate::str::contains("deploy-123"));
+        .stdout(predicate::str::contains("deploy-123"))
+        .stdout(predicate::str::contains("build_logs").not())
+        .stdout(predicate::str::contains("massive-build-log").not());
 }
 
 #[test]
@@ -2726,6 +2732,10 @@ fn test_deploy_list_from_config() {
             "GET",
             format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
         )
+        .match_query(Matcher::UrlEncoded(
+            "include_build_logs".into(),
+            "false".into(),
+        ))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"deploys":[{"id":"deploy-123","status":"live","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z"}]}"#)


### PR DESCRIPTION
## What changed

`floo deploys list --json` now treats deploy history as compact metadata by default. The CLI requests `include_build_logs=false` from the API and strips `build_logs` from list JSON payloads as a compatibility guard if an older API still sends them.

## Why

Feedback from an agent-safe status check showed `floo deploys list --app floo-artifact --json` returning full build logs when the caller only needed deploy IDs, statuses, and commits. Build logs are heavy diagnostics and should be requested explicitly through logs/detail surfaces.

## Risk tier

standard

## Files reviewers should scrutinize

- `src/api_client.rs`
- `src/commands/deploys.rs`
- `tests/mock_api_tests.rs`

## Tests run

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1` (434 unit, 141 CLI, 106 mock API tests passed)

## Known non-goals

This PR does not change the API default; that is handled in the paired `getfloo/floo` PR.

## Issue Closure (Required)

N/A — Slack feedback / friction report, no GitHub issue number attached.