### PR TITLE
fix: render cron log attribution

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -426,7 +426,7 @@ pub struct LogsOptions {
     #[arg(short, long)]
     error: bool,
 
-    /// Minimum severity level (DEFAULT, DEBUG, INFO, WARNING, ERROR, CRITICAL).
+    /// Exact severity level (DEFAULT, DEBUG, INFO, WARNING, ERROR, CRITICAL).
     #[arg(long)]
     severity: Option<String>,
 

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -72,14 +72,17 @@ fn attribution_label(entry: &LogEntry) -> Option<String> {
     entry.service_name.clone()
 }
 
-/// Show the per-line `[attribution]` prefix only when the rendered set spans
-/// more than one distinct service/cron. A single-service app (one label for
-/// every line) renders clean, untagged lines instead of a redundant — and
-/// previously `[unknown]` — prefix; a multi-service or service+cron mix tags
-/// each line so the operator can tell them apart.
+/// Show the per-line `[attribution]` prefix for every cron row and for mixed
+/// service sets. Cron logs always need the visible `cron:<name>` marker because
+/// they are Cloud Run Job output, not service revision output. A single-service
+/// service-only app still renders clean, untagged lines instead of a redundant
+/// prefix.
 fn should_show_prefix(entries: &[LogEntry]) -> bool {
     let mut seen = std::collections::HashSet::new();
     for entry in entries {
+        if entry.cron_job_name.is_some() {
+            return true;
+        }
         if let Some(label) = attribution_label(entry) {
             seen.insert(label);
             if seen.len() > 1 {

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1665,6 +1665,37 @@ fn test_logs_human() {
 }
 
 #[test]
+fn test_logs_human_cron_rows_show_cron_prefix_even_when_filtered() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_logs = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/logs").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("cron".into(), "knowledge-sync".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2024-01-01T00:00:00Z","severity":"DEFAULT","message":"sync complete","service_name":null,"cron_job_name":"knowledge-sync"}],"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["logs", "--app", TEST_APP_NAME, "--cron", "knowledge-sync"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[cron:knowledge-sync]"))
+        .stderr(predicate::str::contains("sync complete"));
+}
+
+#[test]
 fn test_logs_from_config_file() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed

- Render cron log rows with `[cron:<name>]` attribution even when the output is filtered to a single cron job.
- Update `floo logs --severity` help to document exact severity semantics.
- Add a mock API regression test for cron-filtered human log output.

## Why

This closes the #1155 residual observability contract: cron logs are Cloud Run Job output and should not appear as unattributed service logs in human scans.

## Tests run

- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

Refs getfloo/floo#1155