### PR TITLE
fix(cli): treat cancelled as a terminal, non-failure deploy status

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -20,7 +20,7 @@ use crate::resolve::resolve_app;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
-pub(crate) const TERMINAL_STATUSES: &[&str] = &["live", "failed", "superseded"];
+pub(crate) const TERMINAL_STATUSES: &[&str] = &["live", "failed", "superseded", "cancelled"];
 
 #[derive(Debug, Serialize)]
 struct EnvInjectionPlan {
@@ -1056,6 +1056,18 @@ pub fn deploy(
         return;
     }
 
+    if final_status == "cancelled" {
+        output::success(
+            "Deploy cancelled: its target environment was removed before it ran.",
+            Some(serde_json::json!({
+                "app": output::to_value(&app_data),
+                "deploy": output::to_value(&deploy_data),
+                "detection": detection.to_value(),
+            })),
+        );
+        return;
+    }
+
     let url = deploy_data.url.as_deref().unwrap_or("");
 
     if !output::is_json_mode() {
@@ -1216,6 +1228,17 @@ fn deploy_restart(
         return;
     }
 
+    if final_status == "cancelled" {
+        output::success(
+            "Restart cancelled: its target environment was removed before it ran.",
+            Some(serde_json::json!({
+                "app": output::to_value(app_data),
+                "deploy": output::to_value(&deploy_data),
+            })),
+        );
+        return;
+    }
+
     let env_display = deploy_data
         .environment_name
         .as_deref()
@@ -1347,6 +1370,17 @@ fn deploy_rebuild(
     if final_status == "superseded" {
         output::success(
             "Rebuild superseded by a newer deploy.",
+            Some(serde_json::json!({
+                "app": output::to_value(app_data),
+                "deploy": output::to_value(&deploy_data),
+            })),
+        );
+        return;
+    }
+
+    if final_status == "cancelled" {
+        output::success(
+            "Rebuild cancelled: its target environment was removed before it ran.",
             Some(serde_json::json!({
                 "app": output::to_value(app_data),
                 "deploy": output::to_value(&deploy_data),

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -659,7 +659,9 @@ fn colored_status(status: &str) -> String {
     match status {
         "live" => status.green().bold().to_string(),
         "failed" => status.red().bold().to_string(),
-        "superseded" => status.dimmed().to_string(),
+        // superseded (a newer deploy replaced this) and cancelled (target env torn
+        // down before the deploy ran) are both moot terminals — dimmed, not error.
+        "superseded" | "cancelled" => status.dimmed().to_string(),
         "building" | "deploying" | "pending" => status.yellow().to_string(),
         _ => status.to_string(),
     }
@@ -871,6 +873,13 @@ fn print_final_status(deploy: &Deploy) {
                 "deploy": output::to_value(deploy),
             })),
         );
+    } else if status == "cancelled" {
+        output::success(
+            "Deploy cancelled: its target environment was removed before it ran.",
+            Some(serde_json::json!({
+                "deploy": output::to_value(deploy),
+            })),
+        );
     } else if !TERMINAL_STATUSES.contains(&status) {
         output::error(
             &format!("Deploy ended in unexpected state: {status}"),
@@ -953,6 +962,15 @@ mod tests {
         assert!(TERMINAL_STATUSES.contains(&"superseded"));
         assert!(TERMINAL_STATUSES.contains(&"live"));
         assert!(TERMINAL_STATUSES.contains(&"failed"));
+    }
+
+    #[test]
+    fn test_cancelled_is_terminal_status() {
+        // TERMINAL_STATUSES must include "cancelled" so poll/stream loops exit when
+        // the platform cancels a deploy — a PR-preview env torn down before the deploy
+        // could run terminates as "cancelled" (getfloo/floo#1354). Without it,
+        // `floo deploys watch` on a cancelled deploy would spin for POLL_TIMEOUT (10 min).
+        assert!(TERMINAL_STATUSES.contains(&"cancelled"));
     }
 
     #[test]

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -441,8 +441,15 @@ pub fn set(
             process::exit(1);
         }
 
+        // cancelled = the target env was torn down before the restart ran: a moot
+        // terminal (not a failure — exit 0), but don't claim it "Restarted".
+        let restart_msg = if final_status == "cancelled" {
+            "Restart cancelled: its target environment was removed before it ran.".to_string()
+        } else {
+            format!("Restarted {url}")
+        };
         output::success(
-            &format!("Restarted {url}"),
+            &restart_msg,
             Some(serde_json::json!({"env": last_env_result, "deploy": deploy_data})),
         );
     }

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -264,6 +264,23 @@ pub fn connect(
                 })),
             );
         }
+        DeployOutcome::Cancelled { deploy } => {
+            output::success(
+                &format!(
+                    "Connected {name} to {repo}, but the deploy was cancelled \
+                     (its target environment was removed before it ran)."
+                ),
+                Some(serde_json::json!({
+                    "connected": true,
+                    "app": name,
+                    "repo": repo,
+                    "branch": connected_branch,
+                    "deployed": false,
+                    "deploy_status": "cancelled",
+                    "deploy": deploy,
+                })),
+            );
+        }
         DeployOutcome::Failed { deploy } => {
             output::error_with_data(
                 &format!("Connected {name} to {repo} but deploy failed."),
@@ -659,6 +676,9 @@ enum DeployOutcome {
     Superseded {
         deploy: serde_json::Value,
     },
+    Cancelled {
+        deploy: serde_json::Value,
+    },
     Failed {
         deploy: serde_json::Value,
     },
@@ -736,8 +756,14 @@ fn run_initial_deploy(
         DeployOutcome::Superseded {
             deploy: output::to_value(&deploy_data),
         }
+    } else if final_status == "cancelled" {
+        // Target env torn down before the deploy ran (getfloo/floo#1354) — a moot
+        // terminal like superseded, NOT a failure. Must not exit 1 / say "retry".
+        DeployOutcome::Cancelled {
+            deploy: output::to_value(&deploy_data),
+        }
     } else {
-        // Ambiguous status (timeout, cancelled, unknown) — report as failed
+        // Ambiguous status (timeout, unknown) — report as failed
         output::warn(&format!(
             "Deploy ended with unexpected status: {}",
             final_status

--- a/src/commands/previews.rs
+++ b/src/commands/previews.rs
@@ -13,6 +13,14 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600);
 const TERMINAL_STATUSES: &[&str] = &["live", "failed", "cancelled", "superseded"];
 
+/// Under `--wait`, only a genuinely FAILED preview deploy is a non-zero exit.
+/// `cancelled` (the target env was torn down before the deploy ran — the surface
+/// this status originates from, getfloo/floo#1354) and `superseded` are benign
+/// terminals: they exit 0, matching every other deploy-completion site in the CLI.
+fn preview_wait_is_failure(status: Option<&str>) -> bool {
+    status == Some("failed")
+}
+
 pub fn up(
     app_flag: Option<&str>,
     branch: &str,
@@ -97,7 +105,7 @@ pub fn up(
         preview.as_ref(),
     );
 
-    if wait && deploy.status.as_deref() != Some("live") {
+    if wait && preview_wait_is_failure(deploy.status.as_deref()) {
         process::exit(1);
     }
 }
@@ -839,5 +847,23 @@ fn preview_api_suggestion(code: &str) -> Option<&'static str> {
         ),
         "INVALID_PREVIEW_BRANCH" => Some("Push a valid remote GitHub branch and pass it with --branch."),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preview_wait_only_failed_exits_nonzero() {
+        // Under `floo previews up --wait`, only a FAILED preview deploy is a
+        // non-zero exit. cancelled (target env torn down before the deploy ran —
+        // getfloo/floo#1354) and superseded are benign terminals → exit 0, matching
+        // every other deploy-completion site.
+        assert!(preview_wait_is_failure(Some("failed")));
+        assert!(!preview_wait_is_failure(Some("cancelled")));
+        assert!(!preview_wait_is_failure(Some("superseded")));
+        assert!(!preview_wait_is_failure(Some("live")));
+        assert!(!preview_wait_is_failure(None));
     }
 }


### PR DESCRIPTION
## What changed

The floo API now emits a terminal `cancelled` deploy status for a preview deploy whose target environment was torn down before it could run (a PR-preview env whose PR closed/merged — getfloo/floo#1354). This teaches the CLI to handle it end-to-end as a **benign, non-failure terminal** (like `superseded`):

- `TERMINAL_STATUSES` gains `"cancelled"` so `floo deploys watch`/poll loops exit cleanly instead of spinning to the 10-minute timeout.
- Every deploy-completion site that classifies a terminal status now treats `cancelled` as a non-failure (exit 0, clear message), not a success-with-URL or a failure:
  - `deploy` / `redeploy` / `rebuild` and `deploys watch` — dedicated `cancelled` branch before the generic success path.
  - `apps github connect` initial deploy — new `DeployOutcome::Cancelled` variant (previously folded `cancelled` into `Failed` → **exit 1 + "run redeploy"**).
  - `previews up --wait` — previously exited 1 for anything but `live`, so a `cancelled` preview deploy (the surface this status originates from) was reported as a failure. Now only `failed` exits non-zero; this also fixes `superseded` being misreported here.
  - `env` restart — clear "cancelled" message instead of "Restarted {url}".
- Rendered dimmed (a moot terminal), like `superseded`.

## Why

Pairs with getfloo/floo#1354, which stopped false-alarm "preview deploy failed" emails by making the torn-down-env deploy terminate `cancelled` instead of `FAILED`. Without this the CLI would either hang (`deploys watch` never sees a terminal status) or actively mislead — reporting a cancelled deploy as a failure with a "run redeploy" suggestion, on the very `previews`/`github connect` surfaces where `cancelled` shows up.

## Risk tier

**sensitive** — touches `src/commands/deploy.rs` (`TERMINAL_STATUSES`). Reviewed: Claude + Codex on the diff across 4 rounds (each surfaced a real terminal-classification gap: `github connect` then `previews up --wait`), final round clean.

## Tests

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` — all green (457 lib + integration). New regression tests: `test_cancelled_is_terminal_status` (deploys.rs) and `test_preview_wait_only_failed_exits_nonzero` (previews.rs).

## Known non-goals / follow-up

- The CLI hand-rolls terminal-status classification at several sites (each enumerating `failed`/`live`/`superseded`/`cancelled` independently). A single shared "is this deploy status a failure?" classifier would prevent this class of gap when a new status is added — a worthwhile substrate refactor, but out of scope for this fast-follow.
