### PR TITLE
fix(commands): generate command index from the real clap tree

### DIFF
--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -1,622 +1,147 @@
+//! `floo commands` — the agent-facing command index.
+//!
+//! The index is a pure projection of the real clap command tree
+//! (`Cli::command()`): names, descriptions, structure, and usage are all read
+//! from the live `clap::Command`, so the index cannot drift from the CLI it
+//! documents. The only curated metadata is which commands skip authentication
+//! (`AUTH_EXEMPT_PATHS`), and that list is pinned to real commands by a test.
+
+use crate::cli::Cli;
 use crate::constants::VERSION;
 use crate::output;
 
+use clap::CommandFactory;
 use serde::Serialize;
+
+/// Command paths (relative to `floo`) that do NOT require an API key.
+///
+/// Every command not listed here requires authentication. This is the only
+/// hand-maintained metadata in the index — everything else is projected from
+/// clap. `auth_exempt_paths_all_exist` fails if any entry stops matching a
+/// real command, so a rename or removal can't leave a stale entry behind.
+const AUTH_EXEMPT_PATHS: &[&[&str]] = &[
+    &["preflight"],
+    &["auth"],
+    &["auth", "login"],
+    &["auth", "logout"],
+    &["auth", "register"],
+    &["billing", "contact"],
+    &["docs"],
+    &["commands"],
+    &["skills"],
+    &["skills", "install"],
+    &["version"],
+    &["update"],
+];
+
+fn requires_auth(path: &[&str]) -> bool {
+    !AUTH_EXEMPT_PATHS.contains(&path)
+}
 
 #[derive(Serialize)]
 struct CommandInfo {
-    name: &'static str,
-    description: &'static str,
-    usage: &'static str,
+    name: String,
+    description: String,
+    usage: String,
     requires_auth: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     subcommands: Vec<CommandInfo>,
 }
 
-fn command_tree() -> Vec<CommandInfo> {
-    vec![
-        CommandInfo {
-            name: "dev",
-            description: "Run all services locally with managed-service credentials",
-            usage: "floo dev [--app <name>]",
-            requires_auth: true,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "run",
-            description: "Run a one-shot command with a service's managed env vars injected",
-            usage: "floo run [--service <name>] [--app <name>] -- <command...>",
-            requires_auth: true,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "preflight",
-            description: "Validate project config, detect runtimes, and check readiness (no auth required, no side effects)",
-            usage: "floo preflight [PATH] [--app <name>] [--services <name>] [--json]",
-            requires_auth: false,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "redeploy",
-            description: "Force a redeploy (after env var changes, config updates, or to rebuild). The primary deploy path is git push.",
-            usage: "floo redeploy [PATH] [--app <name>] [--rebuild] [--sync-env] [--services <name>]",
-            requires_auth: true,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "deploys",
-            description: "View and manage deploy history (list, watch, logs, rollback). To trigger a deploy, use `floo redeploy` or push to GitHub.",
-            usage: "floo deploys <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "list",
-                    description: "List compact deploy history for an app (no build logs)",
-                    usage: "floo deploys list --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "logs",
-                    description:
-                        "Show build logs for a deploy (use --follow to stream active deploys)",
-                    usage: "floo deploys logs <deploy-id> [--follow] --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "watch",
-                    description: "Stream deploy progress in real-time",
-                    usage: "floo deploys watch --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "rollback",
-                    description: "Rollback to a previous deploy",
-                    usage: "floo deploys rollback <app> <deploy-id>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "init",
-            description: "Initialize a new Floo project (creates config files)",
-            usage: "floo init [NAME] [--path <dir>]",
-            requires_auth: true,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "apps",
-            description: "Manage your apps (list, status, delete)",
-            usage: "floo apps <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "list",
-                    description: "List all your apps",
-                    usage: "floo apps list",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "status",
-                    description: "Show details for an app",
-                    usage: "floo apps status <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "delete",
-                    description: "Delete an app",
-                    usage: "floo apps delete <name> [--force]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "github",
-                    description: "Manage GitHub integration",
-                    usage: "floo apps github <subcommand>",
-                    requires_auth: true,
-                    subcommands: vec![
-                        CommandInfo {
-                            name: "connect",
-                            description: "Connect a GitHub repo for auto-deploy",
-                            usage: "floo apps github connect <owner/repo> --app <name>",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                        CommandInfo {
-                            name: "disconnect",
-                            description: "Disconnect a GitHub repo",
-                            usage: "floo apps github disconnect --app <name>",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                        CommandInfo {
-                            name: "status",
-                            description: "Show GitHub connection status",
-                            usage: "floo apps github status --app <name>",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                    ],
-                },
-                CommandInfo {
-                    name: "password",
-                    description: "Show the shared password for a password-protected app",
-                    usage: "floo apps password <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "invite",
-                    description: "Invite a user to an app",
-                    usage: "floo apps invite <email> --app <name> [--role member|admin]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "env",
-            description: "Manage environment variables",
-            usage: "floo env <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "set",
-                    description: "Set an environment variable",
-                    usage: "floo env set KEY=VALUE --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "get",
-                    description: "Get an environment variable's value",
-                    usage: "floo env get KEY --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "list",
-                    description: "List environment variables",
-                    usage: "floo env list --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "remove",
-                    description: "Remove an environment variable",
-                    usage: "floo env remove KEY --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "import",
-                    description: "Import env vars from a .env file",
-                    usage: "floo env import [FILE] --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "notifications",
-            description: "View and tune which emails floo sends you",
-            usage: "floo notifications <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "list",
-                    description: "Show your email settings and whether each is on or off",
-                    usage: "floo notifications list",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "set",
-                    description: "Turn one category of email on or off",
-                    usage: "floo notifications set <category> <on|off>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "services",
-            description: "Manage services for an app",
-            usage: "floo services <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "list",
-                    description: "List all services for an app",
-                    usage: "floo services list --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "show",
-                    description: "Show details for a service",
-                    usage: "floo services show <service> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "domains",
-            description: "Manage custom domains",
-            usage: "floo domains <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "add",
-                    description: "Add a custom domain to an app",
-                    usage: "floo domains add <hostname> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "list",
-                    description: "List custom domains for an app",
-                    usage: "floo domains list --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "verify",
-                    description: "Verify DNS for a pending custom domain",
-                    usage: "floo domains verify <hostname> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "remove",
-                    description: "Remove a custom domain",
-                    usage: "floo domains remove <hostname> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "status",
-                    description: "Show detailed status for a single domain",
-                    usage: "floo domains status <hostname> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "watch",
-                    description: "Poll until a domain is active or the timeout expires",
-                    usage: "floo domains watch <hostname> --app <name> [--timeout <secs>]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "logs",
-            description: "View runtime logs for an app",
-            usage: "floo logs <query|tail> --app <name> [OPTIONS]",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "query",
-                    description: "Query stored runtime logs once",
-                    usage: "floo logs query --app <name> [--since 1h] [--service web] [--deployment latest] [--json]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "tail",
-                    description: "Tail runtime logs continuously",
-                    usage: "floo logs tail --app <name> [--env prod] [--service web]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "analytics",
-            description: "View traffic analytics for an app or org",
-            usage: "floo analytics [APP] [--period 7d|30d|90d]",
-            requires_auth: true,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "releases",
-            description: "Manage releases and promote to prod",
-            usage: "floo releases <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "list",
-                    description: "List releases for an app",
-                    usage: "floo releases list --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "show",
-                    description: "Show details for a release",
-                    usage: "floo releases show <release-id> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "promote",
-                    description: "Promote an app to prod via GitHub release",
-                    usage: "floo releases promote --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "auth",
-            description: "Authenticate and manage your account",
-            usage: "floo auth <subcommand>",
-            requires_auth: false,
-            subcommands: vec![
-                CommandInfo {
-                    name: "login",
-                    description: "Authenticate with the Floo API",
-                    usage: "floo auth login",
-                    requires_auth: false,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "logout",
-                    description: "Clear stored credentials",
-                    usage: "floo auth logout",
-                    requires_auth: false,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "whoami",
-                    description: "Show the currently authenticated user",
-                    usage: "floo auth whoami",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "token",
-                    description: "Print the current API key",
-                    usage: "floo auth token",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "register",
-                    description: "Create a new Floo account",
-                    usage: "floo auth register <email>",
-                    requires_auth: false,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "update-profile",
-                    description: "Update your profile",
-                    usage: "floo auth update-profile [--name <name>]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "orgs",
-            description: "Manage your organization",
-            usage: "floo orgs <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "members",
-                    description: "Manage org members",
-                    usage: "floo orgs members <subcommand>",
-                    requires_auth: true,
-                    subcommands: vec![
-                        CommandInfo {
-                            name: "list",
-                            description: "List members of the current org",
-                            usage: "floo orgs members list",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                        CommandInfo {
-                            name: "set-role",
-                            description: "Change a member's role",
-                            usage: "floo orgs members set-role <user-id> <role>",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                    ],
-                },
-                CommandInfo {
-                    name: "switch",
-                    description: "Switch active organization",
-                    usage: "floo orgs switch <org-slug>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "billing",
-            description: "Manage billing and spend caps",
-            usage: "floo billing <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "spend-cap",
-                    description: "Manage compute spend cap",
-                    usage: "floo billing spend-cap <get|set>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "upgrade",
-                    description: "Upgrade your plan",
-                    usage: "floo billing upgrade [--plan hobby|pro|team]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "usage",
-                    description: "Show plan, compute credit, and per-app cost breakdown",
-                    usage: "floo billing usage [--period current_month|last_month|last_7d]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "contact",
-                    description: "Print enterprise contact information",
-                    usage: "floo billing contact",
-                    requires_auth: false,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "db",
-            description: "Query, inspect schema, and run migrations for an app's database",
-            usage: "floo db <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "query",
-                    description: "Run a SQL query against the app's managed database",
-                    usage: "floo db query --app <name> \"<SQL>\"",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "schema",
-                    description: "Show the database schema for an app",
-                    usage: "floo db schema --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "migrate",
-                    description: "Run database migrations for an app",
-                    usage: "floo db migrate --app <name> [--env dev|prod]",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "branches",
-                    description: "Inspect and reset preview database branches",
-                    usage: "floo db branches <list|show|reset> <preview> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![
-                        CommandInfo {
-                            name: "list",
-                            description: "List managed Postgres branches backing one preview",
-                            usage: "floo db branches list <preview> --app <name>",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                        CommandInfo {
-                            name: "show",
-                            description: "Show one preview database branch",
-                            usage: "floo db branches show <preview> --app <name> [--name default]",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                        CommandInfo {
-                            name: "reset",
-                            description: "Reset one preview database branch without touching dev/prod",
-                            usage: "floo db branches reset <preview> --app <name> [--name default] --yes",
-                            requires_auth: true,
-                            subcommands: vec![],
-                        },
-                    ],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "cron",
-            description: "List and trigger scheduled cron jobs for an app",
-            usage: "floo cron <subcommand>",
-            requires_auth: true,
-            subcommands: vec![
-                CommandInfo {
-                    name: "list",
-                    description: "List all cron jobs and their last run status",
-                    usage: "floo cron list --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-                CommandInfo {
-                    name: "run",
-                    description: "Manually trigger a cron job",
-                    usage: "floo cron run <job-name> --app <name>",
-                    requires_auth: true,
-                    subcommands: vec![],
-                },
-            ],
-        },
-        CommandInfo {
-            name: "reparo",
-            description: "Manage Reparo auto-recovery events",
-            usage: "floo reparo <subcommand>",
-            requires_auth: true,
-            subcommands: vec![CommandInfo {
-                name: "events",
-                description: "List Reparo auto-recovery events for an app",
-                usage: "floo reparo events --app <name>",
-                requires_auth: true,
-                subcommands: vec![],
-            }],
-        },
-        CommandInfo {
-            name: "feedback",
-            description: "Send feedback, report bugs, or request features",
-            usage: "floo feedback <message> [--category bug|friction|feature_request|general]",
-            requires_auth: true,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "docs",
-            description: "Built-in platform documentation",
-            usage: "floo docs [TOPIC]",
-            requires_auth: false,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "commands",
-            description: "List all commands (structured for agents)",
-            usage: "floo commands [--json]",
-            requires_auth: false,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "skills",
-            description: "Install agent skills for AI coding assistants",
-            usage: "floo skills install [--path <dir>] [--print]",
-            requires_auth: false,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "version",
-            description: "Print installed CLI version",
-            usage: "floo version",
-            requires_auth: false,
-            subcommands: vec![],
-        },
-        CommandInfo {
-            name: "update",
-            description: "Update the CLI binary in-place",
-            usage: "floo update [--version <tag>]",
-            requires_auth: false,
-            subcommands: vec![],
-        },
-    ]
+/// The synthetic `help` subcommand clap injects is not a floo command — skip it
+/// (along with any explicitly hidden command) so the index matches `floo --help`.
+fn is_listable(cmd: &clap::Command) -> bool {
+    !cmd.is_hide_set() && cmd.get_name() != "help"
+}
+
+/// Build the index by walking the live clap command tree.
+fn build_tree() -> Vec<CommandInfo> {
+    Cli::command()
+        .get_subcommands()
+        .filter(|c| is_listable(c))
+        .map(|c| command_info(c, &[c.get_name()]))
+        .collect()
+}
+
+/// Project one `clap::Command` (and its subtree) into a `CommandInfo`.
+/// `path` is the full command path below `floo`, ending in this command's name.
+fn command_info(cmd: &clap::Command, path: &[&str]) -> CommandInfo {
+    let subcommands: Vec<CommandInfo> = cmd
+        .get_subcommands()
+        .filter(|c| is_listable(c))
+        .map(|c| {
+            let mut child_path = path.to_vec();
+            child_path.push(c.get_name());
+            command_info(c, &child_path)
+        })
+        .collect();
+
+    CommandInfo {
+        name: cmd.get_name().to_string(),
+        description: cmd.get_about().map(|s| s.to_string()).unwrap_or_default(),
+        usage: render_usage(path, cmd, !subcommands.is_empty()),
+        requires_auth: requires_auth(path),
+        subcommands,
+    }
+}
+
+/// Render an authoritative usage line: `floo <path> <positionals> [<subcommand>]`.
+/// Positionals come from clap (required → `<NAME>`, optional → `[NAME]`); detailed
+/// flags live behind `floo <command> --help`, which the human footer points to.
+fn render_usage(path: &[&str], cmd: &clap::Command, has_subcommands: bool) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(path.len() + 3);
+    parts.push("floo".to_string());
+    parts.extend(path.iter().map(|s| s.to_string()));
+
+    for arg in cmd.get_positionals() {
+        let name = arg
+            .get_value_names()
+            .and_then(|names| names.first())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| arg.get_id().as_str().to_uppercase());
+        if arg.is_required_set() {
+            parts.push(format!("<{name}>"));
+        } else {
+            parts.push(format!("[{name}]"));
+        }
+    }
+
+    if has_subcommands {
+        parts.push("<subcommand>".to_string());
+    }
+
+    parts.join(" ")
+}
+
+/// Render the human-readable index. Each sibling group aligns its descriptions
+/// to its own longest name plus two spaces, so a name can never abut its
+/// description regardless of length or nesting depth.
+fn render_human(tree: &[CommandInfo]) -> String {
+    let mut out = String::from("Commands:\n");
+    render_level(tree, 0, &mut out);
+    out.push('\n');
+    out.push_str("Run `floo <command> --help` for details.\n");
+    out
+}
+
+fn render_level(cmds: &[CommandInfo], depth: usize, out: &mut String) {
+    let indent = 2 + depth * 2;
+    let column = cmds.iter().map(|c| c.name.len()).max().unwrap_or(0) + 2;
+    for cmd in cmds {
+        let gap = column - cmd.name.len(); // column >= name.len() + 2, so gap >= 2
+        out.push_str(&" ".repeat(indent));
+        out.push_str(&cmd.name);
+        out.push_str(&" ".repeat(gap));
+        out.push_str(&cmd.description);
+        out.push('\n');
+        if !cmd.subcommands.is_empty() {
+            render_level(&cmd.subcommands, depth + 1, out);
+        }
+    }
 }
 
 pub fn commands() {
-    let tree = command_tree();
+    let tree = build_tree();
 
     if output::is_json_mode() {
         output::success(
@@ -627,18 +152,7 @@ pub fn commands() {
             })),
         );
     } else {
-        eprintln!("Commands:");
-        for cmd in &tree {
-            eprintln!("  {:<14}{}", cmd.name, cmd.description);
-            for sub in &cmd.subcommands {
-                eprintln!("    {:<12}{}", sub.name, sub.description);
-                for sub2 in &sub.subcommands {
-                    eprintln!("      {:<10}{}", sub2.name, sub2.description);
-                }
-            }
-        }
-        eprintln!();
-        eprintln!("Run `floo <command> --help` for details.");
+        eprint!("{}", render_human(&tree));
     }
 }
 
@@ -647,66 +161,179 @@ mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
-    #[test]
-    fn test_command_tree_not_empty() {
-        let tree = command_tree();
-        assert!(!tree.is_empty());
+    /// Collect `"a b c"` command paths from the generated index.
+    fn tree_paths(cmds: &[CommandInfo], prefix: &str, out: &mut BTreeSet<String>) {
+        for cmd in cmds {
+            let path = if prefix.is_empty() {
+                cmd.name.clone()
+            } else {
+                format!("{prefix} {}", cmd.name)
+            };
+            out.insert(path.clone());
+            tree_paths(&cmd.subcommands, &path, out);
+        }
+    }
+
+    /// Collect command paths directly from the real clap tree — an independent
+    /// walk, so comparing it to `tree_paths` is a genuine parity check.
+    fn clap_paths(cmd: &clap::Command, prefix: &str, out: &mut BTreeSet<String>) {
+        for sub in cmd.get_subcommands() {
+            if !is_listable(sub) {
+                continue;
+            }
+            let path = if prefix.is_empty() {
+                sub.get_name().to_string()
+            } else {
+                format!("{prefix} {}", sub.get_name())
+            };
+            out.insert(path.clone());
+            clap_paths(sub, &path, out);
+        }
     }
 
     #[test]
-    fn test_all_commands_have_descriptions() {
+    fn index_matches_real_command_tree() {
+        let mut from_tree = BTreeSet::new();
+        tree_paths(&build_tree(), "", &mut from_tree);
+        let mut from_clap = BTreeSet::new();
+        clap_paths(&Cli::command(), "", &mut from_clap);
+        assert_eq!(
+            from_tree, from_clap,
+            "`floo commands` index has drifted from the real clap command tree"
+        );
+    }
+
+    #[test]
+    fn pins_known_drift_regressions() {
+        let mut paths = BTreeSet::new();
+        tree_paths(&build_tree(), "", &mut paths);
+        // Real commands the hand-maintained index used to omit (#1160).
+        for real in [
+            "storage",
+            "doctor",
+            "services add",
+            "services remove",
+            "db connections",
+            "releases rollback",
+            "deploys status",
+        ] {
+            assert!(
+                paths.contains(real),
+                "index is missing real command `{real}`"
+            );
+        }
+        // The index used to invent `apps status`; the real command is `apps show`.
+        assert!(paths.contains("apps show"), "index is missing `apps show`");
+        assert!(
+            !paths.contains("apps status"),
+            "index lists phantom command `apps status`"
+        );
+    }
+
+    #[test]
+    fn every_command_has_description_and_usage() {
         fn check(cmds: &[CommandInfo]) {
             for cmd in cmds {
                 assert!(
                     !cmd.description.is_empty(),
-                    "missing description for {}",
+                    "missing description for `{}` (add a /// doc comment in cli.rs)",
                     cmd.name
                 );
-                assert!(!cmd.usage.is_empty(), "missing usage for {}", cmd.name);
+                assert!(!cmd.usage.is_empty(), "missing usage for `{}`", cmd.name);
                 check(&cmd.subcommands);
             }
         }
-        check(&command_tree());
+        check(&build_tree());
     }
 
     #[test]
-    fn test_command_names_match_cli_enum() {
-        // Must match top-level Commands enum variants in cli.rs.
-        let expected: BTreeSet<&str> = [
-            "analytics",
-            "apps",
-            "auth",
-            "billing",
-            "commands",
-            "cron",
-            "db",
-            "deploys",
-            "dev",
-            "docs",
-            "domains",
-            "env",
-            "feedback",
-            "init",
-            "logs",
-            "notifications",
-            "orgs",
-            "preflight",
-            "redeploy",
-            "releases",
-            "reparo",
-            "run",
-            "services",
-            "skills",
-            "update",
-            "version",
-        ]
-        .into_iter()
-        .collect();
-
-        let actual: BTreeSet<&str> = command_tree().iter().map(|c| c.name).collect();
-        assert_eq!(
-            expected, actual,
-            "command_tree and Commands enum are out of sync"
+    fn usage_starts_with_full_command_path() {
+        let tree = build_tree();
+        let apps = tree
+            .iter()
+            .find(|c| c.name == "apps")
+            .expect("apps command");
+        let show = apps
+            .subcommands
+            .iter()
+            .find(|c| c.name == "show")
+            .expect("apps show");
+        assert!(
+            show.usage.starts_with("floo apps show"),
+            "unexpected usage: {}",
+            show.usage
         );
+        assert!(
+            apps.usage.ends_with("<subcommand>"),
+            "group usage should flag a required subcommand: {}",
+            apps.usage
+        );
+    }
+
+    #[test]
+    fn auth_exempt_paths_all_exist() {
+        let mut clap = BTreeSet::new();
+        clap_paths(&Cli::command(), "", &mut clap);
+        for path in AUTH_EXEMPT_PATHS {
+            let joined = path.join(" ");
+            assert!(
+                clap.contains(&joined),
+                "AUTH_EXEMPT_PATHS lists `{joined}`, which is not a real command"
+            );
+        }
+    }
+
+    #[test]
+    fn requires_auth_classification() {
+        // Pre-auth commands.
+        assert!(!requires_auth(&["auth", "login"]));
+        assert!(!requires_auth(&["docs"]));
+        assert!(!requires_auth(&["preflight"]));
+        assert!(!requires_auth(&["billing", "contact"]));
+        // Authenticated commands, including auth subcommands that need a session.
+        assert!(requires_auth(&["auth", "whoami"]));
+        assert!(requires_auth(&["apps", "show"]));
+        assert!(requires_auth(&["storage"]));
+        assert!(requires_auth(&["billing"]));
+    }
+
+    #[test]
+    fn human_output_never_abuts_name_and_description() {
+        // Exercise render_level directly with a name far longer than any column
+        // the old fixed-width formatter reserved — the bug it must not regress.
+        let cmds = vec![
+            CommandInfo {
+                name: "x".to_string(),
+                description: "short".to_string(),
+                usage: String::new(),
+                requires_auth: true,
+                subcommands: vec![],
+            },
+            CommandInfo {
+                name: "a-very-long-command-name".to_string(),
+                description: "long".to_string(),
+                usage: String::new(),
+                requires_auth: true,
+                subcommands: vec![],
+            },
+        ];
+        let mut out = String::new();
+        render_level(&cmds, 0, &mut out);
+        for line in out.lines() {
+            let (name, desc) = line.trim_start().split_once("  ").unwrap_or_else(|| {
+                panic!("row has no two-space gap between name and description: {line:?}")
+            });
+            assert!(
+                !name.is_empty() && !desc.trim().is_empty(),
+                "malformed row: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn human_output_has_header_and_footer() {
+        let rendered = render_human(&build_tree());
+        assert!(rendered.starts_with("Commands:\n"));
+        assert!(rendered.contains("Run `floo <command> --help` for details."));
     }
 }


### PR DESCRIPTION
## What changed

`floo commands` (the agent-facing command index) is now a **pure projection of the live clap command tree** (`Cli::command()`). Names, descriptions, structure, and usage are all read from clap at runtime, so the index cannot drift from the actual CLI. The previous implementation was a 565-line hand-maintained `command_tree()` validated only against *another* hand-written list — both drifted.

Deletes 660 lines, adds 287 (mostly tests). Net **−373**.

## Why

The hand-maintained index disagreed with the real command tree in both directions:

- **Invented** `apps status` — the real command is `apps show`.
- **Omitted** real commands: `storage`, `doctor`, `services add` / `remove` / `migrate`, `db connections` / `backup` / `backups` / `restore`, `releases rollback`, `deploys status`.
- The "parity" test compared the tree to a hand-written `expected` set that omitted the same commands, so it passed despite the drift — false confidence.
- The plain-text formatter used a fixed minimum column width (`{:<14}` / `{:<12}` / `{:<10}`), so any name longer than the column abutted its description with no separating space (`update-profile`, `disconnect`, `connections`).

Resolves getfloo/floo#1160. (Per the issue's SDLC note, the fix lands here but is driven from the `getfloo/floo` monorepo worktree so the full review/test pipeline applies. Cross-repo, so it can't auto-close — the issue is closed manually on merge. A companion `getfloo/floo` change fixes the same phantom `apps status` that leaked into the KB.)

## Risk tier

standard — CLI display command, no auth/deploy path. `requires_auth` is reported metadata only; it enforces nothing.

## Files reviewers should scrutinize

- `src/commands/command_tree.rs` — the clap walker (`build_tree` / `command_info`), `render_usage`, `render_level` (the formatting fix), and `AUTH_EXEMPT_PATHS` (the only curated metadata, pinned to real commands by `auth_exempt_paths_all_exist`).

## How it can't drift again

- `index_matches_real_command_tree` — independently walks clap and asserts the index covers exactly the same command paths.
- `pins_known_drift_regressions` — asserts the previously-omitted commands are present and phantom `apps status` is absent.
- `every_command_has_description_and_usage` — fails if a clap variant lacks a `///` doc comment.
- `auth_exempt_paths_all_exist` — fails if the auth-exempt list references a command that no longer exists.
- `human_output_never_abuts_name_and_description` — pins the formatting fix against a name longer than any old fixed column.

## Tests run

`cargo test` → 439 + 141 + 108 passed, `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean.

Verified by hand: `floo commands` renders every command with clean spacing at every depth; `floo commands --json` emits exactly one object on stdout with `apps show` present, `apps status` absent, `auth login` `requires_auth:false`, `auth whoami` `requires_auth:true`.

## Known non-goals

- Usage strings show the command path + positionals (not every flag) by design — detailed flags live behind `floo <command> --help`, which the footer points to.