### PR TITLE
refactor(cli): centralize deploy-status classification in one module

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use crate::api_client::FlooClient;
 use crate::api_types::Deploy;
 use crate::config::load_config;
+use crate::deploy_status;
 use crate::detection::{detect_for_services, DetectionResult};
 use crate::errors::{ErrorCode, FlooApiError};
 use crate::output;
@@ -20,7 +21,6 @@ use crate::resolve::resolve_app;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
-pub(crate) const TERMINAL_STATUSES: &[&str] = &["live", "failed", "superseded", "cancelled"];
 
 #[derive(Debug, Serialize)]
 struct EnvInjectionPlan {
@@ -995,7 +995,7 @@ pub fn deploy(
     // Wait for deploy to complete via SSE streaming or polling
     let initial_status = deploy_data.status.as_deref().unwrap_or("");
 
-    if TERMINAL_STATUSES.contains(&initial_status) {
+    if deploy_status::is_terminal(initial_status) {
         // Phase 1: deploy already complete synchronously, skip streaming/polling
     } else if !output::is_json_mode() {
         // Phase 2 human mode: try SSE streaming, fall back to polling
@@ -1022,7 +1022,7 @@ pub fn deploy(
 
     let final_status = deploy_data.status.as_deref().unwrap_or("");
 
-    if final_status == "failed" {
+    if deploy_status::is_failure(final_status) {
         let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
         if !output::is_json_mode() && !build_logs.is_empty() && build_logs != "[no message content]"
         {
@@ -1180,7 +1180,7 @@ fn deploy_restart(
     };
 
     let initial_status = deploy_data.status.as_deref().unwrap_or("");
-    if !TERMINAL_STATUSES.contains(&initial_status) {
+    if !deploy_status::is_terminal(initial_status) {
         let deploy_id = deploy_data.id.clone();
         deploy_data = if !output::is_json_mode() {
             match stream_deploy(client, app_id, &deploy_id) {
@@ -1204,7 +1204,7 @@ fn deploy_restart(
     let final_status = deploy_data.status.as_deref().unwrap_or("");
     let url = deploy_data.url.as_deref().unwrap_or("(no URL)");
 
-    if final_status == "failed" {
+    if deploy_status::is_failure(final_status) {
         output::error_with_data(
             "Restart failed.",
             &ErrorCode::RestartFailed,
@@ -1321,7 +1321,7 @@ fn deploy_rebuild(
     // Wait for deploy to complete via SSE streaming or polling
     let initial_status = deploy_data.status.as_deref().unwrap_or("");
 
-    if TERMINAL_STATUSES.contains(&initial_status) {
+    if deploy_status::is_terminal(initial_status) {
         // Already complete
     } else if !output::is_json_mode() {
         let deploy_id = deploy_data.id.clone();
@@ -1345,7 +1345,7 @@ fn deploy_rebuild(
 
     let final_status = deploy_data.status.as_deref().unwrap_or("");
 
-    if final_status == "failed" {
+    if deploy_status::is_failure(final_status) {
         let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
         if !output::is_json_mode() && !build_logs.is_empty() && build_logs != "[no message content]"
         {
@@ -2652,7 +2652,7 @@ pub(crate) fn poll_deploy(client: &FlooClient, app_id: &str, initial_data: &Depl
     let mut last_log_len: usize = 0;
     let mut deploy_data = initial_data.clone();
 
-    while !TERMINAL_STATUSES.contains(&deploy_data.status.as_deref().unwrap_or("")) {
+    while !deploy_status::is_terminal(deploy_data.status.as_deref().unwrap_or("")) {
         if !output::is_json_mode() {
             let build_logs = deploy_data.build_logs.as_deref().unwrap_or("");
             if build_logs.len() > last_log_len {

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -7,7 +7,8 @@ use colored::Colorize;
 
 use crate::api_client::FlooClient;
 use crate::api_types::Deploy;
-use crate::commands::deploy::{poll_deploy, stream_deploy, stream_deploy_json, TERMINAL_STATUSES};
+use crate::commands::deploy::{poll_deploy, stream_deploy, stream_deploy_json};
+use crate::deploy_status;
 use crate::errors::ErrorCode;
 use crate::output;
 
@@ -404,7 +405,7 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
     };
 
     let status = deploy.status.as_deref().unwrap_or("unknown");
-    let is_terminal = TERMINAL_STATUSES.contains(&status);
+    let is_terminal = deploy_status::is_terminal(status);
 
     // JSON mode
     if output::is_json_mode() {
@@ -413,7 +414,7 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
             match stream_deploy_json(&client, &app_id, &deploy.id) {
                 Ok(d) => {
                     let final_status = d.status.as_deref().unwrap_or("unknown");
-                    if final_status == "failed" {
+                    if deploy_status::is_failure(final_status) {
                         process::exit(1);
                     }
                     return;
@@ -425,7 +426,8 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
                         e.code
                     );
                     let final_deploy = poll_deploy(&client, &app_id, &deploy);
-                    let is_failed = final_deploy.status.as_deref() == Some("failed");
+                    let is_failed =
+                        deploy_status::is_failure(final_deploy.status.as_deref().unwrap_or(""));
                     output::success(
                         "Deploy logs retrieved.",
                         Some(serde_json::json!({
@@ -441,7 +443,7 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
                 }
             }
         }
-        let is_failed = deploy.status.as_deref() == Some("failed");
+        let is_failed = deploy_status::is_failure(deploy.status.as_deref().unwrap_or(""));
         output::success(
             "Deploy logs retrieved.",
             Some(serde_json::json!({
@@ -469,12 +471,12 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
             // Try SSE stream as fallback for missing logs
             match stream_deploy(&client, &app_id, &deploy.id) {
                 Ok(final_deploy) => {
-                    if final_deploy.status.as_deref() == Some("failed") {
+                    if deploy_status::is_failure(final_deploy.status.as_deref().unwrap_or("")) {
                         process::exit(1);
                     }
                 }
                 Err(e) => {
-                    let base_msg = if status == "failed" {
+                    let base_msg = if deploy_status::is_failure(status) {
                         "No build logs captured for this deploy."
                     } else {
                         "No build logs available."
@@ -698,7 +700,7 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
     emit_deploy_found(&deploy, &app_name);
 
     let status = deploy.status.as_deref().unwrap_or("");
-    if TERMINAL_STATUSES.contains(&status) {
+    if deploy_status::is_terminal(status) {
         print_completed_deploy(&deploy);
         print_final_status(&deploy);
         return;
@@ -720,7 +722,7 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
         // SSE stream may end before the deploy reaches a terminal state (e.g. connection
         // drop, server restart). If so, fall back to polling to wait for completion.
         let streamed_status = streamed.status.as_deref().unwrap_or("");
-        if !TERMINAL_STATUSES.contains(&streamed_status) {
+        if !deploy_status::is_terminal(streamed_status) {
             eprintln!("Stream ended in non-terminal state ({streamed_status}), falling back to polling...");
             poll_deploy(&client, &app_id, &streamed)
         } else {
@@ -731,7 +733,7 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
             Ok(d) => {
                 // stream_deploy_json already emitted the "done" NDJSON event
                 let status = d.status.as_deref().unwrap_or("unknown");
-                if status == "failed" {
+                if deploy_status::is_failure(status) {
                     process::exit(1);
                 }
                 return;
@@ -856,44 +858,50 @@ fn print_final_status(deploy: &Deploy) {
             "status": status,
             "url": url,
         }));
-        if status == "failed" {
+        if deploy_status::is_failure(status) {
             process::exit(1);
         }
-    } else if status == "failed" {
-        output::error(
-            "Deploy failed.",
-            &ErrorCode::DeployFailed,
-            Some("Check build output above, or run `floo logs` for details."),
-        );
-        process::exit(1);
-    } else if status == "superseded" {
-        output::success(
-            "Deploy superseded by a newer deploy.",
-            Some(serde_json::json!({
-                "deploy": output::to_value(deploy),
-            })),
-        );
-    } else if status == "cancelled" {
-        output::success(
-            "Deploy cancelled: its target environment was removed before it ran.",
-            Some(serde_json::json!({
-                "deploy": output::to_value(deploy),
-            })),
-        );
-    } else if !TERMINAL_STATUSES.contains(&status) {
-        output::error(
-            &format!("Deploy ended in unexpected state: {status}"),
-            &ErrorCode::DeployFailed,
-            Some("Check deploy status with `floo deploys list --app <name>`."),
-        );
-        process::exit(1);
-    } else {
-        output::success(
-            &format!("Deploy {status}: {url}"),
-            Some(serde_json::json!({
-                "deploy": output::to_value(deploy),
-            })),
-        );
+        return;
+    }
+
+    // Human mode: report the terminal disposition. Matching on `classify` makes a
+    // newly-added terminal status a compile error here instead of silently falling
+    // through to the generic-success arm.
+    match deploy_status::classify(status) {
+        Some(deploy_status::Terminal::Failed) => {
+            output::error(
+                "Deploy failed.",
+                &ErrorCode::DeployFailed,
+                Some("Check build output above, or run `floo logs` for details."),
+            );
+            process::exit(1);
+        }
+        Some(deploy_status::Terminal::Superseded) => {
+            output::success(
+                "Deploy superseded by a newer deploy.",
+                Some(serde_json::json!({ "deploy": output::to_value(deploy) })),
+            );
+        }
+        Some(deploy_status::Terminal::Cancelled) => {
+            output::success(
+                "Deploy cancelled: its target environment was removed before it ran.",
+                Some(serde_json::json!({ "deploy": output::to_value(deploy) })),
+            );
+        }
+        Some(deploy_status::Terminal::Live) => {
+            output::success(
+                &format!("Deploy {status}: {url}"),
+                Some(serde_json::json!({ "deploy": output::to_value(deploy) })),
+            );
+        }
+        None => {
+            output::error(
+                &format!("Deploy ended in unexpected state: {status}"),
+                &ErrorCode::DeployFailed,
+                Some("Check deploy status with `floo deploys list --app <name>`."),
+            );
+            process::exit(1);
+        }
     }
 }
 
@@ -951,26 +959,6 @@ mod tests {
         assert!(!colored_status("deploying").is_empty());
         assert!(!colored_status("pending").is_empty());
         assert!(!colored_status("unknown").is_empty());
-    }
-
-    #[test]
-    fn test_superseded_is_terminal_status() {
-        // TERMINAL_STATUSES must include "superseded" so poll/stream loops exit
-        // when the platform marks a deploy as superseded. Before this was added,
-        // `floo deploys watch` would spin for POLL_TIMEOUT (10 min) on superseded
-        // deploys. See feedback 1748af72 (2026-04-24).
-        assert!(TERMINAL_STATUSES.contains(&"superseded"));
-        assert!(TERMINAL_STATUSES.contains(&"live"));
-        assert!(TERMINAL_STATUSES.contains(&"failed"));
-    }
-
-    #[test]
-    fn test_cancelled_is_terminal_status() {
-        // TERMINAL_STATUSES must include "cancelled" so poll/stream loops exit when
-        // the platform cancels a deploy — a PR-preview env torn down before the deploy
-        // could run terminates as "cancelled" (getfloo/floo#1354). Without it,
-        // `floo deploys watch` on a cancelled deploy would spin for POLL_TIMEOUT (10 min).
-        assert!(TERMINAL_STATUSES.contains(&"cancelled"));
     }
 
     #[test]

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use crate::api_client::FlooClient;
+use crate::deploy_status;
 use crate::errors::ErrorCode;
 use crate::output;
 use crate::project_config;
@@ -431,7 +432,7 @@ pub fn set(
             .and_then(|v| v.as_str())
             .unwrap_or("(no URL)");
 
-        if final_status == "failed" {
+        if deploy_status::is_failure(final_status) {
             output::error_with_data(
                 "Restart failed.",
                 &ErrorCode::RestartFailed,

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -3,6 +3,7 @@ use std::process;
 use std::time::{Duration, Instant};
 
 use crate::api_types::GitHubSetupStatus;
+use crate::deploy_status::{self, Terminal};
 use crate::detection::detect;
 use crate::errors::{ErrorCode, FlooApiError};
 use crate::output;
@@ -719,7 +720,7 @@ fn run_initial_deploy(
 
     let initial_status = deploy_data.status.as_deref().unwrap_or("");
 
-    if !super::deploy::TERMINAL_STATUSES.contains(&initial_status) {
+    if !deploy_status::is_terminal(initial_status) {
         if deploy_data.id.is_empty() {
             return DeployOutcome::Failed {
                 deploy: serde_json::json!({"error": "Deploy missing 'id' in response"}),
@@ -742,34 +743,38 @@ fn run_initial_deploy(
 
     let final_status = deploy_data.status.as_deref().unwrap_or("");
 
-    if final_status == "failed" {
-        DeployOutcome::Failed {
+    // Matching on `classify` makes a newly-added terminal status a compile error
+    // here instead of silently falling into the `None` → failed arm.
+    match deploy_status::classify(final_status) {
+        Some(Terminal::Failed) => DeployOutcome::Failed {
             deploy: output::to_value(&deploy_data),
+        },
+        Some(Terminal::Live) => {
+            let url = deploy_data.url.as_deref().unwrap_or("").to_string();
+            DeployOutcome::Live {
+                url,
+                deploy: output::to_value(&deploy_data),
+            }
         }
-    } else if final_status == "live" {
-        let url = deploy_data.url.as_deref().unwrap_or("").to_string();
-        DeployOutcome::Live {
-            url,
+        Some(Terminal::Superseded) => DeployOutcome::Superseded {
             deploy: output::to_value(&deploy_data),
+        },
+        Some(Terminal::Cancelled) => {
+            // Target env torn down before the deploy ran (getfloo/floo#1354) — a moot
+            // terminal like superseded, NOT a failure. Must not exit 1 / say "retry".
+            DeployOutcome::Cancelled {
+                deploy: output::to_value(&deploy_data),
+            }
         }
-    } else if final_status == "superseded" {
-        DeployOutcome::Superseded {
-            deploy: output::to_value(&deploy_data),
-        }
-    } else if final_status == "cancelled" {
-        // Target env torn down before the deploy ran (getfloo/floo#1354) — a moot
-        // terminal like superseded, NOT a failure. Must not exit 1 / say "retry".
-        DeployOutcome::Cancelled {
-            deploy: output::to_value(&deploy_data),
-        }
-    } else {
-        // Ambiguous status (timeout, unknown) — report as failed
-        output::warn(&format!(
-            "Deploy ended with unexpected status: {}",
-            final_status
-        ));
-        DeployOutcome::Failed {
-            deploy: output::to_value(&deploy_data),
+        None => {
+            // Ambiguous status (timeout, unknown) — report as failed.
+            output::warn(&format!(
+                "Deploy ended with unexpected status: {}",
+                final_status
+            ));
+            DeployOutcome::Failed {
+                deploy: output::to_value(&deploy_data),
+            }
         }
     }
 }

--- a/src/commands/previews.rs
+++ b/src/commands/previews.rs
@@ -6,20 +6,12 @@ use crate::api_client::FlooClient;
 use crate::api_types::{
     CreatePreviewDeployRequest, Deploy, LogEntry, PreviewEnvironment, PreviewManagedResourceBranch,
 };
+use crate::deploy_status;
 use crate::errors::ErrorCode;
 use crate::output;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const POLL_TIMEOUT: Duration = Duration::from_secs(600);
-const TERMINAL_STATUSES: &[&str] = &["live", "failed", "cancelled", "superseded"];
-
-/// Under `--wait`, only a genuinely FAILED preview deploy is a non-zero exit.
-/// `cancelled` (the target env was torn down before the deploy ran — the surface
-/// this status originates from, getfloo/floo#1354) and `superseded` are benign
-/// terminals: they exit 0, matching every other deploy-completion site in the CLI.
-fn preview_wait_is_failure(status: Option<&str>) -> bool {
-    status == Some("failed")
-}
 
 pub fn up(
     app_flag: Option<&str>,
@@ -105,7 +97,7 @@ pub fn up(
         preview.as_ref(),
     );
 
-    if wait && preview_wait_is_failure(deploy.status.as_deref()) {
+    if wait && deploy_status::is_failure(deploy.status.as_deref().unwrap_or("")) {
         process::exit(1);
     }
 }
@@ -541,7 +533,7 @@ pub fn logs(app_flag: Option<&str>, preview_identifier: &str, follow: bool, tail
 fn poll_deploy(client: &FlooClient, app_id: &str, initial: &Deploy) -> Deploy {
     let started = Instant::now();
     let mut deploy = initial.clone();
-    while !TERMINAL_STATUSES.contains(&deploy.status.as_deref().unwrap_or("")) {
+    while !deploy_status::is_terminal(deploy.status.as_deref().unwrap_or("")) {
         if !output::is_json_mode() {
             output::info(
                 &format!(
@@ -847,23 +839,5 @@ fn preview_api_suggestion(code: &str) -> Option<&'static str> {
         ),
         "INVALID_PREVIEW_BRANCH" => Some("Push a valid remote GitHub branch and pass it with --branch."),
         _ => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_preview_wait_only_failed_exits_nonzero() {
-        // Under `floo previews up --wait`, only a FAILED preview deploy is a
-        // non-zero exit. cancelled (target env torn down before the deploy ran —
-        // getfloo/floo#1354) and superseded are benign terminals → exit 0, matching
-        // every other deploy-completion site.
-        assert!(preview_wait_is_failure(Some("failed")));
-        assert!(!preview_wait_is_failure(Some("cancelled")));
-        assert!(!preview_wait_is_failure(Some("superseded")));
-        assert!(!preview_wait_is_failure(Some("live")));
-        assert!(!preview_wait_is_failure(None));
     }
 }

--- a/src/deploy_status.rs
+++ b/src/deploy_status.rs
@@ -1,0 +1,96 @@
+//! Single source of truth for classifying a deploy's status.
+//!
+//! Every command that polls or watches a deploy and reports its outcome routes
+//! its terminal-membership and failure (exit-code) decisions through here, so
+//! adding a new status is a one-place change instead of an audit across every
+//! completion site. getfloo/floo#1354 shipped `cancelled` and review still found
+//! two sites (`apps github connect`, `previews up --wait`) that had independently
+//! hand-rolled "anything but live is a failure" and so misreported a cancelled
+//! deploy as a failure — this module exists to close that class.
+
+/// Terminal deploy statuses: a poll/stream loop stops once a deploy reaches one.
+const TERMINAL: &[&str] = &["live", "failed", "superseded", "cancelled"];
+
+/// How a deploy that has reached a terminal status should be reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Terminal {
+    /// Reached LIVE — a genuine success.
+    Live,
+    /// Failed — the ONLY status that warrants a non-zero exit; operator-actionable.
+    Failed,
+    /// A newer deploy replaced this one — benign, exit 0.
+    Superseded,
+    /// The target environment was torn down before the deploy ran — benign,
+    /// exit 0 (getfloo/floo#1354).
+    Cancelled,
+}
+
+/// True if `status` is a terminal state (a poll/stream loop should stop here).
+pub fn is_terminal(status: &str) -> bool {
+    TERMINAL.contains(&status)
+}
+
+/// Classify a terminal status; `None` while the deploy is still in progress.
+pub fn classify(status: &str) -> Option<Terminal> {
+    match status {
+        "live" => Some(Terminal::Live),
+        "failed" => Some(Terminal::Failed),
+        "superseded" => Some(Terminal::Superseded),
+        "cancelled" => Some(Terminal::Cancelled),
+        _ => None,
+    }
+}
+
+/// True only for a genuine FAILURE — the single status that warrants a non-zero
+/// exit. `live` and the moot terminals (`superseded`/`cancelled`) are NOT failures,
+/// and neither is any in-progress status.
+pub fn is_failure(status: &str) -> bool {
+    classify(status) == Some(Terminal::Failed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_membership() {
+        // Every settled status must be terminal or the poll/stream loops spin for
+        // POLL_TIMEOUT (10 min): `superseded` was the original miss (feedback
+        // 1748af72, 2026-04-24) and `cancelled` the more recent one (getfloo/floo#1354).
+        for s in ["live", "failed", "superseded", "cancelled"] {
+            assert!(is_terminal(s), "{s} should be terminal");
+        }
+        for s in [
+            "pending",
+            "building",
+            "deploying",
+            "configuring_routing",
+            "",
+        ] {
+            assert!(!is_terminal(s), "{s} should not be terminal");
+        }
+    }
+
+    #[test]
+    fn only_failed_is_a_failure() {
+        assert!(is_failure("failed"));
+        // Moot terminals and live must NOT read as failures — they exit 0.
+        assert!(!is_failure("cancelled"));
+        assert!(!is_failure("superseded"));
+        assert!(!is_failure("live"));
+        // In-progress / unknown is not (yet) a failure.
+        assert!(!is_failure("building"));
+        assert!(!is_failure("whatever"));
+    }
+
+    #[test]
+    fn classify_maps_each_terminal_status() {
+        assert_eq!(classify("live"), Some(Terminal::Live));
+        assert_eq!(classify("failed"), Some(Terminal::Failed));
+        assert_eq!(classify("superseded"), Some(Terminal::Superseded));
+        assert_eq!(classify("cancelled"), Some(Terminal::Cancelled));
+        // Non-terminal / unknown statuses do not classify.
+        assert_eq!(classify("building"), None);
+        assert_eq!(classify("whatever"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod commands;
 mod config;
 mod confirm;
 mod constants;
+mod deploy_status;
 mod detection;
 mod dev_proxy;
 mod dockerfile;


### PR DESCRIPTION
## What changed

Centralizes deploy-status classification in a new `src/deploy_status.rs` module — the single source of truth for "given a deploy status, is it terminal / a failure / which disposition":

- `is_terminal(&str) -> bool`
- `classify(&str) -> Option<Terminal>` (enum `Live | Failed | Superseded | Cancelled`)
- `is_failure(&str) -> bool`

Every terminal-membership and exit-code decision in `deploy.rs`, `deploys.rs`, `github.rs`, `previews.rs`, and `env.rs` now routes through it. Two sites — `deploys::print_final_status` and `apps github connect`'s outcome mapping (`run_initial_deploy`) — became exhaustive `match classify(...)`, so a **newly-added status is a compile error** at those sites instead of a silent misclassification. Deletes the two duplicated `TERMINAL_STATUSES` consts and the `previews`-local `preview_wait_is_failure` helper.

## Why

The CLI hand-rolled terminal-status classification at ~6 completion sites, each independently enumerating `live`/`failed`/`superseded`/`cancelled` (`TERMINAL_STATUSES.contains`, `== "failed"`, `!= "live"`, …). That duplication is exactly why the `cancelled` rollout (getfloo/floo#1354, #198) still shipped two sites — `apps github connect` and `previews up --wait` — that misreported a cancelled deploy as a *failure* (exit 1, "run redeploy"). This closes that class: adding a status is now a one-place change (and, at the two `match` sites, a compile error until handled).

## Risk tier

**sensitive** — touches `src/commands/deploy.rs`. Reviewed: Claude + Codex on the diff, with the explicit brief to verify behavior-preservation site-by-site.

## Behavior-preservation (the load-bearing property)

This is a pure refactor — every transformation is an identity:
- `deploy_status::is_terminal(x)` == the old `TERMINAL_STATUSES.contains(&x)` (same 4-element set; `previews.rs`'s copy differed only in element order, irrelevant for `.contains`).
- `deploy_status::is_failure(x)` == the old `x == "failed"` / `x.as_deref() == Some("failed")` (the `Option` sites become `is_failure(opt.unwrap_or(""))`: `None → "" → not a failure`, identical to `Some("failed")` being false for `None`).
- The two `match classify(...)` rewrites reproduce every arm (including the JSON path and the `None`/`else` arm) with identical output, exit codes, and `DeployOutcome`.

**All 458 CLI tests pass unchanged; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.** Command files are net **−31 lines**.

## Tests

New `deploy_status` module unit tests (`terminal_membership`, `only_failed_is_a_failure`, `classify_maps_each_terminal_status`) pin the primitives; the deleted per-call-site tests' rationale (superseded feedback 1748af72, cancelled #1354) is folded into the module's membership test. `cargo test` green.

## Known non-goals

- Disposition-specific *message* branches (`deploy.rs` superseded/cancelled messages, `env.rs` restart message) and the `status`-command readiness signals (`image_built`/`service_ready`/`host_bound`) are a different concern (specific status → specific message/signal) and intentionally not folded into the classifier; their sibling failure/terminal checks in the same functions were converted.
