### PR TITLE
fix(cli): canonical --service flag with --services alias CLI-wide

### DIFF
--- a/plugin/skills/floo-services/SKILL.md
+++ b/plugin/skills/floo-services/SKILL.md
@@ -258,20 +258,20 @@ For server-side code (Node.js, Python), use `API_URL` or `WEB_URL` from `process
 
 ## Env Var Scoping in Multi-Service Apps
 
-In multi-service apps, env vars are scoped per service. You MUST specify `--services` when setting variables:
+In multi-service apps, env vars are scoped per service. You MUST specify `--service` when setting variables:
 
 ```bash
 # Backend secrets — target api/worker only
-floo env set DATABASE_URL=postgres://... --services api
-floo env set API_SECRET=sk_... --services api,worker
+floo env set DATABASE_URL=postgres://... --service api
+floo env set API_SECRET=sk_... --service api --service worker
 
 # Frontend config — target web only (public values only)
-floo env set VITE_API_URL=https://app.getfloo.com/api --services web
+floo env set VITE_API_URL=https://app.getfloo.com/api --service web
 ```
 
 **CRITICAL:** Never set backend secrets (`DATABASE_URL`, API keys, tokens) on frontend services. Build-time variables (`VITE_*`, `NEXT_PUBLIC_*`, `REACT_APP_*`) are baked into the JS bundle and visible to end users.
 
-Managed service env vars (`DATABASE_URL`, `REDIS_URL`, `STORAGE_BUCKET`) are provisioned at app scope (available to all services). If your app has a frontend service that should NOT see these, use `--services` to set them on specific backend services instead.
+Managed service env vars (`DATABASE_URL`, `REDIS_URL`, `STORAGE_BUCKET`) are provisioned at app scope (available to all services). If your app has a frontend service that should NOT see these, use `--service` to set them on specific backend services instead.
 
 ## General Rules
 

--- a/plugin/skills/floo/SKILL.md
+++ b/plugin/skills/floo/SKILL.md
@@ -130,7 +130,7 @@ floo env set DB_URL=... --app my-app --restart         # set and restart
 floo env list --app my-app --json                      # list all vars
 floo env import .env --app my-app                      # import from file
 floo env remove SECRET --app my-app                    # remove a var
-floo env set KEY=VAL --app my-app --services backend   # target a specific service (multi-service apps)
+floo env set KEY=VAL --app my-app --service backend   # target a specific service (multi-service apps)
 ```
 
 ### Logs and Debugging
@@ -150,14 +150,14 @@ floo deploy logs <deploy-id> --app my-app          # build logs
 floo deploy watch --app my-app                     # stream progress
 floo deploy rollback my-app <deploy-id>            # rollback
 floo redeploy --app my-app                         # force redeploy
-floo redeploy --services api --app my-app          # redeploy specific service
+floo redeploy --service api --app my-app          # redeploy specific service
 ```
 
 ### Custom Domains
 
 ```bash
 floo domains add app.example.com --app my-app                       # single-service app
-floo domains add app.example.com --app my-app --services frontend   # target a specific service (multi-service)
+floo domains add app.example.com --app my-app --service frontend   # target a specific service (multi-service)
 floo domains list --app my-app
 ```
 

--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -175,7 +175,7 @@ floo env set DB_URL=... --app my-app --restart         # set and restart
 floo env list --app my-app --json                      # list all vars
 floo env import .env --app my-app                      # import from file
 floo env remove SECRET --app my-app                    # remove a var
-floo env set KEY=VAL --app my-app --services backend   # target a specific service (multi-service apps)
+floo env set KEY=VAL --app my-app --service backend   # target a specific service (multi-service apps)
 ```
 
 ### Logs and Debugging
@@ -185,7 +185,7 @@ floo logs --app my-app                             # last 100 lines
 floo logs --app my-app --since 1h --error          # errors in last hour
 floo logs --app my-app --live                      # stream real-time
 floo logs --app my-app --search "panic" --json     # search + JSON
-floo logs --app my-app --services web              # one service (multi-service apps)
+floo logs --app my-app --service web              # one service (multi-service apps)
 floo logs --app my-app --cron nightly-report       # a specific cron job's output
 ```
 
@@ -196,7 +196,7 @@ floo preflight                                     # audit declared vs deployed 
 floo preflight --json                              # structured plan for agents
 floo redeploy --app my-app                         # force redeploy (after env var changes)
 floo redeploy --restart --app my-app               # restart without rebuilding
-floo redeploy --services api --app my-app          # redeploy specific service
+floo redeploy --service api --app my-app          # redeploy specific service
 floo redeploy --preflight --app my-app             # preview redeploy without executing
 ```
 
@@ -239,7 +239,7 @@ Adding a custom domain is a three-step process:
 1. **Add the domain** — registers it with floo and returns CNAME instructions:
    ```bash
    floo domains add app.example.com --app my-app
-   # multi-service: floo domains add app.example.com --app my-app --services frontend
+   # multi-service: floo domains add app.example.com --app my-app --service frontend
    ```
 
 2. **Add a CNAME record** at the user's DNS provider (Cloudflare, Route 53, etc):

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,7 +127,7 @@ Examples:
   floo run --service api --json -- pytest             Machine-readable exit code")]
     Run {
         /// Service name to inject env vars for (from floo.app.toml).
-        #[arg(long, required = true)]
+        #[arg(long = "service", visible_alias = "services", required = true)]
         service: String,
 
         /// App name or ID. Overrides the app name in floo.app.toml, but the
@@ -155,7 +155,7 @@ Examples:
         app: Option<String>,
 
         /// Validate only these services.
-        #[arg(short, long = "services")]
+        #[arg(short, long = "service", visible_alias = "services")]
         services: Vec<String>,
     },
 
@@ -178,8 +178,8 @@ need to apply env var changes or force a rebuild without a code change.")]
         #[arg(short, long)]
         app: Option<String>,
 
-        /// Deploy only these services (repeatable: --services api --services web).
-        #[arg(short, long = "services")]
+        /// Deploy only these services (repeatable: --service api --service web).
+        #[arg(short, long = "service", visible_alias = "services")]
         services: Vec<String>,
 
         /// Force a full rebuild from the latest commit (re-download source and run Cloud Build).
@@ -431,7 +431,7 @@ pub struct LogsOptions {
     severity: Option<String>,
 
     /// Filter logs to specific services (repeatable).
-    #[arg(long)]
+    #[arg(long = "service", visible_alias = "services")]
     services: Vec<String>,
 
     /// Filter logs to a specific cron job by name.
@@ -702,7 +702,7 @@ pub enum EnvCommands {
         app: Option<String>,
 
         /// Target specific services (repeatable).
-        #[arg(long)]
+        #[arg(long = "service", visible_alias = "services")]
         services: Vec<String>,
 
         /// Restart the app after setting the env var (redeploy with fresh env vars).
@@ -736,7 +736,7 @@ pub enum EnvCommands {
         app: Option<String>,
 
         /// Target specific services (repeatable).
-        #[arg(long)]
+        #[arg(long = "service", visible_alias = "services")]
         services: Vec<String>,
 
         /// Environment: dev or prod.
@@ -754,7 +754,7 @@ pub enum EnvCommands {
         app: Option<String>,
 
         /// Target specific services (repeatable).
-        #[arg(long)]
+        #[arg(long = "service", visible_alias = "services")]
         services: Vec<String>,
 
         /// Environment: dev or prod.
@@ -777,7 +777,7 @@ pub enum EnvCommands {
         app: Option<String>,
 
         /// Target a specific service.
-        #[arg(long)]
+        #[arg(long = "service", visible_alias = "services")]
         service: Option<String>,
 
         /// Environment: dev or prod.
@@ -796,7 +796,7 @@ pub enum EnvCommands {
         app: Option<String>,
 
         /// Target specific services (repeatable).
-        #[arg(long, conflicts_with = "all")]
+        #[arg(long = "service", visible_alias = "services", conflicts_with = "all")]
         services: Vec<String>,
 
         /// Import env vars for all services using their configured env_file paths.
@@ -853,7 +853,11 @@ pub enum ServicesCommands {
         app: Option<String>,
 
         /// Service name. Mutually exclusive with the positional form.
-        #[arg(long = "service", alias = "services", conflicts_with = "service_name")]
+        #[arg(
+            long = "service",
+            visible_alias = "services",
+            conflicts_with = "service_name"
+        )]
         service: Option<String>,
     },
 
@@ -974,8 +978,8 @@ pub enum DomainsCommands {
         #[arg(short, long)]
         app: Option<String>,
 
-        /// Target service name (required for multi-service apps).
-        #[arg(long)]
+        /// Route this domain to a specific service (required for multi-service apps).
+        #[arg(long = "service", visible_alias = "services")]
         services: Option<String>,
     },
 
@@ -2341,6 +2345,98 @@ mod tests {
             panic!("expected Analytics");
         };
         assert_eq!(app_flag.or(app), None);
+    }
+
+    // --- #1161: `--service` canonical, `--services` alias, CLI-wide ---
+    //
+    // Every service-targeting flag accepts both spellings so agents never have
+    // to special-case singular vs plural per subcommand. Canonical is
+    // `--service`; `--services` is a visible alias (same arg id), so existing
+    // scripts keep working and `--service` is the one true name in help.
+
+    #[test]
+    fn run_accepts_both_service_spellings() {
+        for flag in ["--service", "--services"] {
+            let cli = Cli::try_parse_from(["floo", "run", flag, "api", "--", "echo", "hi"])
+                .unwrap_or_else(|e| panic!("clap rejected `run {flag}`: {e}"));
+            let Commands::Run { service, .. } = cli.command else {
+                panic!("expected Run");
+            };
+            assert_eq!(service, "api", "run {flag}");
+        }
+    }
+
+    #[test]
+    fn env_get_accepts_both_service_spellings() {
+        for flag in ["--service", "--services"] {
+            let cli = Cli::try_parse_from(["floo", "env", "get", "KEY", flag, "api"])
+                .unwrap_or_else(|e| panic!("clap rejected `env get {flag}`: {e}"));
+            let Commands::Env(EnvCommands::Get { service, .. }) = cli.command else {
+                panic!("expected Env::Get");
+            };
+            assert_eq!(service.as_deref(), Some("api"), "env get {flag}");
+        }
+    }
+
+    #[test]
+    fn domains_add_accepts_both_service_spellings() {
+        for flag in ["--service", "--services"] {
+            let cli = Cli::try_parse_from(["floo", "domains", "add", "x.com", flag, "api"])
+                .unwrap_or_else(|e| panic!("clap rejected `domains add {flag}`: {e}"));
+            let Commands::Domains(DomainsCommands::Add { services, .. }) = cli.command else {
+                panic!("expected Domains::Add");
+            };
+            assert_eq!(services.as_deref(), Some("api"), "domains add {flag}");
+        }
+    }
+
+    #[test]
+    fn logs_accepts_both_service_spellings_and_repeats() {
+        for flag in ["--service", "--services"] {
+            let cli = Cli::try_parse_from(["floo", "logs", flag, "api", flag, "web"])
+                .unwrap_or_else(|e| panic!("clap rejected `logs {flag}`: {e}"));
+            let Commands::Logs { options, .. } = cli.command else {
+                panic!("expected Logs");
+            };
+            assert_eq!(options.services, vec!["api", "web"], "logs {flag}");
+        }
+    }
+
+    #[test]
+    fn env_set_accepts_both_service_spellings_and_repeats() {
+        for flag in ["--service", "--services"] {
+            let cli = Cli::try_parse_from(["floo", "env", "set", "K=V", flag, "api", flag, "web"])
+                .unwrap_or_else(|e| panic!("clap rejected `env set {flag}`: {e}"));
+            let Commands::Env(EnvCommands::Set { services, .. }) = cli.command else {
+                panic!("expected Env::Set");
+            };
+            assert_eq!(services, vec!["api", "web"], "env set {flag}");
+        }
+    }
+
+    #[test]
+    fn redeploy_accepts_both_service_spellings_and_short() {
+        // `redeploy` keeps its `-s` short form alongside the renamed long flag.
+        for flag in ["--service", "--services", "-s"] {
+            let cli = Cli::try_parse_from(["floo", "redeploy", flag, "api"])
+                .unwrap_or_else(|e| panic!("clap rejected `redeploy {flag}`: {e}"));
+            let Commands::Redeploy { services, .. } = cli.command else {
+                panic!("expected Redeploy");
+            };
+            assert_eq!(services, vec!["api"], "redeploy {flag}");
+        }
+    }
+
+    #[test]
+    fn mixed_service_spellings_address_one_arg() {
+        // Both spellings target the same arg id, so on a repeatable flag they
+        // accumulate in order rather than colliding as two distinct args.
+        let cli =
+            Cli::try_parse_from(["floo", "logs", "--service", "api", "--services", "web"]).unwrap();
+        let Commands::Logs { options, .. } = cli.command else {
+            panic!("expected Logs");
+        };
+        assert_eq!(options.services, vec!["api", "web"]);
     }
 
     // --- `--json` arg-error contract (#1156) ---

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -485,14 +485,14 @@ Floo Config Files
   Env vars are scoped per service. In multi-service apps, you MUST specify
   which service receives the variable:
 
-    floo env set DATABASE_URL=postgres://... --services api
-    floo env set REDIS_URL=redis://... --services api,worker
+    floo env set DATABASE_URL=postgres://... --service api
+    floo env set REDIS_URL=redis://... --service api --service worker
 
   Scoping rules:
 
   - Single-service app: env vars go to the only service (no flag needed)
   - Multi-service app with 1 service: auto-targets that service
-  - Multi-service app with 2+ services: --services is REQUIRED
+  - Multi-service app with 2+ services: --service is REQUIRED
 
   SECURITY: Secrets set on a frontend service (web, dashboard) end up in
   the container runtime. Build-time vars (VITE_*, NEXT_PUBLIC_*, REACT_APP_*)
@@ -502,17 +502,17 @@ Floo Config Files
   Recommended pattern for multi-service apps:
 
     # Backend secrets — api/worker only
-    floo env set DATABASE_URL=postgres://... --services api
-    floo env set LINEAR_API_KEY=lin_... --services api
-    floo env set REDIS_URL=redis://... --services api,worker
+    floo env set DATABASE_URL=postgres://... --service api
+    floo env set LINEAR_API_KEY=lin_... --service api
+    floo env set REDIS_URL=redis://... --service api --service worker
 
     # Frontend config — web only (public, not secret)
-    floo env set VITE_API_URL=https://my-app.getfloo.com/api --services web
+    floo env set VITE_API_URL=https://my-app.getfloo.com/api --service web
 
   List env vars per service:
 
-    floo env list --services api
-    floo env list --services web
+    floo env list --service api
+    floo env list --service web
 
   Managed service env vars are generated at app scope, then attached to
   services by [services.<name>.env] managed:
@@ -563,7 +563,7 @@ Floo Deploy Flow
   Use `floo redeploy` when you need to redeploy without a code change
   (e.g., after updating env vars):
 
-    floo env set API_KEY=new-value --app myapp --services api
+    floo env set API_KEY=new-value --app myapp --service api
     floo redeploy --app myapp
 
 ## First Deploy
@@ -633,7 +633,7 @@ Floo Deploy Flow
   floo redeploy --app <name>       — redeploy with fresh env vars (no rebuild)
   floo redeploy --app <name> --rebuild  — force a full rebuild from latest commit
   floo redeploy [path]             — full redeploy from local project directory
-  floo redeploy --services <name>  — redeploy specific services only
+  floo redeploy --service <name>  — redeploy specific services only
   floo redeploy --sync-env         — re-sync env vars from env_file before redeploying
   floo redeploy --rebuild --skip-migrations  — hotfix path: bypass MIGRATE step
 
@@ -927,7 +927,7 @@ Floo — Golden Path
 
   For multi-service apps, target a specific service:
 
-  floo domains add api.example.com --app my-app --services api
+  floo domains add api.example.com --app my-app --service api
 
 ## How to Roll Back
 
@@ -938,7 +938,7 @@ Floo — Golden Path
 
   floo logs query --app my-app --since 1h --error
   floo logs tail --app my-app --env prod
-  floo logs query --app my-app --services web        # one service (multi-service apps)
+  floo logs query --app my-app --service web        # one service (multi-service apps)
   floo logs query --app my-app --cron nightly-report # a specific cron job's output
   floo logs query --app my-app --deployment latest --json
   floo logs query --app my-app --json --limit 100 --cursor \"$NEXT_CURSOR\"
@@ -1045,7 +1045,7 @@ Floo Templates — Copy-Paste App Structures
   3. floo preflight                            # validate both services
   4. git push origin main                      # push to GitHub first
   5. floo apps github connect owner/my-app     # triggers first deploy
-  6. floo env set DATABASE_URL=<url> --services api  # managed postgres auto-sets this
+  6. floo env set DATABASE_URL=<url> --service api  # managed postgres auto-sets this
   7. floo apps show my-app                     # get your URL
 
 ### Local Development (two terminals)
@@ -1064,11 +1064,11 @@ Floo Templates — Copy-Paste App Structures
 ### Env Vars
 
   Backend secrets (api service only):
-    floo env set DATABASE_URL=postgres://... --services api
-    floo env set SECRET_KEY=... --services api
+    floo env set DATABASE_URL=postgres://... --service api
+    floo env set SECRET_KEY=... --service api
 
   Frontend config (web service only, public — baked into JS bundle):
-    floo env set VITE_API_URL=/api --services web
+    floo env set VITE_API_URL=/api --service web
 
   SECURITY: Never set backend secrets on the web service.
   Build-time vars (VITE_*, NEXT_PUBLIC_*) are visible to end users.


### PR DESCRIPTION
## What changed
Every service-targeting flag now accepts both `--service` and `--services`. `--service` is the canonical (visible) name; `--services` is a visible alias addressing the same arg id, so existing scripts/agents keep working either way.

Sites: `run`, `preflight`, `redeploy`, `logs`, `env set|list|unset|get|import`, `domains add`. `services show` already used this shape — its hidden `alias` is upgraded to `visible_alias` for uniformity.

Also aligned the embedded agent skills (`skills/floo`, `plugin/skills/*`) and `floo docs` to `--service`, and fixed three `--service api,worker` examples: the flag is a repeatable `Vec` with no comma delimiter, so the comma form silently targeted a service literally named `api,worker`. Corrected to the repeated `--service api --service worker` form.

## Why
Finding 1 of #1161: service-targeting flags were inconsistently named (`run`/`env get` = singular `--service`; `logs`/`redeploy`/`env set|list|unset|import` = plural `--services`), forcing agents to special-case the flag name per subcommand.

## Risk tier
standard — additive aliasing only. Field names unchanged, so dispatch/command signatures are untouched. No behavior removed.

## Files reviewers should scrutinize
- `src/cli.rs` — the `#[arg(...)]` attribute changes + new parse tests.

## Tests run
`cargo test` (441 + 141 + 108 pass), `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean). New tests assert both spellings parse identically for single-target (`run`, `env get`, `domains add`), multi-target (`logs`, `env set`, `redeploy` incl. `-s`), and that mixed spellings accumulate into one arg.

## Known non-goals
- Comma-separated service lists (`--service a,b`) are not added here — docs corrected to the repeated form instead; a `value_delimiter` ergonomic follow-up is tracked separately.
- Domains `list`/`remove` still accept a (now-ignored) service flag; their app-level cleanup is finding 4 of #1161, shipping as a separate PR.

Part of #1161