### PR TITLE
docs: align floo docs storage cheatsheet with the runtime contract

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -197,7 +197,14 @@ confirmation.
   lock file or in your repo:
     postgres → DATABASE_URL + PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD
     redis    → REDIS_URL
-    storage  → STORAGE_BUCKET + STORAGE_URL (use STORAGE_URL for signed URLs)
+    storage  → STORAGE_BUCKET (read/write via the GCS SDK over ADC)
+
+  Your app reaches storage with the native GCS SDK (Rails Active Storage
+  `:google` in proxy mode). floo runs your container as a service account
+  with read/write on the bucket, so ADC just works — no key file, no
+  project id. STORAGE_URL is a floo operator endpoint, not your app's
+  runtime path, and S3-compatible SDKs are not supported.
+  Full guide: https://getfloo.com/docs/guides/cloud-storage
 
   Managed Storage buckets keep noncurrent object versions for 30 days.
   To recover an overwritten or deleted object:


### PR DESCRIPTION
## What changed
The offline `floo docs` cheatsheet (`SERVICES`) said *"use STORAGE_URL for signed URLs"* — the same incomplete framing that was wrong in the published cloud-storage guide. `STORAGE_URL` is an **admin/operator** endpoint, not the app's runtime path.

Fixed the storage section of the cheatsheet to mirror the rewritten guide:
- Read/write via the **native GCS SDK over ADC** (the container runs as a per-app service account with read/write on the bucket — no key file, no project id).
- Rails Active Storage `:google` in **proxy mode**.
- `STORAGE_URL` is operator-only; **S3-compatible SDKs are unsupported**.
- Added the missing `cloud-storage` full-guide link.

## Why
Third surface of a three-surface doc fix. The internal contract is in `getfloo/floo` (KB PR #1308, merged) and the canonical customer guide in `getfloo/floo-docs` (#22, merged) — this keeps the agent-facing terminal cheatsheet aligned so `floo docs storage` doesn't contradict the published docs.

## Verification
- `cargo fmt --check` clean.
- `cargo test docs` + `cargo test --test no_dead_doc_links` pass (the dead-link test caught and I fixed a `docs.getfloo.com` → `getfloo.com/docs` slip).
- `cargo clippy --bin floo -- -D warnings` clean.

## Risk
Docs-string only. No behavior change.

Refs getfloo/floo#1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)