### PR TITLE
fix: repair the CLI docs surface (dead links, hidden topics, --help)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Contributions are welcome! Please:
 
 ## Documentation
 
-- [Getting Started](https://docs.getfloo.com)
-- [CLI Reference](https://docs.getfloo.com/cli)
-- [API Reference](https://docs.getfloo.com/api)
+- [Getting Started](https://getfloo.com/docs/introduction)
+- [CLI Reference](https://getfloo.com/docs/cli/overview)
+- [Configuration Reference](https://getfloo.com/docs/reference/config-spec)
 
 ## License
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,9 +329,16 @@ Examples:
         context: Option<String>,
     },
 
-    /// Built-in platform documentation.
+    /// Built-in platform documentation. Run `floo docs` (no topic) for the
+    /// full list of topics with one-line descriptions.
+    #[command(after_help = "\
+Topics: golden-path, quickstart, build, nextjs, rails, fastapi, django,
+express, templates, services, config, cron, deploy, auth, notifications,
+feedback.
+Aliases: storage -> services, app-toml -> config.
+Run `floo docs` (no topic) for a one-line description of each topic.")]
     Docs {
-        /// Topic: services, config, deploy. Omit for overview.
+        /// Documentation topic to display. Omit for the overview.
         topic: Option<String>,
     },
 
@@ -2145,6 +2152,31 @@ mod tests {
 
     fn argv(parts: &[&str]) -> Vec<OsString> {
         parts.iter().map(OsString::from).collect()
+    }
+
+    /// `floo docs --help` must list every topic and alias. Pinned to the
+    /// `TOPICS`/`ALIASES` tables so the help block can't silently drift —
+    /// before #1159 it advertised only "services, config, deploy".
+    #[test]
+    fn docs_help_lists_every_topic_and_alias() {
+        use clap::CommandFactory;
+        let mut cmd = Cli::command();
+        let docs = cmd
+            .find_subcommand_mut("docs")
+            .expect("docs subcommand exists");
+        let help = docs.render_long_help().to_string();
+        for (name, _) in crate::commands::docs::TOPICS {
+            assert!(
+                help.contains(name),
+                "`floo docs --help` is missing topic '{name}'",
+            );
+        }
+        for (alias, _) in crate::commands::docs::ALIASES {
+            assert!(
+                help.contains(alias),
+                "`floo docs --help` is missing alias '{alias}'",
+            );
+        }
     }
 
     fn strs(args: &[OsString]) -> Vec<&str> {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -36,12 +36,12 @@ never uploads code.
   floo docs django     — build and deploy a Django app on floo (end-to-end)
   floo docs express    — build and deploy an Express app on floo (end-to-end)
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
-  floo docs services   — service types and managed services
-  floo docs storage    — managed Storage restore commands
-  floo docs config     — config file formats with examples
+  floo docs services   — service types and managed services (alias: storage)
+  floo docs config     — config file formats with examples (alias: app-toml)
   floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
   floo docs deploy     — detailed deploy flow and runtime detection
   floo docs auth       — add user authentication to your app
+  floo docs notifications — control which emails floo sends you
   floo docs feedback   — report bugs, friction, or feature requests
   floo --help          — all available commands
   floo <command> --help — details for a specific command
@@ -163,7 +163,7 @@ deployable. Floo distinguishes two kinds by how they are authored:
 The split matters: removing a line from floo.app.toml that deleted a
 database would be catastrophic, so managed services are never coupled to
 config-file edits. Destruction is always an explicit CLI command with
-confirmation. See also: floo docs state-model.
+confirmation.
 
 ## App Services (your code)
 
@@ -211,7 +211,7 @@ confirmation. See also: floo docs state-model.
   Postgres ships with pgvector enabled. The `vector` type resolves
   unqualified: use it in migrations and queries with no CREATE EXTENSION
   and no schema prefix. Rails (`t.vector`), Django, SQLAlchemy, and Prisma
-  all emit the bare type. Full guide: https://docs.getfloo.com/guides/databases
+  all emit the bare type. Full guide: https://getfloo.com/docs/guides/databases
 
   Preview database branches are preview-owned managed Postgres branches.
   Inspect them from the terminal:
@@ -776,7 +776,7 @@ curl testing or scripts, send the headers yourself:
        -H \"X-Floo-User-Id: dev-user-1\" \\
        http://localhost:3000/dashboard
 
-Full docs: https://docs.getfloo.com/guides/app-auth
+Full docs: https://getfloo.com/docs/guides/app-auth
 ";
 
 const FEEDBACK: &str = "\
@@ -1158,7 +1158,7 @@ end-to-end in a real Rails / Next.js / Django / etc. project.
 If you know which capability you need, jump to the capability guide. If
 you're starting a new project, start with the stack guide.
 
-Full guides: https://docs.getfloo.com/build/
+Full guides: https://getfloo.com/docs/build/
 ";
 
 const RAILS: &str = "\
@@ -1295,7 +1295,7 @@ Add the CNAME shown in the output at your DNS provider.
   - asset compilation runs in the Dockerfile (RAILS_SERVE_STATIC_FILES=1)
   - Rails 7+ force_ssl works correctly behind floo's edge (X-Forwarded-Proto)
 
-Full guide with complete Ruby code: https://docs.getfloo.com/build/rails
+Full guide with complete Ruby code: https://getfloo.com/docs/build/rails
 ";
 
 const NEXTJS: &str = "\
@@ -1369,7 +1369,7 @@ Then in a Server Component or Route Handler:
   - output: \"standalone\" in next.config.js
   - Never expose tokens to client components
 
-Full guide with complete TypeScript code: https://docs.getfloo.com/build/nextjs
+Full guide with complete TypeScript code: https://getfloo.com/docs/build/nextjs
 ";
 
 const FASTAPI: &str = "\
@@ -1442,7 +1442,7 @@ Then a FastAPI dependency:
   - Don't mix asyncpg and psycopg2 — pick one
   - X-Forwarded-Proto: build absolute URLs from forwarded scheme
 
-Full guide with complete Python code: https://docs.getfloo.com/build/fastapi
+Full guide with complete Python code: https://getfloo.com/docs/build/fastapi
 ";
 
 const DJANGO: &str = "\
@@ -1535,7 +1535,7 @@ headers with HTTP_ and uppercases them):
   - DJANGO_SECRET_KEY must be set or sessions can be forged
   - SECURE_PROXY_SSL_HEADER required for is_secure() to work behind floo
 
-Full guide with complete Python code: https://docs.getfloo.com/build/django
+Full guide with complete Python code: https://getfloo.com/docs/build/django
 ";
 
 const EXPRESS: &str = "\
@@ -1609,7 +1609,7 @@ won't get set behind floo's edge.
   - SESSION_SECRET required for cookie-session
   - For server-side sessions: floo services add redis + connect-redis
 
-Full guide with complete JavaScript code: https://docs.getfloo.com/build/express
+Full guide with complete JavaScript code: https://getfloo.com/docs/build/express
 ";
 
 const CRON: &str = "\
@@ -1684,32 +1684,43 @@ deploy (added, updated, or removed to match config).
   https://getfloo.com/docs/reference/config-spec   — full [cron.<name>] schema reference
 ";
 
-const TOPICS: &[(&str, &str)] = &[
-    ("quickstart", QUICKSTART),
+// Canonical docs topics, in the order the overview lists them. This table is
+// the single source of truth for which `floo docs` topics exist: the overview
+// listing, the `floo docs --help` block, and every `floo docs <topic>`
+// cross-reference are all pinned back to it by tests in this module (and the
+// `--help` block by a test in `cli.rs`). Add a topic here and those tests fail
+// until the overview and `--help` list it too.
+pub(crate) const TOPICS: &[(&str, &str)] = &[
     ("golden-path", HOWTO),
+    ("quickstart", QUICKSTART),
     ("build", BUILD),
     ("nextjs", NEXTJS),
     ("rails", RAILS),
     ("fastapi", FASTAPI),
     ("django", DJANGO),
     ("express", EXPRESS),
+    ("templates", TEMPLATES),
     ("services", SERVICES),
-    ("storage", SERVICES),
     ("config", CONFIG),
-    ("app-toml", CONFIG), // alias — agents can run `floo docs app-toml` after `floo init`
     ("cron", CRON),
     ("deploy", DEPLOY),
     ("auth", AUTH),
-    ("feedback", FEEDBACK),
     ("notifications", NOTIFICATIONS),
-    ("templates", TEMPLATES),
+    ("feedback", FEEDBACK),
 ];
+
+// Convenience aliases. An agent types the concrete noun it already has — a
+// managed-service name (`storage`) or a config filename (`app-toml`) — and
+// lands on the canonical topic instead of hitting "Unknown docs topic". Each
+// alias resolves to a TOPICS name and is surfaced in the overview so it stays
+// discoverable; both invariants are pinned by tests in this module.
+pub(crate) const ALIASES: &[(&str, &str)] = &[("storage", "services"), ("app-toml", "config")];
 
 pub fn docs(topic: Option<&str>) {
     let (topic_name, content) = match topic {
         None => ("overview", OVERVIEW),
-        Some(t) => match TOPICS.iter().find(|(name, _)| *name == t) {
-            Some((name, content)) => (*name, *content),
+        Some(t) => match resolve_topic(t) {
+            Some(resolved) => resolved,
             None => {
                 let available: Vec<&str> = TOPICS.iter().map(|(n, _)| *n).collect();
                 output::error(
@@ -1733,6 +1744,18 @@ pub fn docs(topic: Option<&str>) {
     } else {
         eprintln!("{}", content.trim());
     }
+}
+
+/// Resolve a requested topic name to its `(canonical_name, content)`. Accepts
+/// both canonical topics and convenience aliases; an alias resolves to the
+/// canonical topic's name and content, so `floo docs storage` and
+/// `floo docs services` are indistinguishable downstream.
+fn resolve_topic(t: &str) -> Option<(&'static str, &'static str)> {
+    if let Some(entry) = TOPICS.iter().find(|(name, _)| *name == t) {
+        return Some(*entry);
+    }
+    let target = ALIASES.iter().find(|(alias, _)| *alias == t)?.1;
+    TOPICS.iter().find(|(name, _)| *name == target).copied()
 }
 
 #[cfg(test)]
@@ -1862,7 +1885,7 @@ mod tests {
         assert!(BUILD.contains("floo docs fastapi"));
         assert!(BUILD.contains("floo docs django"));
         assert!(BUILD.contains("floo docs express"));
-        assert!(BUILD.contains("docs.getfloo.com/build/"));
+        assert!(BUILD.contains("getfloo.com/docs/build"));
     }
 
     #[test]
@@ -1918,7 +1941,7 @@ mod tests {
             );
             assert!(content.contains("floo dev"), "{stack}: missing 'floo dev'");
             assert!(
-                content.contains("docs.getfloo.com/build/"),
+                content.contains("getfloo.com/docs/build"),
                 "{stack}: missing link to full guide"
             );
         }
@@ -1963,5 +1986,75 @@ mod tests {
                 "{stack}: leaked 'Hosted app OAuth'"
             );
         }
+    }
+
+    /// Every `floo docs <topic>` mention across the overview and every topic
+    /// body must resolve to a real topic or alias. The dead
+    /// `floo docs state-model` cross-reference (#1159) is exactly what this
+    /// pins — the whole class, not just that one instance.
+    #[test]
+    fn test_every_floo_docs_cross_reference_resolves() {
+        let valid: std::collections::HashSet<&str> = TOPICS
+            .iter()
+            .map(|(n, _)| *n)
+            .chain(ALIASES.iter().map(|(a, _)| *a))
+            .collect();
+        let re = regex::Regex::new(r"floo docs ([a-z][a-z-]*)").unwrap();
+        let mut bodies: Vec<&str> = TOPICS.iter().map(|(_, c)| *c).collect();
+        bodies.push(OVERVIEW);
+        for body in bodies {
+            for cap in re.captures_iter(body) {
+                let referenced = cap.get(1).unwrap().as_str();
+                assert!(
+                    valid.contains(referenced),
+                    "cross-reference `floo docs {referenced}` has no matching topic or alias",
+                );
+            }
+        }
+    }
+
+    /// Every canonical topic must be listed in the overview so an agent reading
+    /// `floo docs` can discover all of them. `notifications` was invisible here
+    /// before #1159.
+    #[test]
+    fn test_overview_lists_every_canonical_topic() {
+        for (name, _) in TOPICS {
+            assert!(
+                OVERVIEW.contains(&format!("floo docs {name}")),
+                "overview is missing `floo docs {name}`",
+            );
+        }
+    }
+
+    /// Every alias must resolve to a real canonical topic, must not shadow a
+    /// canonical name, and must be surfaced in the overview so it stays
+    /// discoverable rather than being a hidden duplicate (#1159).
+    #[test]
+    fn test_every_alias_resolves_to_canonical_topic() {
+        for (alias, target) in ALIASES {
+            assert!(
+                TOPICS.iter().any(|(n, _)| n == target),
+                "alias `{alias}` points at unknown canonical topic `{target}`",
+            );
+            assert!(
+                !TOPICS.iter().any(|(n, _)| n == alias),
+                "alias `{alias}` collides with a canonical topic name",
+            );
+            assert!(
+                OVERVIEW.contains(alias),
+                "alias `{alias}` is not surfaced in the overview",
+            );
+        }
+    }
+
+    /// Dispatching an alias returns the canonical topic's name and content; an
+    /// unknown topic returns None so the caller shows the available-topics hint.
+    #[test]
+    fn test_alias_dispatch_resolves_to_canonical() {
+        assert_eq!(resolve_topic("storage"), Some(("services", SERVICES)));
+        assert_eq!(resolve_topic("app-toml"), Some(("config", CONFIG)));
+        assert_eq!(resolve_topic("services"), Some(("services", SERVICES)));
+        assert!(resolve_topic("state-model").is_none());
+        assert!(resolve_topic("definitely-not-a-topic").is_none());
     }
 }

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -6,7 +6,7 @@ mod service_config;
 pub const SERVICE_CONFIG_FILE: &str = "floo.service.toml";
 pub const APP_CONFIG_FILE: &str = "floo.app.toml";
 pub const LEGACY_CONFIG_FILE: &str = "floo.toml";
-const SCHEMA_URL: &str = "https://getfloo.com/docs/floo-toml";
+const SCHEMA_URL: &str = "https://getfloo.com/docs/reference/config-spec";
 const MAX_WALK_UP_LEVELS: usize = 20;
 
 /// Convert a `toml::de::Error` from project-config parsing into a FlooError

--- a/src/project_config/resolve.rs
+++ b/src/project_config/resolve.rs
@@ -49,7 +49,7 @@ pub fn resolve_app_context(cwd: &Path, app_flag: Option<&str>) -> Result<Resolve
                     current.display()
                 ),
                 format!(
-                    "Migrate to {} + {}. See https://getfloo.com/docs/migration for details.",
+                    "Migrate to {} + {}. See https://getfloo.com/docs/reference/config-spec for details.",
                     APP_CONFIG_FILE, SERVICE_CONFIG_FILE
                 ),
             ));

--- a/tests/no_dead_doc_links.rs
+++ b/tests/no_dead_doc_links.rs
@@ -1,0 +1,41 @@
+//! Substrate guard for CLI-emitted documentation links.
+//!
+//! floo's docs moved off the `docs.getfloo.com` subdomain (retired, no DNS)
+//! behind the `getfloo.com/docs` proxy in getfloo/floo#1140 / #1144. The CLI's
+//! built-in docs (`floo docs`, config-error hints, README) kept pointing at the
+//! dead subdomain — getfloo/floo#1159. This test fails CI if any source file
+//! reintroduces a reference to it, so the whole class stays closed instead of
+//! relying on reviewers to spot a rotted host.
+//!
+//! The needle literal lives here in `tests/`, never under `src/`, so the scan
+//! of `src/` below never matches its own definition.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn no_source_file_references_the_retired_docs_subdomain() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let needle = "docs.getfloo.com";
+    let mut offenders = Vec::new();
+    collect_offenders(&src, needle, &mut offenders);
+    assert!(
+        offenders.is_empty(),
+        "these source files still reference the retired {needle} subdomain \
+         (use getfloo.com/docs/<path> instead): {offenders:#?}",
+    );
+}
+
+fn collect_offenders(dir: &Path, needle: &str, offenders: &mut Vec<String>) {
+    for entry in fs::read_dir(dir).expect("src/ is readable") {
+        let path = entry.expect("dir entry is readable").path();
+        if path.is_dir() {
+            collect_offenders(&path, needle, offenders);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            let body = fs::read_to_string(&path).expect("source file is readable");
+            if body.contains(needle) {
+                offenders.push(path.display().to_string());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Repairs the built-in `floo docs` surface (getfloo/floo#1159):

- **Dead links** — floo's docs moved off the retired `docs.getfloo.com` subdomain behind the `getfloo.com/docs` proxy ([getfloo/floo#1140](https://github.com/getfloo/floo/pull/1140), [#1144](https://github.com/getfloo/floo/pull/1144)). Every `floo docs` "Full guide" link, the README, and the config-schema + legacy-migration error hints now point at `getfloo.com/docs`. The schema/migration hints were already `404`s under the proxy (`/docs/floo-toml`, `/docs/migration`); they now point at `reference/config-spec`.
- **Dead cross-reference** — removed `See also: floo docs state-model` from `floo docs services` (no such topic).
- **Hidden/duplicate topics** — `storage` and `app-toml` are now **explicit** aliases (`storage -> services`, `app-toml -> config`) resolved by `resolve_topic`, and both are surfaced in the overview. The canonical `notifications` topic was missing from the overview index and is now listed.
- **`--help` under-listing** — `floo docs --help` advertised only `services, config, deploy`. It now lists every topic + alias via an `after_help` block.

## Why

The CLI docs surface pointed users and agents at dead links and hid/duplicated topics. All five findings in getfloo/floo#1159 reconciled against work shipped through 2026-06-23.

## Risk tier

**standard** — CLI documentation output strings, error hints, and tests. No auth/deploy/config-parsing behavior changes.

## How the class is closed (not just the instances)

`TOPICS` is now the single source of truth. New tests pin every derived surface to it, so the drift class can't recur:

- `test_every_floo_docs_cross_reference_resolves` — every `floo docs <x>` mention resolves to a topic/alias.
- `test_overview_lists_every_canonical_topic` — overview lists every canonical topic.
- `test_every_alias_resolves_to_canonical_topic` — aliases resolve, don't shadow, stay discoverable.
- `docs_help_lists_every_topic_and_alias` (cli.rs) — `--help` can't drop a topic.
- `tests/no_dead_doc_links.rs` — repo-wide guard: CI fails if any source file references the retired subdomain again.

## Files reviewers should scrutinize

- `src/commands/docs.rs` — `TOPICS`/`ALIASES` split + `resolve_topic` + the four new pin tests.
- `src/cli.rs` — `Docs` `after_help` and the help-pin test.

## Tests run

`cargo test` (all 6 test binaries green), `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean). Behavior verified against the built binary: `floo docs --help` lists all 16 topics + 2 aliases; `floo docs storage`/`app-toml` resolve; unknown topics error with the full available list; zero `docs.getfloo.com` references remain in `src/` or the README.

## Known non-goals

- Does not auto-close getfloo/floo#1159 (GitHub only auto-closes same-repo issues); will close manually on merge.
- floo-docs content is unchanged — it already lives at `getfloo.com/docs`; this PR only fixes the CLI's pointers to it.

Refs getfloo/floo#1159