### PR TITLE
feat: add preview resource branch commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -882,6 +882,46 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn list_preview_managed_resource_branches(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+    ) -> Result<PreviewManagedResourceBranchListResponse, FlooApiError> {
+        let resp = self.get(&format!(
+            "/v1/apps/{app_id}/previews/{preview_slug}/resources"
+        ))?;
+        self.handle_response(resp)
+    }
+
+    pub fn get_preview_managed_resource_branch(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+        resource_key: &str,
+    ) -> Result<PreviewManagedResourceBranch, FlooApiError> {
+        let encoded_resource_key = resource_key.replace(':', "%3A");
+        let resp = self.get(&format!(
+            "/v1/apps/{app_id}/previews/{preview_slug}/resources/{encoded_resource_key}"
+        ))?;
+        self.handle_response(resp)
+    }
+
+    pub fn reset_preview_managed_resource_branch(
+        &self,
+        app_id: &str,
+        preview_slug: &str,
+        resource_key: &str,
+    ) -> Result<PreviewManagedResourceBranch, FlooApiError> {
+        let encoded_resource_key = resource_key.replace(':', "%3A");
+        let resp = self.post_json(
+            &format!(
+                "/v1/apps/{app_id}/previews/{preview_slug}/resources/{encoded_resource_key}/reset"
+            ),
+            &serde_json::json!({}),
+        )?;
+        self.handle_response(resp)
+    }
+
     // --- Preflight ---
 
     pub fn preflight(

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -424,6 +424,38 @@ pub struct PreviewDatabaseBranchListResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewManagedResourceBranch {
+    pub id: String,
+    pub managed_service_id: Option<String>,
+    pub resource_type: String,
+    pub name: String,
+    pub resource_key: String,
+    pub source_environment: String,
+    pub preview_slug: String,
+    pub resource_status: String,
+    pub hydration_mode: String,
+    pub schema_name: Option<String>,
+    pub role_name: Option<String>,
+    pub base_schema_name: Option<String>,
+    pub base_role_name: Option<String>,
+    pub database_id: Option<String>,
+    pub bucket_name: Option<String>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub reset_eligible: bool,
+    pub reset_blocked_reason: Option<String>,
+    #[serde(default)]
+    pub dev_prod_untouched: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreviewManagedResourceBranchListResponse {
+    pub resources: Vec<PreviewManagedResourceBranch>,
+    pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PreviewResource {
     pub id: String,
     #[serde(rename = "type")]
@@ -451,6 +483,8 @@ pub struct PreviewEnvironment {
     pub resources: Vec<PreviewResource>,
     #[serde(default)]
     pub database_branches: Vec<PreviewDatabaseBranch>,
+    #[serde(default)]
+    pub managed_resource_branches: Vec<PreviewManagedResourceBranch>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1305,6 +1305,70 @@ pub enum PreviewsSubcommands {
         #[arg(long, alias = "force")]
         yes: bool,
     },
+
+    /// Inspect and reset preview managed-resource branches.
+    #[command(subcommand)]
+    Resources(PreviewResourcesSubcommands),
+}
+
+#[derive(Subcommand)]
+pub enum PreviewResourcesSubcommands {
+    /// List preview-owned Postgres, Redis, and Storage branches.
+    #[command(after_help = "\
+Examples:
+  floo previews resources list feat-db-abcde --app my-app
+  floo previews resources list feat-db-abcde --app my-app --json")]
+    List {
+        /// Preview slug, source branch, preview URL, or unambiguous #PR.
+        preview: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Show one preview managed-resource branch.
+    #[command(after_help = "\
+Examples:
+  floo previews resources show feat-db-abcde --app my-app --resource redis:default
+  floo previews resources show feat-db-abcde --app my-app --resource storage:uploads --json")]
+    Show {
+        /// Preview slug, source branch, preview URL, or unambiguous #PR.
+        preview: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Resource key, shaped type:name, e.g. postgres:default or redis:cache.
+        #[arg(long)]
+        resource: String,
+    },
+
+    /// Reset one preview managed-resource branch.
+    #[command(after_help = "\
+Examples:
+  floo previews resources reset feat-db-abcde --app my-app --resource postgres:default --yes
+  floo previews resources reset feat-db-abcde --app my-app --resource redis:cache --dry-run --json
+
+Reset is preview-scoped. Dev and prod resources are not touched. Providers that
+do not yet support reset fail closed with the API's named reset blocker.")]
+    Reset {
+        /// Preview slug, source branch, preview URL, or unambiguous #PR.
+        preview: String,
+
+        /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Resource key, shaped type:name, e.g. postgres:default or storage:uploads.
+        #[arg(long)]
+        resource: String,
+
+        /// Skip the y/N prompt. Required in non-interactive contexts.
+        #[arg(long, alias = "force")]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1721,6 +1785,7 @@ const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
     "db migrate",
     "db query",
     "db branches reset",
+    "previews resources reset",
 ];
 
 fn reject_unsupported_dry_run(command: &Commands) {
@@ -1928,6 +1993,22 @@ pub fn run() {
             PreviewsSubcommands::Delete { preview, app, yes } => {
                 commands::previews::delete(app.as_deref(), &preview, yes)
             }
+            PreviewsSubcommands::Resources(sub) => match sub {
+                PreviewResourcesSubcommands::List { preview, app } => {
+                    commands::previews::resources_list(app.as_deref(), &preview)
+                }
+                PreviewResourcesSubcommands::Show {
+                    preview,
+                    app,
+                    resource,
+                } => commands::previews::resources_show(app.as_deref(), &preview, &resource),
+                PreviewResourcesSubcommands::Reset {
+                    preview,
+                    app,
+                    resource,
+                    yes,
+                } => commands::previews::resources_reset(app.as_deref(), &preview, &resource, yes),
+            },
         },
         Commands::Auth(sub) => match sub {
             AuthCommands::Login { api_key, force } => {
@@ -2448,6 +2529,21 @@ mod tests {
                     "feat-db-abcde",
                     "--app",
                     "myapp",
+                    "--dry-run",
+                ],
+            ),
+            (
+                "previews resources reset",
+                &[
+                    "floo",
+                    "previews",
+                    "resources",
+                    "reset",
+                    "feat-db-abcde",
+                    "--app",
+                    "myapp",
+                    "--resource",
+                    "postgres:default",
                     "--dry-run",
                 ],
             ),

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -368,6 +368,7 @@ Non-streaming commands print one JSON object. Automation can rely on:
   url
   expires_at
   database_branches
+  managed_resource_branches
   dev_prod_untouched: true
 
 `up --wait` watches the deploy returned by the create call and exits non-zero
@@ -380,6 +381,16 @@ previews. floo-managed Postgres, Redis, and Storage get preview-owned
 resources. If isolation cannot be provisioned, the command surfaces
 PREVIEW_MANAGED_SERVICE_ISOLATION_UNAVAILABLE instead of falling back to dev
 or prod credentials.
+
+Preview managed-resource branches are visible through one command group:
+
+  floo previews resources list <preview> --app <name>
+  floo previews resources show <preview> --app <name> --resource redis:default
+  floo previews resources reset <preview> --app <name> --resource postgres:default --yes
+
+The resource key is shaped `type:name`, for example `postgres:default`,
+`redis:cache`, or `storage:uploads`. Reset is preview-scoped and fails closed
+with the API's named blocker when a provider cannot reset that resource yet.
 
 `floo previews delete` tears down preview-owned Cloud Run services, managed
 resources, gateway routes, and env vars. Dev and prod are untouched.
@@ -1960,6 +1971,8 @@ mod tests {
         assert!(PREVIEWS.contains("floo previews up"));
         assert!(PREVIEWS.contains("remote GitHub source only"));
         assert!(PREVIEWS.contains("dev_prod_untouched: true"));
+        assert!(PREVIEWS.contains("managed_resource_branches"));
+        assert!(PREVIEWS.contains("floo previews resources list"));
         assert!(PREVIEWS.contains("PREVIEW_MANAGED_SERVICE_ISOLATION_UNAVAILABLE"));
         assert!(PREVIEWS.contains("floo previews delete"));
         assert!(PREVIEWS.contains("getfloo.com/docs/cli/previews"));

--- a/src/commands/previews.rs
+++ b/src/commands/previews.rs
@@ -3,7 +3,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::api_client::FlooClient;
-use crate::api_types::{CreatePreviewDeployRequest, Deploy, LogEntry, PreviewEnvironment};
+use crate::api_types::{
+    CreatePreviewDeployRequest, Deploy, LogEntry, PreviewEnvironment, PreviewManagedResourceBranch,
+};
 use crate::errors::ErrorCode;
 use crate::output;
 
@@ -272,6 +274,189 @@ pub fn delete(app_flag: Option<&str>, preview_identifier: &str, yes: bool) {
     }
 }
 
+pub fn resources_list(app_flag: Option<&str>, preview_identifier: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview = resolve_preview(&client, &app_id, &app_name, preview_identifier);
+    let listing = match client.list_preview_managed_resource_branches(&app_id, &preview.slug) {
+        Ok(listing) => listing,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview managed-resource branches retrieved.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "preview": preview_json(&preview),
+                "managed_resource_branches": output::to_value(&listing.resources),
+                "total": listing.total,
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    output::info(
+        &format!(
+            "Preview managed-resource branches for {app_name} (preview: {}):",
+            preview.slug
+        ),
+        None,
+    );
+    render_preview(&preview);
+    if listing.resources.is_empty() {
+        output::info(
+            "No preview managed-resource branches. This preview has no floo-managed service attachments.",
+            None,
+        );
+        return;
+    }
+    render_resource_table(&listing.resources);
+}
+
+pub fn resources_show(app_flag: Option<&str>, preview_identifier: &str, resource_key: &str) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview = resolve_preview(&client, &app_id, &app_name, preview_identifier);
+    let branch =
+        match client.get_preview_managed_resource_branch(&app_id, &preview.slug, resource_key) {
+            Ok(branch) => branch,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        };
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview managed-resource branch retrieved.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "preview": preview_json(&preview),
+                "managed_resource_branch": output::to_value(&branch),
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    output::info(
+        &format!(
+            "Preview managed-resource branch {} for {app_name} (preview: {}):",
+            branch.resource_key, preview.slug
+        ),
+        None,
+    );
+    render_resource_detail(&branch);
+}
+
+pub fn resources_reset(
+    app_flag: Option<&str>,
+    preview_identifier: &str,
+    resource_key: &str,
+    yes: bool,
+) {
+    use crate::confirm::{confirm_tier2, ConfirmOutcome, RiskMetadata, Tier};
+
+    if output::is_dry_run_mode() {
+        let risk: RiskMetadata = Tier::Two.into();
+        let preview = normalize_preview_identifier(preview_identifier)
+            .unwrap_or_else(|| preview_identifier.trim().to_string());
+        output::dry_run_preview(
+            &format!(
+                "Would reset preview managed-resource branch '{resource_key}' on preview '{preview}'. Dev and prod are untouched."
+            ),
+            serde_json::json!({
+                "action": "preview_managed_resource_branch_reset",
+                "app": app_flag,
+                "preview": preview,
+                "resource_key": resource_key,
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+                "scope": "preview",
+                "dev_prod_untouched": true,
+            }),
+        );
+        return;
+    }
+
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    let preview = resolve_preview(&client, &app_id, &app_name, preview_identifier);
+
+    match confirm_tier2(
+        "Reset preview managed-resource branch",
+        &format!(
+            "{resource_key} on {app_name}/{} (dev/prod untouched)",
+            preview.slug
+        ),
+        yes,
+    ) {
+        ConfirmOutcome::Proceed => {}
+        ConfirmOutcome::Aborted => {
+            if output::is_json_mode() {
+                output::success("Cancelled.", Some(serde_json::json!({"cancelled": true})));
+            } else {
+                output::info("Cancelled.", None);
+            }
+            process::exit(0);
+        }
+        ConfirmOutcome::Refused { suggestion } => {
+            crate::confirm::exit_refused(
+                &format!(
+                    "Refusing to reset preview managed-resource branch '{resource_key}' on {app_name}/{} without explicit confirmation; dev/prod untouched.",
+                    preview.slug
+                ),
+                &suggestion,
+            );
+        }
+    }
+
+    let branch =
+        match client.reset_preview_managed_resource_branch(&app_id, &preview.slug, resource_key) {
+            Ok(branch) => branch,
+            Err(e) => {
+                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                process::exit(1);
+            }
+        };
+    let risk: RiskMetadata = Tier::Two.into();
+
+    if output::is_json_mode() {
+        output::success(
+            "Preview managed-resource branch reset.",
+            Some(serde_json::json!({
+                "app": app_json(&app_id, &app_name),
+                "preview": preview_json(&preview),
+                "managed_resource_branch": output::to_value(&branch),
+                "destructive": risk.destructive,
+                "data_loss": risk.data_loss,
+                "tier": risk.tier,
+                "scope": "preview",
+                "dev_prod_untouched": true,
+            })),
+        );
+        return;
+    }
+
+    output::success(
+        &format!(
+            "Reset preview managed-resource branch {resource_key} for {app_name}/{}. Dev and prod were untouched.",
+            preview.slug
+        ),
+        None,
+    );
+    render_resource_detail(&branch);
+}
+
 pub fn logs(app_flag: Option<&str>, preview_identifier: &str, follow: bool, tail: u32) {
     super::require_auth();
     let client = super::init_client(None);
@@ -527,6 +712,7 @@ fn preview_json(preview: &PreviewEnvironment) -> serde_json::Value {
         "expires_at": preview.expires_at,
         "resources": output::to_value(&preview.resources),
         "database_branches": output::to_value(&preview.database_branches),
+        "managed_resource_branches": output::to_value(&preview.managed_resource_branches),
     })
 }
 
@@ -568,6 +754,82 @@ fn format_log_line(entry: &LogEntry) -> String {
         .map(|name| format!(" [{name}]"))
         .unwrap_or_default();
     format!("{ts}{service} [{sev}] {msg}")
+}
+
+fn render_resource_table(branches: &[PreviewManagedResourceBranch]) {
+    let rows: Vec<Vec<String>> = branches
+        .iter()
+        .map(|branch| {
+            vec![
+                branch.resource_key.clone(),
+                branch.resource_type.clone(),
+                branch.source_environment.clone(),
+                branch.resource_status.clone(),
+                branch.hydration_mode.clone(),
+                provider_identity(branch).unwrap_or_else(|| "-".to_string()),
+                branch.expires_at.clone().unwrap_or_else(|| "-".to_string()),
+                reset_status(branch),
+            ]
+        })
+        .collect();
+    output::table(
+        &[
+            "Resource",
+            "Type",
+            "Source",
+            "Status",
+            "Hydration",
+            "Provider ID",
+            "Expires",
+            "Reset",
+        ],
+        &rows,
+        None,
+    );
+}
+
+fn render_resource_detail(branch: &PreviewManagedResourceBranch) {
+    output::info(&format!("  Resource:  {}", branch.resource_key), None);
+    output::info(&format!("  Type:      {}", branch.resource_type), None);
+    output::info(&format!("  Preview:   {}", branch.preview_slug), None);
+    output::info(&format!("  Source:    {}", branch.source_environment), None);
+    output::info(&format!("  Status:    {}", branch.resource_status), None);
+    output::info(&format!("  Hydration: {}", branch.hydration_mode), None);
+    output::info(
+        &format!(
+            "  Provider:  {}",
+            provider_identity(branch).unwrap_or_else(|| "-".to_string())
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "  Expires:   {}",
+            branch.expires_at.as_deref().unwrap_or("-")
+        ),
+        None,
+    );
+    output::info(&format!("  Reset:     {}", reset_status(branch)), None);
+    output::info("  Dev/prod:  untouched", None);
+}
+
+fn provider_identity(branch: &PreviewManagedResourceBranch) -> Option<String> {
+    branch
+        .schema_name
+        .clone()
+        .or_else(|| branch.database_id.clone())
+        .or_else(|| branch.bucket_name.clone())
+}
+
+fn reset_status(branch: &PreviewManagedResourceBranch) -> String {
+    if branch.reset_eligible {
+        "eligible".to_string()
+    } else {
+        branch
+            .reset_blocked_reason
+            .clone()
+            .unwrap_or_else(|| "blocked".to_string())
+    }
 }
 
 fn preview_api_suggestion(code: &str) -> Option<&'static str> {

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -256,6 +256,8 @@ fn recommended_permissions() -> (Vec<&'static str>, Vec<&'static str>) {
         "Bash(floo previews list:*)",
         "Bash(floo previews status:*)",
         "Bash(floo previews logs:*)",
+        "Bash(floo previews resources list:*)",
+        "Bash(floo previews resources show:*)",
         "Bash(floo env list:*)",
         "Bash(floo services list:*)",
         "Bash(floo services show:*)",
@@ -279,6 +281,7 @@ fn recommended_permissions() -> (Vec<&'static str>, Vec<&'static str>) {
         "Bash(floo deploy:*)",
         "Bash(floo previews up:*)",
         "Bash(floo previews delete:*)",
+        "Bash(floo previews resources reset:*)",
         "Bash(floo deploys rollback:*)",
         "Bash(floo init:*)",
         "Bash(floo env set:*)",
@@ -384,6 +387,8 @@ mod tests {
         assert!(read_only.contains(&"Bash(floo apps list:*)"));
         assert!(read_only.contains(&"Bash(floo logs:*)"));
         assert!(read_only.contains(&"Bash(floo previews status:*)"));
+        assert!(read_only.contains(&"Bash(floo previews resources list:*)"));
+        assert!(read_only.contains(&"Bash(floo previews resources show:*)"));
         assert!(read_only.contains(&"Bash(floo redeploy --dry-run:*)"));
         assert!(read_only.contains(&"Bash(floo docs:*)"));
         // Write commands should not be in read-only
@@ -396,6 +401,7 @@ mod tests {
         let (_, read_write) = recommended_permissions();
         assert!(read_write.contains(&"Bash(floo deploy:*)"));
         assert!(read_write.contains(&"Bash(floo previews up:*)"));
+        assert!(read_write.contains(&"Bash(floo previews resources reset:*)"));
         assert!(read_write.contains(&"Bash(floo env set:*)"));
         assert!(read_write.contains(&"Bash(floo apps delete:*)"));
         // Read-only commands should not be in read-write

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -140,7 +140,9 @@ fn preview_branch_json(name: &str, status: &str, reset_eligible: bool) -> String
         r#"{{
             "id":"resource-{name}",
             "managed_service_id":"ms-{name}",
+            "resource_type":"postgres",
             "name":"{name}",
+            "resource_key":"postgres:{name}",
             "source_environment":"dev",
             "preview_slug":"feat-db-abcde",
             "resource_status":"{status}",
@@ -149,11 +151,47 @@ fn preview_branch_json(name: &str, status: &str, reset_eligible: bool) -> String
             "role_name":"floo_app_default_preview_feat_db_abcde",
             "base_schema_name":"app_default_dev",
             "base_role_name":"floo_app_default_dev",
+            "database_id":null,
+            "bucket_name":null,
             "created_at":"2026-06-24T10:00:00Z",
             "updated_at":"2026-06-24T10:01:00Z",
             "expires_at":"2026-06-27T10:00:00Z",
             "reset_eligible":{reset_eligible},
-            "reset_blocked_reason":{blocked}
+            "reset_blocked_reason":{blocked},
+            "dev_prod_untouched":true
+        }}"#
+    )
+}
+
+fn preview_redis_branch_json(name: &str, status: &str, reset_eligible: bool) -> String {
+    let blocked = if reset_eligible {
+        "null".to_string()
+    } else {
+        r#""Preview Redis reset is not implemented.""#.to_string()
+    };
+    format!(
+        r#"{{
+            "id":"redis-resource-{name}",
+            "managed_service_id":"redis-ms-{name}",
+            "resource_type":"redis",
+            "name":"{name}",
+            "resource_key":"redis:{name}",
+            "source_environment":"dev",
+            "preview_slug":"feat-db-abcde",
+            "resource_status":"{status}",
+            "hydration_mode":"clone-dev",
+            "schema_name":null,
+            "role_name":null,
+            "base_schema_name":null,
+            "base_role_name":null,
+            "database_id":"preview-redis-{name}",
+            "bucket_name":null,
+            "created_at":"2026-06-24T10:00:00Z",
+            "updated_at":"2026-06-24T10:01:00Z",
+            "expires_at":"2026-06-27T10:00:00Z",
+            "reset_eligible":{reset_eligible},
+            "reset_blocked_reason":{blocked},
+            "dev_prod_untouched":true
         }}"#
     )
 }
@@ -173,7 +211,8 @@ fn preview_detail_json(branches: &str) -> String {
             "ttl_hours":72,
             "expires_at":"2026-06-27T10:00:00Z",
             "resources":[],
-            "database_branches":[{branches}]
+            "database_branches":[{branches}],
+            "managed_resource_branches":[{branches}]
         }}"#
     )
 }
@@ -2360,6 +2399,129 @@ fn test_db_branches_reset_with_yes_calls_preview_scoped_endpoint() {
         .stdout(predicate::str::contains(r#""scope":"preview""#))
         .stdout(predicate::str::contains(r#""database_branch":{"#))
         .stdout(predicate::str::contains("postgresql://").not());
+}
+
+#[test]
+fn test_preview_resources_list_json_returns_all_managed_resource_branches() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let postgres = preview_branch_json("default", "ready", true);
+    let redis = preview_redis_branch_json("cache", "ready", false);
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(&format!("{postgres},{redis}")))
+        .create();
+    let _resources = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde/resources").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"resources":[{postgres},{redis}],"total":2}}"#))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "previews",
+            "resources",
+            "list",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("managed_resource_branches"))
+        .stdout(predicate::str::contains(
+            r#""resource_key":"postgres:default""#,
+        ))
+        .stdout(predicate::str::contains(r#""resource_key":"redis:cache""#))
+        .stdout(predicate::str::contains(
+            r#""database_id":"preview-redis-cache""#,
+        ))
+        .stdout(predicate::str::contains("postgresql://").not())
+        .stdout(predicate::str::contains("password").not());
+}
+
+#[test]
+fn test_preview_resources_reset_dry_run_and_yes_use_generic_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    floo()
+        .args([
+            "--json",
+            "--dry-run",
+            "previews",
+            "resources",
+            "reset",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+            "--resource",
+            "redis:cache",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "preview_managed_resource_branch_reset",
+        ))
+        .stdout(predicate::str::contains(r#""resource_key":"redis:cache""#))
+        .stdout(predicate::str::contains(r#""dev_prod_untouched":true"#));
+
+    let _reset = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde/resources/redis%3Acache/reset")
+                .as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_redis_branch_json("cache", "ready", true))
+        .create();
+    let _preview = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/previews/feat-db-abcde").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(preview_detail_json(&preview_redis_branch_json(
+            "cache", "ready", true,
+        )))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "previews",
+            "resources",
+            "reset",
+            "feat-db-abcde",
+            "--app",
+            TEST_APP_NAME,
+            "--resource",
+            "redis:cache",
+            "--yes",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(r#""resource_key":"redis:cache""#))
+        .stdout(predicate::str::contains(r#""scope":"preview""#))
+        .stdout(predicate::str::contains(r#""dev_prod_untouched":true"#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `floo previews resources list/show/reset` for preview managed-resource branches across Postgres, Redis, and Storage
- add typed API client/response models for the generic `/previews/{slug}/resources` contract
- update `floo docs previews` and agent skill permissions for the new commands

Closes getfloo/floo#1336
Parent getfloo/floo#1331
Depends on getfloo/floo#1338 / getfloo/floo#1332

## Tests
- `cargo fmt`
- `cargo check`
- `cargo test`