### PR TITLE
fix: render structured deploy records

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -429,6 +429,28 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn list_deploys_paginated(
+        &self,
+        app_id: &str,
+        limit: u32,
+        cursor: Option<&str>,
+    ) -> Result<ListDeploysResponse, FlooApiError> {
+        let limit_value = limit.to_string();
+        let mut owned_query: Vec<(&str, String)> = vec![
+            ("include_build_logs", "false".to_string()),
+            ("limit", limit_value),
+        ];
+        if let Some(cursor) = cursor {
+            owned_query.push(("cursor", cursor.to_string()));
+        }
+        let query: Vec<(&str, &str)> = owned_query
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect();
+        let resp = self.get_with_query(&format!("/v1/apps/{app_id}/deploys"), &query)?;
+        self.handle_response(resp)
+    }
+
     // --- Doctor ---
 
     pub fn diagnose_accounts(

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -147,6 +147,18 @@ pub struct ListAppsResponse {
 // --- Deploy ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureRootCause {
+    pub stage: Option<String>,
+    pub reason: Option<String>,
+    #[serde(default)]
+    pub details: Option<serde_json::Value>,
+    #[serde(default)]
+    pub first_failure_at: Option<String>,
+    #[serde(default)]
+    pub root_cause_event_excerpt: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Deploy {
     pub id: String,
     pub status: Option<String>,
@@ -159,6 +171,26 @@ pub struct Deploy {
     pub commit_sha: Option<String>,
     #[serde(default)]
     pub environment_name: Option<String>,
+    #[serde(default)]
+    pub failure_category: Option<String>,
+    #[serde(default)]
+    pub failure_message: Option<String>,
+    #[serde(default)]
+    pub failure_step: Option<String>,
+    #[serde(default)]
+    pub failure_root_cause: Option<FailureRootCause>,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    #[serde(default)]
+    pub failure_stage: Option<String>,
+    #[serde(default)]
+    pub failing_stage: Option<String>,
+    #[serde(default)]
+    pub started_at: Option<String>,
+    #[serde(default)]
+    pub finished_at: Option<String>,
+    #[serde(default)]
+    pub duration_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -169,6 +201,18 @@ pub struct AppPasswordResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListDeploysResponse {
     pub deploys: Vec<Deploy>,
+    #[serde(default)]
+    pub total: Option<u64>,
+    #[serde(default)]
+    pub page: Option<u32>,
+    #[serde(default)]
+    pub per_page: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+    #[serde(default)]
+    pub has_more: bool,
 }
 
 // --- Env Var ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1106,6 +1106,14 @@ pub enum DeploysSubcommands {
         /// App name or ID (uses config file if omitted).
         #[arg(short, long)]
         app: Option<String>,
+
+        /// Maximum deploy rows to return.
+        #[arg(long, default_value_t = 20)]
+        limit: u32,
+
+        /// Continue from a previous next_cursor value.
+        #[arg(long)]
+        cursor: Option<String>,
     },
 
     /// Show build logs for a deploy (defaults to the latest deploy).
@@ -1740,7 +1748,9 @@ pub fn run() {
         } => commands::deploy::deploy(path, app, services, rebuild, sync_env, skip_migrations),
 
         Commands::Deploys(sub) => match sub {
-            DeploysSubcommands::List { app } => commands::deploys::list(app.as_deref()),
+            DeploysSubcommands::List { app, limit, cursor } => {
+                commands::deploys::list(app.as_deref(), limit, cursor.as_deref())
+            }
             DeploysSubcommands::Logs {
                 deploy_id,
                 app,

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -95,11 +95,20 @@ pub fn status(app: Option<&str>, deploy_id: Option<&str>) {
         "commit": commit_short,
         "status": deploy_status,
         "app_status": app_status,
+        "status_semantics": {
+            "status": "deploy_attempt",
+            "app_status": "currently_serving_app",
+        },
         "url": gateway_url,
         "image_built": image_built,
         "service_ready": service_ready,
         "host_bound": host_bound,
+        "failure_reason": failure_reason(&deploy),
+        "failing_stage": failure_stage(&deploy),
         "created_at": deploy.created_at,
+        "started_at": deploy.started_at,
+        "finished_at": deploy.finished_at,
+        "duration_ms": deploy.duration_ms,
         "next_command": next_command,
     });
 
@@ -111,10 +120,10 @@ pub fn status(app: Option<&str>, deploy_id: Option<&str>) {
     let header = format!("{} ({})", app_name, deploy.id);
     output::bold_line(&header);
     output::dim_line(&format!(
-        "  status:        {}",
+        "  status:        {} (deploy attempt)",
         colored_status(deploy_status)
     ));
-    output::dim_line(&format!("  app_status:    {}", app_status));
+    output::dim_line(&format!("  app_status:    {} (current app)", app_status));
     output::dim_line(&format!(
         "  commit:        {}",
         commit_short.unwrap_or("\u{2014}")
@@ -126,6 +135,14 @@ pub fn status(app: Option<&str>, deploy_id: Option<&str>) {
     output::dim_line(&format!("  image_built:   {}", image_built));
     output::dim_line(&format!("  service_ready: {}", service_ready));
     output::dim_line(&format!("  host_bound:    {}", host_bound));
+    output::dim_line(&format!(
+        "  duration:      {}",
+        format_duration_ms(deploy.duration_ms)
+    ));
+    if let Some(reason) = failure_reason(&deploy) {
+        let stage = failure_stage(&deploy).unwrap_or("unknown");
+        output::dim_line(&format!("  failure:       {stage}: {reason}"));
+    }
     output::dim_line(&format!("  next_command:  {}", next_command));
 }
 
@@ -155,22 +172,35 @@ fn deploy_list_payload(result: &crate::api_types::ListDeploysResponse) -> serde_
                 "url": &d.url,
                 "runtime": &d.runtime,
                 "created_at": &d.created_at,
+                "started_at": &d.started_at,
+                "finished_at": &d.finished_at,
+                "duration_ms": &d.duration_ms,
+                "failure_reason": failure_reason(d),
+                "failing_stage": failure_stage(d),
                 "triggered_by": &d.triggered_by,
                 "commit_sha": &d.commit_sha,
                 "environment_name": &d.environment_name,
             })
         })
         .collect();
-    serde_json::json!({ "deploys": deploys })
+    serde_json::json!({
+        "deploys": deploys,
+        "total": result.total,
+        "page": result.page,
+        "per_page": result.per_page,
+        "limit": result.limit,
+        "next_cursor": result.next_cursor,
+        "has_more": result.has_more,
+    })
 }
 
-pub fn list(app: Option<&str>) {
+pub fn list(app: Option<&str>, limit: u32, cursor: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
     let (app_id, _app_name) = super::resolve_app_from_config(&client, app);
 
-    let result = match client.list_deploys(&app_id) {
+    let result = match client.list_deploys_paginated(&app_id, limit, cursor) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
@@ -180,10 +210,7 @@ pub fn list(app: Option<&str>) {
 
     if result.deploys.is_empty() {
         if output::is_json_mode() {
-            output::success(
-                "No deploys found.",
-                Some(serde_json::json!({"deploys": []})),
-            );
+            output::success("No deploys found.", Some(deploy_list_payload(&result)));
         } else {
             output::info("No deploys found.", None);
         }
@@ -203,13 +230,22 @@ pub fn list(app: Option<&str>) {
             let status = d.status.as_deref().unwrap_or("-");
             let env = d.environment_name.as_deref().unwrap_or("\u{2014}");
             let created = d.created_at.as_deref().unwrap_or("-");
+            let duration = format_duration_ms(d.duration_ms);
+            let failure = failure_reason(d)
+                .map(|reason| {
+                    let stage = failure_stage(d).unwrap_or("unknown");
+                    truncate_text(&format!("{stage}: {reason}"), 64)
+                })
+                .unwrap_or_else(|| "\u{2014}".to_string());
             vec![
                 short_id,
                 colored_status(status),
                 env.to_string(),
                 d.triggered_by.as_deref().unwrap_or("\u{2014}").to_string(),
                 commit.to_string(),
+                duration,
                 relative_time(created),
+                failure,
             ]
         })
         .collect();
@@ -221,17 +257,78 @@ pub fn list(app: Option<&str>) {
             "Env",
             "Triggered By",
             "Commit",
+            "Duration",
             "Created",
+            "Failure",
         ],
         &rows,
         Some(deploy_list_payload(&result)),
     );
+    if let Some(next_cursor) = result.next_cursor.as_deref() {
+        let app_arg = app.map(|name| format!(" --app {name}")).unwrap_or_default();
+        output::dim_line(&format!(
+            "More deploys available. Next: floo deploys list{app_arg} --limit {} --cursor {next_cursor}",
+            result.limit.unwrap_or(limit)
+        ));
+    }
 }
 
 /// Check if a log string is meaningful (not empty or placeholder text).
 fn is_real_log(logs: &str) -> bool {
     let trimmed = logs.trim();
     !trimmed.is_empty() && trimmed != "[no message content]"
+}
+
+fn failure_stage(deploy: &Deploy) -> Option<&str> {
+    deploy
+        .failing_stage
+        .as_deref()
+        .or(deploy.failure_stage.as_deref())
+        .or(deploy
+            .failure_root_cause
+            .as_ref()
+            .and_then(|cause| cause.stage.as_deref()))
+        .or(deploy.failure_step.as_deref())
+}
+
+fn failure_reason(deploy: &Deploy) -> Option<&str> {
+    deploy
+        .failure_reason
+        .as_deref()
+        .or(deploy
+            .failure_root_cause
+            .as_ref()
+            .and_then(|cause| cause.reason.as_deref()))
+        .or(deploy.failure_message.as_deref())
+}
+
+fn format_duration_ms(duration_ms: Option<i64>) -> String {
+    let Some(duration_ms) = duration_ms else {
+        return "\u{2014}".to_string();
+    };
+    if duration_ms < 1000 {
+        return format!("{duration_ms}ms");
+    }
+    let total_seconds = duration_ms / 1000;
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+fn truncate_text(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('\u{2026}');
+    truncated
 }
 
 /// Print deploy metadata header to stderr.
@@ -253,6 +350,14 @@ fn print_deploy_header(deploy: &Deploy) {
     output::dim_line(&format!("  Commit:  {commit}"));
     output::dim_line(&format!("  By:      {triggered_by}"));
     output::dim_line(&format!("  Created: {created}"));
+    output::dim_line(&format!(
+        "  Duration: {}",
+        format_duration_ms(deploy.duration_ms)
+    ));
+    if let Some(reason) = failure_reason(deploy) {
+        let stage = failure_stage(deploy).unwrap_or("unknown");
+        output::dim_line(&format!("  Failure: {stage}: {reason}"));
+    }
     output::dim_line("");
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -522,7 +522,9 @@ fn test_deploy_list_help() {
         .args(["deploys", "list", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("List compact deploy history"));
+        .stdout(predicate::str::contains("List compact deploy history"))
+        .stdout(predicate::str::contains("--limit"))
+        .stdout(predicate::str::contains("--cursor"));
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1442,14 +1442,14 @@ fn test_deploy_list_json() {
             "GET",
             format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
         )
-        .match_query(Matcher::UrlEncoded(
-            "include_build_logs".into(),
-            "false".into(),
-        ))
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "20".into()),
+        ]))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            r#"{"deploys":[{"id":"deploy-123","status":"live","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z","build_logs":"massive-build-log"}]}"#,
+            r#"{"deploys":[{"id":"deploy-123","status":"live","runtime":"nodejs","created_at":"2024-01-01T00:00:00Z","started_at":"2024-01-01T00:00:00Z","finished_at":"2024-01-01T00:02:00Z","duration_ms":120000,"failure_reason":null,"failing_stage":null,"build_logs":"massive-build-log"}],"total":1,"page":1,"per_page":20,"limit":20,"next_cursor":"cursor-next","has_more":true}"#,
         )
         .create();
 
@@ -1461,8 +1461,53 @@ fn test_deploy_list_json() {
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains("deploys"))
         .stdout(predicate::str::contains("deploy-123"))
+        .stdout(predicate::str::contains(r#""duration_ms":120000"#))
+        .stdout(predicate::str::contains(r#""next_cursor":"cursor-next""#))
+        .stdout(predicate::str::contains(r#""has_more":true"#))
         .stdout(predicate::str::contains("build_logs").not())
         .stdout(predicate::str::contains("massive-build-log").not());
+}
+
+#[test]
+fn test_deploy_list_json_sends_cursor_and_limit() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "2".into()),
+            Matcher::UrlEncoded("cursor".into(), "cursor-1".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"deploys":[],"total":5,"page":2,"per_page":2,"limit":2,"next_cursor":"cursor-2","has_more":true}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploys",
+            "list",
+            "--app",
+            TEST_APP_NAME,
+            "--limit",
+            "2",
+            "--cursor",
+            "cursor-1",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""limit":2"#))
+        .stdout(predicate::str::contains(r#""next_cursor":"cursor-2""#));
 }
 
 #[test]


### PR DESCRIPTION
## What changed
- Added deploy lifecycle timing, failure-stage aliases, failure-root-cause fields, and cursor pagination fields to CLI API types.
- Updated deploy list/status rendering and JSON passthrough so agents can distinguish deploy attempt status from current app status.
- Kept list requests compact by sending cursor/limit without requiring build logs.

## Why
Companion CLI slice for getfloo/floo#1158. The API now exposes deploy-record state directly; the CLI should render those fields instead of forcing agents to infer from logs.

## Risk tier
standard

## Tests run
- cargo fmt --check
- cargo test
- cargo clippy -- -D warnings

## Known non-goals
- Does not trigger deploys; this is display/API-client handling only.
- Monorepo API/schema PR lands separately and closes getfloo/floo#1158.