### PR TITLE
fix(cli): domains list/remove are app-level, drop ignored service flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,7 +165,7 @@ Examples:
   floo redeploy --app my-app               Redeploy with fresh env vars (no rebuild)
   floo redeploy --app my-app --rebuild     Force a full rebuild from latest commit
   floo redeploy                            Redeploy from current project directory
-  floo redeploy --services api             Redeploy specific services only
+  floo redeploy --service api              Redeploy specific services only
 
 Note: The primary way to deploy is `git push`. Use `floo redeploy` when you
 need to apply env var changes or force a rebuild without a code change.")]
@@ -734,7 +734,7 @@ pub enum EnvCommands {
     /// List environment variables for an app.
     ///
     /// Values are shown masked (`********`); the value itself is never echoed
-    /// here. With no `--services`, lists every service's vars plus app-level in
+    /// here. With no `--service`, lists every service's vars plus app-level in
     /// one pass — with a `Service` column labelling each row's scope whenever the
     /// app has services (a service-less app keeps the plain Key/Value table).
     List {
@@ -991,14 +991,13 @@ pub enum DomainsCommands {
     },
 
     /// List custom domains for an app.
+    ///
+    /// Custom domains are app/ingress-level, so this lists every domain on the
+    /// app regardless of which service each routes to — no service target.
     List {
         /// App name or ID (uses config file if omitted).
         #[arg(short, long)]
         app: Option<String>,
-
-        /// Target service name (required for multi-service apps).
-        #[arg(long)]
-        services: Option<String>,
     },
 
     /// Verify DNS for a pending custom domain.
@@ -1022,10 +1021,6 @@ pub enum DomainsCommands {
         /// App name or ID (uses config file if omitted).
         #[arg(short, long)]
         app: Option<String>,
-
-        /// Target service name (required for multi-service apps).
-        #[arg(long)]
-        services: Option<String>,
 
         /// Skip the y/N prompt. Required in non-interactive contexts.
         #[arg(long)]
@@ -1953,18 +1948,13 @@ pub fn run() {
                 app,
                 services,
             } => commands::domains::add(&hostname, app.as_deref(), services.as_deref()),
-            DomainsCommands::List { app, services } => {
-                commands::domains::list(app.as_deref(), services.as_deref())
-            }
+            DomainsCommands::List { app } => commands::domains::list(app.as_deref()),
             DomainsCommands::Verify { hostname, app } => {
                 commands::domains::verify(&hostname, app.as_deref())
             }
-            DomainsCommands::Remove {
-                hostname,
-                app,
-                services,
-                yes,
-            } => commands::domains::remove(&hostname, app.as_deref(), services.as_deref(), yes),
+            DomainsCommands::Remove { hostname, app, yes } => {
+                commands::domains::remove(&hostname, app.as_deref(), yes)
+            }
             DomainsCommands::Show { hostname, app } => {
                 commands::domains::status(&hostname, app.as_deref())
             }
@@ -2469,6 +2459,34 @@ mod tests {
             panic!("expected Logs");
         };
         assert_eq!(options.services, vec!["api", "web"]);
+    }
+
+    #[test]
+    fn domains_list_and_remove_reject_service_flag() {
+        // #1161: custom domains are app/ingress-level, so `list`/`remove` no
+        // longer accept a service target (it was required-but-ignored before).
+        // clap must reject the removed flag in either spelling.
+        let invocations: &[&[&str]] = &[
+            &["floo", "domains", "list", "--service", "api"],
+            &["floo", "domains", "list", "--services", "api"],
+            &[
+                "floo",
+                "domains",
+                "remove",
+                "x.com",
+                "--service",
+                "api",
+                "--yes",
+            ],
+        ];
+        for args in invocations {
+            let err = parse_err(args);
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::UnknownArgument,
+                "expected UnknownArgument for {args:?}",
+            );
+        }
     }
 
     // --- `--json` arg-error contract (#1156) ---

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1657,7 +1657,7 @@ fn validate_preflight(
                     )
                     .with_path(&svc.path)
                     .with_hint(format!(
-                        "Set them with `floo env set <KEY>=<value> --services {}` (or confirm they're already set server-side).",
+                        "Set them with `floo env set <KEY>=<value> --service {}` (or confirm they're already set server-side).",
                         svc.name
                     )),
                 );
@@ -2168,7 +2168,7 @@ fn generate_security_findings(
                                 PreflightFinding::warning(
                                     "SECRET_IN_WEB_SERVICE",
                                     format!(
-                                        "Secret-looking var '{}' in {}/{} — if this is a backend secret, remove it from the web service and set it on the api service: floo env set {}=<val> --services api",
+                                        "Secret-looking var '{}' in {}/{} — if this is a backend secret, remove it from the web service and set it on the api service: floo env set {}=<val> --service api",
                                         key, svc.name, env_filename, key
                                     ),
                                 )

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -17,9 +17,9 @@ fn check_services_flag(client: &FlooClient, app_id: &str, services: Option<&str>
 
     if result.services.len() > 1 && services.is_none() {
         output::error(
-            "Multiple services found. Specify --services.",
+            "Multiple services found. Specify --service.",
             &ErrorCode::MultipleServicesNoTarget,
-            Some("Use --services <name> to target a specific service."),
+            Some("Use --service <name> to target a specific service."),
         );
         process::exit(1);
     }
@@ -88,12 +88,11 @@ pub fn add(hostname: &str, app: Option<&str>, services: Option<&str>) {
     }
 }
 
-pub fn list(app: Option<&str>, services: Option<&str>) {
+pub fn list(app: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
 
     let (app_id, app_name) = super::resolve_app_from_config(&client, app);
-    check_services_flag(&client, &app_id, services);
 
     let result = match client.list_domains(&app_id) {
         Ok(r) => r,
@@ -168,7 +167,7 @@ pub fn verify(hostname: &str, app: Option<&str>) {
     }
 }
 
-pub fn remove(hostname: &str, app: Option<&str>, services: Option<&str>, yes: bool) {
+pub fn remove(hostname: &str, app: Option<&str>, yes: bool) {
     use crate::confirm::{confirm_tier2, ConfirmOutcome, RiskMetadata, Tier};
 
     if output::is_dry_run_mode() {
@@ -181,7 +180,6 @@ pub fn remove(hostname: &str, app: Option<&str>, services: Option<&str>, yes: bo
                 "action": "domain_remove",
                 "hostname": hostname,
                 "app": app,
-                "service": services,
                 "destructive": risk.destructive,
                 "data_loss": risk.data_loss,
                 "tier": risk.tier,
@@ -194,7 +192,6 @@ pub fn remove(hostname: &str, app: Option<&str>, services: Option<&str>, yes: bo
     let client = super::init_client(None);
 
     let (app_id, app_name) = super::resolve_app_from_config(&client, app);
-    check_services_flag(&client, &app_id, services);
 
     match confirm_tier2("Remove domain", &format!("{hostname} from {app_name}"), yes) {
         ConfirmOutcome::Proceed => {}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -130,23 +130,6 @@ fn mock_services_single(server: &mut Server) -> Mock {
         .create()
 }
 
-/// Mock two user-managed services (api + web).
-fn mock_services_multi(server: &mut Server) -> Mock {
-    server
-        .mock(
-            "GET",
-            format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
-        )
-        .match_query(Matcher::AllOf(vec![
-            Matcher::UrlEncoded("page".into(), "1".into()),
-            Matcher::UrlEncoded("per_page".into(), "100".into()),
-        ]))
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{"services":[{"id":"svc-api-1","name":"api","type":"api","status":"live","cloud_run_url":"https://api.floo.app","port":8000},{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000}]}"#)
-        .create()
-}
-
 fn preview_branch_json(name: &str, status: &str, reset_eligible: bool) -> String {
     let blocked = if reset_eligible {
         "null".to_string()
@@ -1217,26 +1200,14 @@ fn test_domains_remove_json_with_yes_flag() {
 }
 
 #[test]
-fn test_domains_list_multi_service_requires_services_flag() {
+fn test_domains_list_is_app_level_on_multi_service() {
+    // #1161: custom domains are app/ingress-level, so `domains list` lists
+    // every domain on the app and never demands a service target — even on a
+    // multi-service app. It does not resolve services at all (no /services
+    // call is mocked here, and the command must still succeed).
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
-    let _services = mock_services_multi(&mut server);
-
-    floo()
-        .args(["--json", "domains", "list", "--app", TEST_APP_NAME])
-        .env("HOME", home.path())
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("MULTIPLE_SERVICES_NO_TARGET"));
-}
-
-#[test]
-fn test_domains_list_multi_service_with_services_flag() {
-    let mut server = Server::new();
-    let home = setup_config(&server);
-    let _resolve = mock_resolve_app(&mut server);
-    let _services = mock_services_multi(&mut server);
 
     let _m_list = server
         .mock(
@@ -1249,15 +1220,7 @@ fn test_domains_list_multi_service_with_services_flag() {
         .create();
 
     floo()
-        .args([
-            "--json",
-            "domains",
-            "list",
-            "--app",
-            TEST_APP_NAME,
-            "--services",
-            "api",
-        ])
+        .args(["--json", "domains", "list", "--app", TEST_APP_NAME])
         .env("HOME", home.path())
         .assert()
         .success()


### PR DESCRIPTION
## What changed
`floo domains list` and `floo domains remove` no longer accept a service flag. They previously *required* `--service`/`--services` on multi-service apps and then ignored it — `list_domains` and `delete_domain` are keyed on `(app, hostname)` only. clap now rejects the removed flag (regression-tested).

`floo domains add` keeps its service target (renamed to `--service` in the prior PR) — a new domain genuinely routes to one service's ingress.

Also completes the #1161 `--service` canonicalization in user-facing strings missed in the first PR: the `redeploy` after_help example, `env list` help text, two `preflight` suggestion strings, and the domains multiple-services error/hint.

## Why
Finding 4 of #1161: the forced `--service` choice on app-level commands was pure friction — every accepted value returned the identical result, and the common `domains list` case errored until you named an arbitrary service.

## Risk tier
standard — CLI behavior change (removes a required-but-ignored flag). Domains add/verify/show/watch unchanged.

## Files reviewers should scrutinize
- `src/commands/domains.rs` — `list`/`remove` signatures + dropped `check_services_flag` calls (still used by `add`).
- `src/cli.rs` — removed args from the `List`/`Remove` variants + dispatch; new `domains_list_and_remove_reject_service_flag` test.

## Tests run
`cargo test` (452 + 141 + 107 pass), `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean). Flipped `test_domains_list_multi_service_*` to assert app-level success; added a clap-rejection unit test; removed the now-unused `mock_services_multi` helper.

## Known non-goals
- Whether the API honors a per-service domain on `add` is unchanged here — only the CLI surface is touched.

Part of #1161