### PR TITLE
fix(cli): emit spend_cap_cents from spend-cap get (key parity)

### DIFF
--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -82,8 +82,11 @@ pub fn spend_cap_get() {
         process::exit(1);
     });
 
+    // Cap is cents-denominated; emit it as `spend_cap_cents` to match
+    // `billing usage` and every other *_cents field. One key per concept so
+    // agents never special-case `spend_cap` vs `spend_cap_cents` (#1161).
     let data = serde_json::json!({
-        "spend_cap": spend_cap,
+        "spend_cap_cents": spend_cap,
         "current_period_spend_cents": current_spend,
         "spend_cap_exceeded": exceeded,
     });

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -208,6 +208,36 @@ fn test_apps_list_json() {
 }
 
 #[test]
+fn test_billing_spend_cap_get_json_uses_cents_key() {
+    // #1161: `spend-cap get` emits the cap as `spend_cap_cents`, consistent
+    // with `billing usage` and every other *_cents field. The bare `spend_cap`
+    // key that drifted between the two commands is gone.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _m = server
+        .mock("GET", "/v1/orgs/me")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"{TEST_ORG_ID}","name":"Test Org","slug":"test-org","spend_cap":5000,"current_period_spend_cents":1200,"spend_cap_exceeded":false}}"#
+        ))
+        .create();
+
+    floo()
+        .args(["--json", "billing", "spend-cap", "get"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""spend_cap_cents":5000"#))
+        .stdout(predicate::str::contains(
+            r#""current_period_spend_cents":1200"#,
+        ))
+        // The drifted bare key (`"spend_cap":`) must not reappear.
+        .stdout(predicate::str::contains(r#""spend_cap":"#).not());
+}
+
+#[test]
 fn test_apps_list_human() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed
`floo billing spend-cap get --json` now emits the cap as `spend_cap_cents` instead of `spend_cap`, matching `floo billing usage` and every other cents-denominated field.

## Why
Finding 2 of #1161: the two sibling commands returned the same cap value under different keys (`spend_cap` vs `spend_cap_cents`), forcing agents to special-case per command. One key per concept.

## Risk tier
standard — JSON output key rename on one CLI command. The API contract (`GET /v1/orgs/me` → `spend_cap`) is unchanged; the CLI maps it to `spend_cap_cents` on output.

## Files reviewers should scrutinize
- `src/commands/billing.rs` — the single key change in `spend_cap_get`.

## Tests run
`cargo test` (452 + 141 + 108 pass), clippy + fmt clean. New `test_billing_spend_cap_get_json_uses_cents_key` asserts the new key is present and the drifted `"spend_cap":` key is gone.

## Known non-goals
- Breaking: scripts parsing `spend_cap` from this command must read `spend_cap_cents` (pre-v1; both billing commands now agree).

Part of #1161