### PR TITLE
feat(cli): add orgs invite <email> --role for one-step role invites

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -266,6 +266,17 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn create_org_invite(
+        &self,
+        org_id: &str,
+        email: &str,
+        role: &str,
+    ) -> Result<CreateInviteResponse, FlooApiError> {
+        let body = serde_json::json!({"email": email, "role": role});
+        let resp = self.post_json(&format!("/v1/orgs/{org_id}/invites"), &body)?;
+        self.handle_response(resp)
+    }
+
     // --- Access ---
 
     pub fn grant_app_access(&self, app_id: &str, email: &str) -> Result<Value, FlooApiError> {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -113,6 +113,18 @@ pub struct MemberRoleResponse {
     pub role: String,
 }
 
+/// Response from creating an org invite. `invite_url` is a one-time link and is
+/// treated as secret-shaped by the redactor (see `redact::SECRET_FIELD_NAMES`),
+/// so it is redacted in `--json` output unless `--reveal-secrets` is passed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateInviteResponse {
+    pub email: String,
+    pub role: String,
+    pub status: String,
+    pub invite_url: String,
+    pub expires_at: String,
+}
+
 // --- App ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -563,6 +563,19 @@ pub enum OrgsCommands {
     #[command(subcommand)]
     Members(MembersCommands),
 
+    /// Invite a user to the current org with a role, in one step.
+    ///
+    /// Sends an invite email and returns a one-time invite link. The role is
+    /// assigned on acceptance, with no separate `orgs members set-role` call.
+    Invite {
+        /// Email address to invite.
+        email: String,
+
+        /// Role to grant: admin, member, or viewer.
+        #[arg(long, default_value = "member", value_parser = ["admin", "member", "viewer"])]
+        role: String,
+    },
+
     /// Switch the default org for subsequent commands.
     Switch {
         /// Org slug or ID.
@@ -1802,6 +1815,7 @@ pub fn run() {
                     commands::orgs::set_role(&user_id, &role)
                 }
             },
+            OrgsCommands::Invite { email, role } => commands::orgs::invite(&email, &role),
             OrgsCommands::Switch { org_slug } => commands::orgs::switch(&org_slug),
         },
 
@@ -2487,6 +2501,28 @@ mod tests {
                 "expected UnknownArgument for {args:?}",
             );
         }
+    }
+
+    #[test]
+    fn orgs_invite_role_flag_parses_defaults_and_validates() {
+        // #1161: `orgs invite --role` captures the role in one step; the
+        // default is member; clap rejects anything outside admin/member/viewer.
+        let cli =
+            Cli::try_parse_from(["floo", "orgs", "invite", "a@x.com", "--role", "admin"]).unwrap();
+        let Commands::Orgs(OrgsCommands::Invite { email, role }) = cli.command else {
+            panic!("expected Orgs::Invite");
+        };
+        assert_eq!(email, "a@x.com");
+        assert_eq!(role, "admin");
+
+        let cli = Cli::try_parse_from(["floo", "orgs", "invite", "a@x.com"]).unwrap();
+        let Commands::Orgs(OrgsCommands::Invite { role, .. }) = cli.command else {
+            panic!("expected Orgs::Invite");
+        };
+        assert_eq!(role, "member", "default role");
+
+        let err = parse_err(&["floo", "orgs", "invite", "a@x.com", "--role", "owner"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     // --- `--json` arg-error contract (#1156) ---

--- a/src/commands/orgs.rs
+++ b/src/commands/orgs.rs
@@ -78,6 +78,41 @@ pub fn set_role(user_id: &str, role: &str) {
     }
 }
 
+pub fn invite(email: &str, role: &str) {
+    // `role` is constrained to admin/member/viewer by clap's value_parser, so
+    // no manual validation is needed here.
+    super::require_auth();
+    let client = super::init_client(None);
+
+    let org = match client.get_org_me() {
+        Ok(o) => o,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+    let org_name = org.name.as_deref().unwrap_or("your org");
+
+    match client.create_org_invite(&org.id, email, role) {
+        Ok(result) => {
+            if output::is_json_mode() {
+                output::success("", Some(output::to_value(&result)));
+            } else {
+                output::success(
+                    &format!("Invited {email} to {org_name} as {}.", result.role),
+                    None,
+                );
+                output::info(&format!("  Invite link: {}", result.invite_url), None);
+                output::info("  An invite email was also sent.", None);
+            }
+        }
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
 pub fn switch(org_slug: &str) {
     super::require_auth();
     let client = super::init_client(None);

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -287,6 +287,47 @@ fn test_billing_usage_period_scopes_derived_fields() {
 }
 
 #[test]
+fn test_orgs_invite_json_assigns_role_and_redacts_url() {
+    // #1161: `orgs invite` resolves the current org, POSTs email + role in one
+    // step, and returns a one-time invite_url that is secret-shaped (redacted
+    // in JSON, never printed raw).
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+
+    let _invite = server
+        .mock("POST", format!("/v1/orgs/{TEST_ORG_ID}/invites").as_str())
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "email": "alice@example.com",
+            "role": "admin",
+        })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"inv-1","org_id":"org-uuid-5678","email":"alice@example.com","role":"admin","status":"pending","invited_by_id":"u-1","expires_at":"2026-07-01T00:00:00Z","created_at":"2026-06-26T00:00:00Z","invite_url":"https://app.getfloo.com/invite/secret-token-xyz"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "orgs",
+            "invite",
+            "alice@example.com",
+            "--role",
+            "admin",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""role":"admin""#))
+        // The one-time invite_url is secret-shaped: redacted, never raw.
+        .stdout(predicate::str::contains("secret-token-xyz").not())
+        .stdout(predicate::str::contains("contains_secrets"));
+}
+
+#[test]
 fn test_apps_list_human() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed
Adds `floo orgs invite <email> --role <admin|member|viewer>` (default `member`, clap-validated). It resolves the current org via `get_org_me()`, POSTs `{email, role}` to the existing `POST /v1/orgs/{org_id}/invites`, and surfaces the one-time `invite_url` the API returns.

`invite_url` is already in the redactor's secret-field list, so it is redacted in `--json` output (revealable with `--reveal-secrets`) and shown in human output — matching how `apps password` treats sensitive values.

## Why
Finding 5 of #1161: assigning a role on invite took two steps (invite, then a separate `orgs members set-role`). The role-accepting org-invite API existed but had no CLI surface. This delivers one-step invite-with-role.

Per-app roles remain out of scope (tracked in #235); app-level access (`apps invite`) stays binary. See the issue thread for the decision rationale.

## Risk tier
standard — new CLI command wiring an existing ADMIN-scoped API endpoint. No API change.

## Files reviewers should scrutinize
- `src/commands/orgs.rs` — the new `invite` fn (org resolution, output, JSON vs human).
- `src/api_client.rs` / `src/api_types.rs` — `create_org_invite` + `CreateInviteResponse` (note `invite_url` redaction).

## Tests run
`cargo test` (453 + 141 + 110 pass), clippy + fmt clean. Integration test mocks `GET /v1/orgs/me` + `POST /v1/orgs/{org_id}/invites`, body-matches `{email, role:admin}`, and asserts the response role plus that the `invite_url` token is redacted (`contains_secrets`, raw token absent). Unit test covers role parsing, the `member` default, and clap rejection of invalid roles.

## Known non-goals
- Per-app roles (#235). `apps invite` (binary app access) is unchanged.

Part of #1161