### PR TITLE
feat: add preview sandbox CLI commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -815,6 +815,35 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn create_preview_deploy(
+        &self,
+        app_id: &str,
+        request: &CreatePreviewDeployRequest<'_>,
+    ) -> Result<Deploy, FlooApiError> {
+        let mut body = serde_json::json!({
+            "runtime": request.runtime,
+            "environment": request.environment,
+            "branch": request.branch,
+        });
+        if let Some(commit_sha) = request.commit_sha {
+            body["commit_sha"] = Value::String(commit_sha.to_string());
+        }
+        if let Some(ref_name) = request.ref_name {
+            body["ref"] = Value::String(ref_name.to_string());
+        }
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/deploys"), &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn delete_preview(&self, app_id: &str, preview_slug: &str) -> Result<(), FlooApiError> {
+        let resp = self.delete(&format!("/v1/apps/{app_id}/previews/{preview_slug}"))?;
+        if resp.status().as_u16() == 204 {
+            return Ok(());
+        }
+        self.handle_response_value(resp)?;
+        Ok(())
+    }
+
     pub fn list_preview_database_branches(
         &self,
         app_id: &str,

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -173,6 +173,10 @@ pub struct FailureRootCause {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Deploy {
     pub id: String,
+    #[serde(default)]
+    pub app_id: Option<String>,
+    #[serde(default)]
+    pub environment_id: Option<String>,
     pub status: Option<String>,
     pub url: Option<String>,
     pub build_logs: Option<String>,
@@ -182,7 +186,13 @@ pub struct Deploy {
     pub triggered_by: Option<String>,
     pub commit_sha: Option<String>,
     #[serde(default)]
+    pub github_ref: Option<String>,
+    #[serde(default)]
     pub environment_name: Option<String>,
+    #[serde(default)]
+    pub preview_slug: Option<String>,
+    #[serde(default)]
+    pub source_branch: Option<String>,
     #[serde(default)]
     pub failure_category: Option<String>,
     #[serde(default)]
@@ -447,6 +457,17 @@ pub struct PreviewEnvironment {
 pub struct PreviewEnvironmentListResponse {
     pub previews: Vec<PreviewEnvironment>,
     pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreatePreviewDeployRequest<'a> {
+    pub runtime: &'a str,
+    pub environment: &'a str,
+    pub branch: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<&'a str>,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub ref_name: Option<&'a str>,
 }
 
 // --- Preflight ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -229,6 +229,24 @@ Note: To trigger a deploy, use `floo redeploy` or push to GitHub.
     )]
     Deploys(DeploysSubcommands),
 
+    /// Create and manage preview sandboxes for remote GitHub branches.
+    #[command(
+        name = "previews",
+        alias = "preview",
+        subcommand,
+        after_help = "\
+Examples:
+  floo previews up --app my-app --branch feat/foo --wait
+  floo previews list --app my-app --json
+  floo previews status --app my-app feat-foo-abcde
+  floo previews logs --app my-app feat-foo-abcde --follow
+  floo previews delete --app my-app feat-foo-abcde --yes
+
+Preview sandboxes deploy remote GitHub source only. Push your branch first;
+dirty local files are not uploaded."
+    )]
+    Previews(PreviewsSubcommands),
+
     /// Authenticate and manage your account.
     #[command(subcommand)]
     Auth(AuthCommands),
@@ -1211,6 +1229,85 @@ pub enum DeploysSubcommands {
 }
 
 #[derive(Subcommand)]
+pub enum PreviewsSubcommands {
+    /// Create or refresh a preview sandbox from a remote GitHub branch.
+    Up {
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Remote GitHub branch to deploy into an isolated preview.
+        #[arg(long)]
+        branch: String,
+
+        /// Wait for the returned deploy ID to reach a terminal state.
+        #[arg(long)]
+        wait: bool,
+
+        /// Runtime hint for the deploy request.
+        #[arg(long, default_value = "auto")]
+        runtime: String,
+
+        /// Exact remote commit SHA to deploy.
+        #[arg(long)]
+        commit_sha: Option<String>,
+
+        /// Remote git ref to record on the deploy.
+        #[arg(long = "ref")]
+        ref_name: Option<String>,
+    },
+
+    /// List active preview sandboxes for an app.
+    List {
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Show preview sandbox status.
+    Status {
+        /// Preview slug, source branch, preview URL, or unambiguous #PR.
+        preview: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Show logs for the preview's latest deploy.
+    Logs {
+        /// Preview slug, source branch, preview URL, or unambiguous #PR.
+        preview: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Follow deploy logs while the preview deploy is active.
+        #[arg(short, long)]
+        follow: bool,
+
+        /// Number of runtime log lines to fetch when not streaming deploy logs.
+        #[arg(long, default_value_t = 100)]
+        tail: u32,
+    },
+
+    /// Delete a preview sandbox and its preview-owned resources.
+    Delete {
+        /// Preview slug, source branch, preview URL, or unambiguous #PR.
+        preview: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Skip the y/N prompt. Required in non-interactive contexts.
+        #[arg(long, alias = "force")]
+        yes: bool,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum SkillsCommands {
     /// Install the floo agent skill file to a directory.
     Install {
@@ -1801,6 +1898,36 @@ pub fn run() {
                 deploy_id,
                 yes,
             } => commands::rollbacks::rollback(&app, &deploy_id, yes),
+        },
+        Commands::Previews(sub) => match sub {
+            PreviewsSubcommands::Up {
+                app,
+                branch,
+                wait,
+                runtime,
+                commit_sha,
+                ref_name,
+            } => commands::previews::up(
+                app.as_deref(),
+                &branch,
+                wait,
+                &runtime,
+                commit_sha.as_deref(),
+                ref_name.as_deref(),
+            ),
+            PreviewsSubcommands::List { app } => commands::previews::list(app.as_deref()),
+            PreviewsSubcommands::Status { preview, app } => {
+                commands::previews::status(app.as_deref(), &preview)
+            }
+            PreviewsSubcommands::Logs {
+                preview,
+                app,
+                follow,
+                tail,
+            } => commands::previews::logs(app.as_deref(), &preview, follow, tail),
+            PreviewsSubcommands::Delete { preview, app, yes } => {
+                commands::previews::delete(app.as_deref(), &preview, yes)
+            }
         },
         Commands::Auth(sub) => match sub {
             AuthCommands::Login { api_key, force } => {

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -216,6 +216,8 @@ mod tests {
             "db connections",
             "releases rollback",
             "deploys status",
+            "previews up",
+            "previews delete",
         ] {
             assert!(
                 paths.contains(real),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod init;
 pub mod logs;
 pub mod notifications;
 pub mod orgs;
+pub mod previews;
 pub mod releases;
 pub mod reparo;
 pub mod rollbacks;

--- a/src/commands/previews.rs
+++ b/src/commands/previews.rs
@@ -1,0 +1,581 @@
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::api_client::FlooClient;
+use crate::api_types::{CreatePreviewDeployRequest, Deploy, LogEntry, PreviewEnvironment};
+use crate::errors::ErrorCode;
+use crate::output;
+
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+const POLL_TIMEOUT: Duration = Duration::from_secs(600);
+const TERMINAL_STATUSES: &[&str] = &["live", "failed", "cancelled", "superseded"];
+
+pub fn up(
+    app_flag: Option<&str>,
+    branch: &str,
+    wait: bool,
+    runtime: &str,
+    commit_sha: Option<&str>,
+    ref_name: Option<&str>,
+) {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        output::error(
+            "--branch cannot be empty.",
+            &ErrorCode::InvalidFormat,
+            Some("Pass the remote GitHub branch to deploy, e.g. --branch feat/my-change."),
+        );
+        process::exit(1);
+    }
+
+    if output::is_dry_run_mode() {
+        output::dry_run_preview(
+            &format!(
+                "Would create a preview sandbox from remote GitHub branch '{branch}'. Local dirty files are not uploaded."
+            ),
+            serde_json::json!({
+                "action": "preview_up",
+                "app": app_flag,
+                "branch": branch,
+                "runtime": runtime,
+                "commit_sha": commit_sha,
+                "ref": ref_name,
+                "environment": "preview",
+                "github_source_only": true,
+                "dev_prod_untouched": true,
+            }),
+        );
+        return;
+    }
+
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+
+    if !output::is_json_mode() {
+        output::info(
+            &format!("Creating preview for {app_name} from branch {branch}..."),
+            None,
+        );
+    }
+
+    let request = CreatePreviewDeployRequest {
+        runtime,
+        environment: "preview",
+        branch,
+        commit_sha,
+        ref_name,
+    };
+    let mut deploy = match client.create_preview_deploy(&app_id, &request) {
+        Ok(deploy) => deploy,
+        Err(e) => {
+            output::error(
+                &e.message,
+                &ErrorCode::from_api(&e.code),
+                preview_api_suggestion(&e.code),
+            );
+            process::exit(1);
+        }
+    };
+
+    if wait {
+        deploy = poll_deploy(&client, &app_id, &deploy);
+    }
+
+    let preview = deploy
+        .preview_slug
+        .as_deref()
+        .and_then(|slug| client.get_preview(&app_id, slug).ok());
+    emit_preview_command_result(
+        "Preview deploy created.",
+        &app_id,
+        &app_name,
+        &deploy,
+        preview.as_ref(),
+    );
+
+    if wait && deploy.status.as_deref() != Some("live") {
+        process::exit(1);
+    }
+}
+
+pub fn list(app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let listing = match client.list_previews(&app_id) {
+        Ok(listing) => listing,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Previews retrieved.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "previews": listing.previews.iter().map(preview_json).collect::<Vec<_>>(),
+                "total": listing.total,
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    if listing.previews.is_empty() {
+        output::info(&format!("No previews found for {app_name}."), None);
+        return;
+    }
+    let rows: Vec<Vec<String>> = listing
+        .previews
+        .iter()
+        .map(|preview| {
+            vec![
+                preview.slug.clone(),
+                preview
+                    .source_branch
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+                preview
+                    .latest_deploy_status
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+                preview.url.clone().unwrap_or_else(|| "-".to_string()),
+                preview
+                    .expires_at
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+            ]
+        })
+        .collect();
+    output::table(
+        &["Preview", "Branch", "Status", "URL", "Expires"],
+        &rows,
+        None,
+    );
+}
+
+pub fn status(app_flag: Option<&str>, preview_identifier: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview = resolve_preview(&client, &app_id, &app_name, preview_identifier);
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview status retrieved.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "preview": preview_json(&preview),
+                "source_branch": preview.source_branch,
+                "deploy_id": preview.latest_deploy_id,
+                "status": preview.latest_deploy_status,
+                "url": preview.url,
+                "expires_at": preview.expires_at,
+                "database_branches": output::to_value(&preview.database_branches),
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    output::info(&format!("Preview {} for {app_name}", preview.slug), None);
+    render_preview(&preview);
+    output::info(
+        &format!("Next: floo previews logs {} --app {app_name}", preview.slug),
+        None,
+    );
+}
+
+pub fn delete(app_flag: Option<&str>, preview_identifier: &str, yes: bool) {
+    use crate::confirm::{confirm_tier2, ConfirmOutcome, RiskMetadata, Tier};
+
+    if output::is_dry_run_mode() {
+        let preview = normalize_preview_identifier(preview_identifier)
+            .unwrap_or_else(|| preview_identifier.trim().to_string());
+        let risk: RiskMetadata = Tier::Two.into();
+        output::dry_run_preview(
+            &format!(
+                "Would delete preview sandbox '{preview}'. Cloud Run services, preview-owned resources, routes, and env vars would be torn down; dev and prod are untouched."
+            ),
+            serde_json::json!({
+                "action": "preview_delete",
+                "app": app_flag,
+                "preview": preview,
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+                "scope": "preview",
+                "dev_prod_untouched": true,
+            }),
+        );
+        return;
+    }
+
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview = resolve_preview(&client, &app_id, &app_name, preview_identifier);
+
+    match confirm_tier2(
+        "Delete preview sandbox",
+        &format!("{} on {app_name} (dev/prod untouched)", preview.slug),
+        yes,
+    ) {
+        ConfirmOutcome::Proceed => {}
+        ConfirmOutcome::Aborted => {
+            if output::is_json_mode() {
+                output::success("Cancelled.", Some(serde_json::json!({"cancelled": true})));
+            } else {
+                output::info("Cancelled.", None);
+            }
+            process::exit(0);
+        }
+        ConfirmOutcome::Refused { suggestion } => {
+            crate::confirm::exit_refused(
+                &format!(
+                    "Refusing to delete preview '{}' on {app_name} without explicit confirmation; dev/prod untouched.",
+                    preview.slug
+                ),
+                &suggestion,
+            );
+        }
+    }
+
+    if let Err(e) = client.delete_preview(&app_id, &preview.slug) {
+        output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+        process::exit(1);
+    }
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview deleted.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "preview": preview_json(&preview),
+                "deleted": true,
+                "scope": "preview",
+                "dev_prod_untouched": true,
+            })),
+        );
+    } else {
+        output::success(
+            &format!(
+                "Deleted preview {} for {app_name}. Dev and prod were untouched.",
+                preview.slug
+            ),
+            None,
+        );
+    }
+}
+
+pub fn logs(app_flag: Option<&str>, preview_identifier: &str, follow: bool, tail: u32) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview = resolve_preview(&client, &app_id, &app_name, preview_identifier);
+    let Some(deploy_id) = preview.latest_deploy_id.as_deref() else {
+        output::error(
+            &format!("Preview '{}' has no deploy yet.", preview.slug),
+            &ErrorCode::DeployNotFound,
+            Some("Run `floo previews status` to inspect the preview lifecycle."),
+        );
+        process::exit(1);
+    };
+
+    if follow {
+        let streamed = if output::is_json_mode() {
+            crate::commands::deploy::stream_deploy_json(&client, &app_id, deploy_id)
+        } else {
+            crate::commands::deploy::stream_deploy(&client, &app_id, deploy_id)
+        };
+        match streamed {
+            Ok(_) => return,
+            Err(e) if e.code == "NOT_FOUND" || e.code == "STREAM_ERROR" => {}
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        }
+    }
+
+    let response = match client.get_logs(
+        &app_id,
+        tail,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(deploy_id),
+        Some("preview"),
+        None,
+    ) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview logs retrieved.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "preview": preview_json(&preview),
+                "deploy_id": deploy_id,
+                "logs": output::to_value(&response.logs),
+                "total": response.total,
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    if response.logs.is_empty() {
+        output::info("No logs found for this preview deploy.", None);
+        return;
+    }
+    for entry in response.logs {
+        output::info(&format_log_line(&entry), None);
+    }
+}
+
+fn poll_deploy(client: &FlooClient, app_id: &str, initial: &Deploy) -> Deploy {
+    let started = Instant::now();
+    let mut deploy = initial.clone();
+    while !TERMINAL_STATUSES.contains(&deploy.status.as_deref().unwrap_or("")) {
+        if !output::is_json_mode() {
+            output::info(
+                &format!(
+                    "Deploy {}...",
+                    deploy.status.as_deref().unwrap_or("pending")
+                ),
+                None,
+            );
+        }
+        if started.elapsed() >= POLL_TIMEOUT {
+            output::error(
+                "Preview deploy timed out after 10 minutes.",
+                &ErrorCode::DeployTimeout,
+                Some("The deploy may still complete. Run `floo previews status <preview>`."),
+            );
+            process::exit(1);
+        }
+        thread::sleep(POLL_INTERVAL);
+        deploy = match client.get_deploy(app_id, &deploy.id) {
+            Ok(deploy) => deploy,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        };
+    }
+    deploy
+}
+
+fn emit_preview_command_result(
+    message: &str,
+    app_id: &str,
+    app_name: &str,
+    deploy: &Deploy,
+    preview: Option<&PreviewEnvironment>,
+) {
+    if output::is_json_mode() {
+        output::success(
+            message,
+            Some(serde_json::json!({
+                "app": app_json(app_id, app_name),
+                "preview": preview.map(preview_json).unwrap_or_else(|| serde_json::json!({
+                    "slug": deploy.preview_slug,
+                    "environment_name": "preview",
+                    "source_branch": deploy.source_branch,
+                    "url": deploy.url,
+                })),
+                "source_branch": deploy.source_branch,
+                "deploy_id": deploy.id,
+                "status": deploy.status,
+                "url": deploy.url,
+                "expires_at": preview.and_then(|p| p.expires_at.clone()),
+                "database_branches": preview
+                    .map(|p| output::to_value(&p.database_branches))
+                    .unwrap_or_else(|| serde_json::json!([])),
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    let status = deploy.status.as_deref().unwrap_or("unknown");
+    let slug = deploy.preview_slug.as_deref().unwrap_or("(pending)");
+    output::success(&format!("Preview {slug} is {status}."), None);
+    if let Some(url) = deploy
+        .url
+        .as_deref()
+        .or_else(|| preview.and_then(|p| p.url.as_deref()))
+    {
+        output::info(&format!("URL: {url}"), None);
+    }
+    output::info(
+        &format!("Next: floo previews status {slug} --app {app_name}"),
+        None,
+    );
+}
+
+fn resolve_preview(
+    client: &FlooClient,
+    app_id: &str,
+    app_name: &str,
+    preview_identifier: &str,
+) -> PreviewEnvironment {
+    if let Some(slug) = normalize_preview_identifier(preview_identifier) {
+        if let Ok(preview) = client.get_preview(app_id, &slug) {
+            return preview;
+        }
+    }
+
+    let listing = match client.list_previews(app_id) {
+        Ok(response) => response,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+    let matches: Vec<PreviewEnvironment> = listing
+        .previews
+        .into_iter()
+        .filter(|preview| {
+            preview.slug == preview_identifier
+                || preview.source_branch.as_deref() == Some(preview_identifier)
+                || preview.url.as_deref() == Some(preview_identifier)
+                || preview
+                    .pr_number
+                    .map(|pr| format!("#{pr}") == preview_identifier)
+                    .unwrap_or(false)
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [preview] => preview.clone(),
+        [] => {
+            output::error(
+                &format!("Preview '{preview_identifier}' not found on {app_name}."),
+                &ErrorCode::Other("PREVIEW_NOT_FOUND".to_string()),
+                Some("Pass a preview slug, source branch, preview URL, or unambiguous #PR."),
+            );
+            process::exit(1);
+        }
+        _ => {
+            output::error(
+                &format!("Preview identifier '{preview_identifier}' is ambiguous on {app_name}."),
+                &ErrorCode::Other("AMBIGUOUS_PREVIEW_IDENTIFIER".to_string()),
+                Some("Pass the exact preview slug from `floo previews list`."),
+            );
+            process::exit(1);
+        }
+    }
+}
+
+fn normalize_preview_identifier(identifier: &str) -> Option<String> {
+    let trimmed = identifier.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let host = without_scheme.split('/').next().unwrap_or(without_scheme);
+    if let Some(prefix_start) = host.find("-preview-") {
+        let after_prefix = &host[prefix_start + "-preview-".len()..];
+        let label = after_prefix.split('.').next().unwrap_or(after_prefix);
+        return Some(label.to_string());
+    }
+    if trimmed.contains("://")
+        || trimmed.contains(".")
+        || trimmed.contains('/')
+        || trimmed.starts_with('#')
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn app_json(app_id: &str, app_name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": app_id,
+        "name": app_name,
+    })
+}
+
+fn preview_json(preview: &PreviewEnvironment) -> serde_json::Value {
+    serde_json::json!({
+        "id": preview.id,
+        "slug": preview.slug,
+        "environment_name": "preview",
+        "source_branch": preview.source_branch,
+        "pr_number": preview.pr_number,
+        "url": preview.url,
+        "latest_deploy_id": preview.latest_deploy_id,
+        "latest_deploy_status": preview.latest_deploy_status,
+        "latest_commit_sha": preview.latest_commit_sha,
+        "ttl_hours": preview.ttl_hours,
+        "expires_at": preview.expires_at,
+        "resources": output::to_value(&preview.resources),
+        "database_branches": output::to_value(&preview.database_branches),
+    })
+}
+
+fn render_preview(preview: &PreviewEnvironment) {
+    output::info(
+        &format!(
+            "  Branch:  {}",
+            preview.source_branch.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "  Status:  {}",
+            preview.latest_deploy_status.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+    output::info(
+        &format!("  URL:     {}", preview.url.as_deref().unwrap_or("-")),
+        None,
+    );
+    output::info(
+        &format!(
+            "  Expires: {}",
+            preview.expires_at.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+}
+
+fn format_log_line(entry: &LogEntry) -> String {
+    let ts = entry.timestamp.as_deref().unwrap_or("");
+    let sev = entry.severity.as_deref().unwrap_or("DEFAULT");
+    let msg = entry.message.as_deref().unwrap_or("");
+    let service = entry
+        .service_name
+        .as_deref()
+        .map(|name| format!(" [{name}]"))
+        .unwrap_or_default();
+    format!("{ts}{service} [{sev}] {msg}")
+}
+
+fn preview_api_suggestion(code: &str) -> Option<&'static str> {
+    match code {
+        "PREVIEW_MANAGED_SERVICE_ISOLATION_UNAVAILABLE" => Some(
+            "Preview managed-service isolation could not be provisioned. Fix the attached managed service state, then retry.",
+        ),
+        "INVALID_PREVIEW_BRANCH" => Some("Push a valid remote GitHub branch and pass it with --branch."),
+        _ => None,
+    }
+}

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -253,6 +253,9 @@ fn recommended_permissions() -> (Vec<&'static str>, Vec<&'static str>) {
         "Bash(floo deploys list:*)",
         "Bash(floo deploys logs:*)",
         "Bash(floo deploys watch:*)",
+        "Bash(floo previews list:*)",
+        "Bash(floo previews status:*)",
+        "Bash(floo previews logs:*)",
         "Bash(floo env list:*)",
         "Bash(floo services list:*)",
         "Bash(floo services show:*)",
@@ -274,6 +277,8 @@ fn recommended_permissions() -> (Vec<&'static str>, Vec<&'static str>) {
         "Bash(floo apps password:*)",
         "Bash(floo env get:*)",
         "Bash(floo deploy:*)",
+        "Bash(floo previews up:*)",
+        "Bash(floo previews delete:*)",
         "Bash(floo deploys rollback:*)",
         "Bash(floo init:*)",
         "Bash(floo env set:*)",
@@ -378,6 +383,7 @@ mod tests {
         let (read_only, _) = recommended_permissions();
         assert!(read_only.contains(&"Bash(floo apps list:*)"));
         assert!(read_only.contains(&"Bash(floo logs:*)"));
+        assert!(read_only.contains(&"Bash(floo previews status:*)"));
         assert!(read_only.contains(&"Bash(floo redeploy --dry-run:*)"));
         assert!(read_only.contains(&"Bash(floo docs:*)"));
         // Write commands should not be in read-only
@@ -389,6 +395,7 @@ mod tests {
     fn test_recommended_permissions_read_write() {
         let (_, read_write) = recommended_permissions();
         assert!(read_write.contains(&"Bash(floo deploy:*)"));
+        assert!(read_write.contains(&"Bash(floo previews up:*)"));
         assert!(read_write.contains(&"Bash(floo env set:*)"));
         assert!(read_write.contains(&"Bash(floo apps delete:*)"));
         // Read-only commands should not be in read-write

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -178,6 +178,26 @@ fn preview_detail_json(branches: &str) -> String {
     )
 }
 
+fn preview_deploy_json(status: &str) -> String {
+    format!(
+        r#"{{
+            "id":"deploy-preview-1",
+            "app_id":"{TEST_APP_ID}",
+            "status":"{status}",
+            "runtime":"nodejs",
+            "url":"https://my-app-preview-feat-db-abcde.on.getfloo.com",
+            "build_logs":null,
+            "triggered_by":"manual",
+            "commit_sha":"abc123",
+            "environment_id":"env-preview-1",
+            "environment_name":"preview",
+            "preview_slug":"feat-db-abcde",
+            "source_branch":"feat/db-branch",
+            "created_at":"2026-06-24T10:00:00Z"
+        }}"#
+    )
+}
+
 // ───────────────────────── Apps ─────────────────────────
 
 #[test]
@@ -2340,6 +2360,230 @@ fn test_db_branches_reset_with_yes_calls_preview_scoped_endpoint() {
         .stdout(predicate::str::contains(r#""scope":"preview""#))
         .stdout(predicate::str::contains(r#""database_branch":{"#))
         .stdout(predicate::str::contains("postgresql://").not());
+}
+
+#[test]
+fn test_previews_up_json_sends_preview_deploy_payload_and_returns_single_object() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _deploy = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "environment": "preview",
+            "branch": "feat/db-branch",
+            "runtime": "nodejs",
+            "commit_sha": "abc123",
+            "ref": "refs/heads/feat/db-branch"
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_deploy_json("pending"))
+        .create();
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(""))
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "previews",
+            "up",
+            "--app",
+            TEST_APP_NAME,
+            "--branch",
+            "feat/db-branch",
+            "--runtime",
+            "nodejs",
+            "--commit-sha",
+            "abc123",
+            "--ref",
+            "refs/heads/feat/db-branch",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""deploy_id":"deploy-preview-1""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""source_branch":"feat/db-branch""#,
+        ))
+        .stdout(predicate::str::contains(r#""dev_prod_untouched":true"#));
+
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert_eq!(
+        output.lines().count(),
+        1,
+        "non-streaming JSON must be one object"
+    );
+}
+
+#[test]
+fn test_previews_status_resolves_preview_url_identifier() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(""))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "previews",
+            "status",
+            "https://my-app-preview-feat-db-abcde.on.getfloo.com",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""environment_name":"preview""#))
+        .stdout(predicate::str::contains(
+            r#""deploy_id":"deploy-preview-1""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""url":"https://my-app-preview-feat-db-abcde.on.getfloo.com""#,
+        ));
+}
+
+#[test]
+fn test_previews_delete_uses_preview_teardown_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(""))
+        .create();
+    let _delete = server
+        .mock(
+            "DELETE",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(204)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "previews",
+            "delete",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+            "--yes",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""deleted":true"#))
+        .stdout(predicate::str::contains(r#""scope":"preview""#))
+        .stdout(predicate::str::contains(r#""dev_prod_untouched":true"#));
+}
+
+#[test]
+fn test_previews_logs_reads_latest_preview_deploy_logs() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(""))
+        .create();
+    let _logs = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/logs").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("deployment".into(), "deploy-preview-1".into()),
+            Matcher::UrlEncoded("environment".into(), "preview".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"logs":[{"timestamp":"2026-06-24T10:02:00Z","severity":"INFO","message":"Preview booted","deployment_id":"deploy-preview-1","service_name":"web"}],"total":1,"app_name":"my-app"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "previews",
+            "logs",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#""deploy_id":"deploy-preview-1""#,
+        ))
+        .stdout(predicate::str::contains("Preview booted"));
+}
+
+#[test]
+fn test_previews_up_surfaces_preview_isolation_failure() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _deploy = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/deploys").as_str(),
+        )
+        .with_status(422)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"PREVIEW_MANAGED_SERVICE_ISOLATION_UNAVAILABLE","message":"Preview managed-service isolation is unavailable."}}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "previews",
+            "up",
+            "--app",
+            TEST_APP_NAME,
+            "--branch",
+            "feat/db-branch",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "PREVIEW_MANAGED_SERVICE_ISOLATION_UNAVAILABLE",
+        ))
+        .stdout(predicate::str::contains(
+            "Preview managed-service isolation could not be provisioned",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `floo previews` / `floo preview` commands for `up`, `list`, `status`, `logs`, and `delete`.
- Sends preview deploys through the existing GitHub-sourced deploy route with `environment=preview` and `branch`, then reports stable preview/deploy JSON for agents.
- Pins preview identifier resolution, delete teardown, logs lookup, dry-run safety, agent permissions, and isolation failure surfacing in tests.

## Issue Closure (Required)
Closes getfloo/floo#1327

## Changes
- `src/cli.rs`, `src/commands/previews.rs`: new preview lifecycle command group with JSON/human output and dry-run for mutators.
- `src/api_client.rs`, `src/api_types.rs`: preview deploy/delete client methods and preview-aware deploy fields.
- `src/commands/skills.rs`, `src/commands/command_tree.rs`: agent permission recommendations and command-index regression coverage.
- `tests/mock_api_tests.rs`: mock API coverage for payload shape, identifier resolution, delete behavior, logs, and isolation errors.

## Test Plan
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --test mock_api_tests previews`

## Discovered Issues
None