### PR TITLE
fix(cli): scope every billing usage field to --period

### DIFF
--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -173,10 +173,18 @@ pub fn usage(period: &str) {
     };
 
     let plan = org.plan.as_deref().unwrap_or("free");
-    let current_spend = org.current_period_spend_cents.unwrap_or(0);
     let spend_cap = org.spend_cap;
-    let exceeded = org.spend_cap_exceeded.unwrap_or(false);
     let max_cap = limits.max_spend_cap_cents;
+
+    // Every period-derived field reads from the period-scoped breakdown — the
+    // authoritative spend for the requested `--period` — instead of the org's
+    // always-current-month `current_period_spend_cents` / `spend_cap_exceeded`
+    // columns. `total_cost_usd` is `org_usage_spend_cents(period) / 100`, so
+    // rounding back recovers the exact period cents and keeps `% of cap`, the
+    // progress bar, and `spend_cap_exceeded` consistent with the spend the
+    // command actually displays (#1161).
+    let period_spend_cents = (breakdown.total_cost_usd * 100.0).round() as u64;
+    let exceeded = matches!(spend_cap, Some(cap) if cap > 0 && period_spend_cents >= cap);
 
     let plan_price = match plan {
         "hobby" => "$5/mo",
@@ -190,7 +198,7 @@ pub fn usage(period: &str) {
         "plan": plan,
         "spend_cap_cents": spend_cap,
         "max_spend_cap_cents": max_cap,
-        "current_period_spend_cents": current_spend,
+        "period_spend_cents": period_spend_cents,
         "spend_cap_exceeded": exceeded,
         "period": period,
         "total_cost_usd": breakdown.total_cost_usd,
@@ -226,7 +234,7 @@ pub fn usage(period: &str) {
             };
             eprintln!("  Spend cap: ${:.2}/month{}", cents as f64 / 100.0, max_str);
 
-            let pct = ((current_spend as f64 / cents as f64) * 100.0).min(100.0);
+            let pct = ((period_spend_cents as f64 / cents as f64) * 100.0).min(100.0);
             let filled = (pct / 100.0 * 30.0).round() as usize;
             let empty = 30 - filled;
             eprintln!("  Usage: {:.0}% of cap", pct);
@@ -250,6 +258,13 @@ pub fn usage(period: &str) {
 
     if exceeded {
         eprintln!();
-        output::warn("Spend cap exceeded \u{2014} deploys are blocked.");
+        if period == "last_month" {
+            output::warn(&format!(
+                "Spend exceeded the cap in {}.",
+                breakdown.period.label
+            ));
+        } else {
+            output::warn("Spend cap exceeded \u{2014} deploys are blocked.");
+        }
     }
 }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -238,6 +238,55 @@ fn test_billing_spend_cap_get_json_uses_cents_key() {
 }
 
 #[test]
+fn test_billing_usage_period_scopes_derived_fields() {
+    // #1161: `--period` must scope every period-derived field. The org's
+    // always-current-month columns (current_period_spend_cents=9000,
+    // spend_cap_exceeded=false) must NOT leak into a `--period last_month`
+    // view — that view's spend and exceeded flag come from the period-scoped
+    // breakdown (total_cost_usd=120.0 -> 12000c, over the 10000c cap).
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let _org = server
+        .mock("GET", "/v1/orgs/me")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"id":"{TEST_ORG_ID}","name":"Test Org","slug":"test-org","plan":"pro","spend_cap":10000,"current_period_spend_cents":9000,"spend_cap_exceeded":false}}"#
+        ))
+        .create();
+
+    let _limits = server
+        .mock("GET", "/v1/billing/limits")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"plan":"pro","max_spend_cap_cents":20000}"#)
+        .create();
+
+    let _breakdown = server
+        .mock("GET", "/v1/billing/orgs/me/cost-breakdown")
+        .match_query(Matcher::UrlEncoded("period".into(), "last_month".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"period":{"start":"2026-05-01T00:00:00Z","end":"2026-06-01T00:00:00Z","label":"Last month"},"total_cost_usd":120.0,"included_cost_usd":5.0,"apps":[]}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "billing", "usage", "--period", "last_month"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        // Period-scoped spend from the breakdown (12000c), not the org's 9000c.
+        .stdout(predicate::str::contains(r#""period_spend_cents":12000"#))
+        // Period-scoped exceeded (12000 >= 10000 cap), not the org's current false.
+        .stdout(predicate::str::contains(r#""spend_cap_exceeded":true"#))
+        // The stale current-month key is gone from `usage`.
+        .stdout(predicate::str::contains("current_period_spend_cents").not());
+}
+
+#[test]
 fn test_apps_list_human() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed
`floo billing usage --period P` now derives **every** period-related field from the period-scoped cost breakdown, not the org's current-month columns:
- `period_spend_cents`, the `% of cap` figure, and the progress bar now reflect the selected period.
- `spend_cap_exceeded` is now `period_spend_cents >= cap` (period-scoped), not the org's live deploys-blocked flag.
- The over-cap warning no longer claims "deploys are blocked" for a historical `--period last_month` view.

The cap itself (`spend_cap_cents`, `max_spend_cap_cents`) stays current — it is not period-derived.

## Why
Finding 3 of #1161: `--period` scoped the total and per-app breakdown but left `% of cap`, the progress bar, the spend figure, and `spend_cap_exceeded` on stale current-month values, so `--period last_month` showed last month's totals beside this month's cap usage.

## How it's correct
`breakdown.total_cost_usd` is `org_usage_spend_cents(period) / 100`, so `round(total_cost_usd * 100)` recovers the exact period cents losslessly. For the default `current_month` (when the billing period aligns with the calendar month) this equals the old `current_period_spend_cents`, so the default view is behavior-preserving; for `last_month`/`last_7d` it is now correctly scoped. No API change needed — the breakdown endpoint already does the period-scoped query.

## Risk tier
standard — CLI-only output/logic change. One JSON key in `usage` renamed (`current_period_spend_cents` → `period_spend_cents`).

## Files reviewers should scrutinize
- `src/commands/billing.rs` — `usage()` derived-field computation + period-aware warning.

## Tests run
`cargo test` (452 + 141 + 109 pass), clippy + fmt clean. New `test_billing_usage_period_scopes_derived_fields` proves that with org current-month=9000c/not-exceeded but a `last_month` breakdown of 12000c over a 10000c cap, the output reports `period_spend_cents:12000` and `spend_cap_exceeded:true` — i.e. the org's stale values do not leak in.

## Known non-goals
- Breaking: scripts parsing `current_period_spend_cents` from `usage` must read `period_spend_cents`. `spend-cap get` is unchanged.

Part of #1161