### PR TITLE
feat(ci): canonical scripts/test with corrupt-harness self-heal guard (#204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Suspected trigger for the corrupt test-harness class (floo-cli#204) is
+  # incremental-compilation state; CI gains nothing from incremental (the
+  # target/ cache would otherwise preserve a corrupt artifact forever).
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   test:
@@ -25,8 +29,8 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check installer syntax
-        run: bash -n install.sh
+      - name: Check script syntax
+        run: bash -n install.sh && bash -n scripts/test
 
       - name: Run installer script tests
         run: bash tests/install_script_test.sh
@@ -34,14 +38,14 @@ jobs:
       - name: Run installer script e2e
         run: bash tests/install_script_e2e.sh
 
-      - name: Run tests
-        run: cargo test
+      - name: Run test-harness guard tests
+        run: bash tests/test_script_test.sh
 
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
-
-      - name: Check formatting
-        run: cargo fmt --check
+      # fmt + clippy + cargo test via the canonical entry point, which also
+      # self-heals the corrupt-harness artifact class (floo-cli#204) that the
+      # target/ cache would otherwise pin across runs.
+      - name: Run fmt, clippy, and tests
+        run: ./scripts/test
 
   coverage:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,9 @@ cargo build                      # Debug build
 cargo build --release            # Release build (~2MB static binary)
 
 # Test
-cargo test                       # All tests (unit + integration)
+./scripts/test                   # Canonical: fmt --check + clippy + all tests,
+                                 # with the corrupt-harness guard (#204)
+cargo test                       # All tests only (unit + integration)
 
 # Lint & format
 cargo clippy -- -D warnings      # Lint (deny all warnings)
@@ -81,7 +83,7 @@ Packs source into `.tar.gz`, respects `.flooignore`. 500MB size limit.
 ## Key Conventions
 
 - Rust 2021 edition, **cargo** for build/deps, **clap** derive for CLI
-- Lint: **clippy** (`-D warnings`). Format: **cargo fmt**. Test: **cargo test**
+- Lint: **clippy** (`-D warnings`). Format: **cargo fmt**. Test: **`./scripts/test`** (canonical entry point; wraps fmt + clippy + `cargo test` and self-heals the #204 corrupt-harness artifact class)
 - No `println!` — use `output` module functions
 - No `unwrap()` in production paths — use `?` operator
 - No `unsafe` without documented justification

--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ Contributions are welcome! Please:
 2. Create a feature branch (`git checkout -b feat/my-feature`)
 3. Run tests and lint before committing:
    ```bash
-   cargo test
-   cargo clippy -- -D warnings
-   cargo fmt --check
+   ./scripts/test
    ```
 4. Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
 5. Open a pull request

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/test — canonical test entry point for floo-cli.
+#
+# Runs fmt --check, clippy (-D warnings), and cargo test, in that order, and
+# exits nonzero on the first failing phase. Extra args are forwarded to
+# `cargo test`.
+#
+# Corrupt-harness guard (floo-cli#204): rarely, after heavy incremental
+# churn, a bin's unittest binary ends up executing the REAL clap main()
+# instead of the libtest harness — it prints the CLI usage banner and exits 2
+# before any assertion runs. The failure is environmental (a stale build
+# artifact; `cargo clean` always clears it) and would otherwise persist
+# forever in CI via the target/ cache. On that exact two-part signature
+# ("test exited abnormally" from cargo AND the CLI's own "Usage: floo"
+# banner in the captured output) this script cleans the package's artifacts
+# and retries ONCE. A normal test failure never matches the signature pair
+# and is never retried; a persistent corrupt harness still fails loudly on
+# the second run. Worst case for a false match (a failing integration test
+# that itself printed the usage banner AND died abnormally): one redundant
+# retry, then the genuine failure surfaces.
+set -u
+
+# Test seam: tests/test_script_test.sh points this at a shim.
+CARGO="${FLOO_TEST_CARGO:-cargo}"
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+run_tests() {
+    # No pipe here on purpose: a pipe reports the downstream command's exit
+    # code, which is how masked failures ship (2026-07-02 daily log).
+    "$CARGO" test "$@" >"$log" 2>&1
+    local status=$?
+    cat "$log"
+    return "$status"
+}
+
+is_corrupt_harness() {
+    grep -q 'test exited abnormally' "$log" && grep -q 'Usage: floo' "$log"
+}
+
+"$CARGO" fmt --check || exit 1
+"$CARGO" clippy --all-targets -- -D warnings || exit 1
+
+run_tests "$@"
+status=$?
+if [ "$status" -eq 0 ]; then
+    exit 0
+fi
+if is_corrupt_harness; then
+    echo "warning: corrupt test-harness binary detected (floo-cli#204);" \
+        "cleaning package artifacts and retrying once" >&2
+    "$CARGO" clean -p floo
+    run_tests "$@"
+    exit $?
+fi
+exit "$status"

--- a/tests/test_script_test.sh
+++ b/tests/test_script_test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Tests for scripts/test — the corrupt-harness guard (floo-cli#204).
+#
+# Uses a cargo shim (via FLOO_TEST_CARGO) so no real build runs. Each case
+# pins one branch of the guard: pass-through success, heal-and-retry on the
+# corrupt-harness signature, no retry on a normal failure, and loud failure
+# when the corruption persists.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WRAPPER="${REPO_ROOT}/scripts/test"
+
+pass() {
+    echo "[pass] $*"
+}
+
+fail() {
+    echo "[fail] $*" >&2
+    exit 1
+}
+
+make_shim() {
+    local dir="$1"
+    : >"${dir}/calls"
+    cat >"${dir}/cargo" <<'SHIM'
+#!/usr/bin/env bash
+dir="$(cd "$(dirname "$0")" && pwd)"
+cmd="${1:-}"
+echo "$cmd" >>"${dir}/calls"
+case "$cmd" in
+    fmt | clippy | clean)
+        exit 0
+        ;;
+    test)
+        n="$(grep -c '^test$' "${dir}/calls")"
+        mode="$(cat "${dir}/mode")"
+        case "$mode" in
+            ok)
+                echo "test result: ok. 1 passed"
+                exit 0
+                ;;
+            corrupt-once)
+                if [ "$n" -eq 1 ]; then
+                    echo "Usage: floo-a45172a3dc4b14e2 [OPTIONS] <COMMAND>"
+                    echo "error: test failed, to rerun pass \`--bin floo\`"
+                    echo "note: test exited abnormally; to see the full output pass --no-capture to the harness."
+                    exit 2
+                fi
+                echo "test result: ok. 1 passed"
+                exit 0
+                ;;
+            corrupt-always)
+                echo "Usage: floo-a45172a3dc4b14e2 [OPTIONS] <COMMAND>"
+                echo "note: test exited abnormally; to see the full output pass --no-capture to the harness."
+                exit 2
+                ;;
+            plain-failure)
+                echo "test result: FAILED. 1 failed; 42 passed"
+                echo "error: test failed, to rerun pass \`--bin floo\`"
+                exit 101
+                ;;
+        esac
+        ;;
+esac
+exit 0
+SHIM
+    chmod +x "${dir}/cargo"
+}
+
+run_wrapper() {
+    local dir="$1"
+    set +e
+    FLOO_TEST_CARGO="${dir}/cargo" bash "$WRAPPER" >"${dir}/out" 2>&1
+    WRAPPER_STATUS=$?
+    set -e
+}
+
+clean_calls() {
+    grep -c '^clean$' "$1/calls" || true
+}
+
+test_calls() {
+    grep -c '^test$' "$1/calls" || true
+}
+
+# --- Case 1: success passes through, no clean, single test run ---
+dir="$(mktemp -d)"
+make_shim "$dir"
+echo ok >"${dir}/mode"
+run_wrapper "$dir"
+[ "$WRAPPER_STATUS" -eq 0 ] || fail "success case: expected exit 0, got $WRAPPER_STATUS"
+[ "$(clean_calls "$dir")" -eq 0 ] || fail "success case: clean must not run"
+[ "$(test_calls "$dir")" -eq 1 ] || fail "success case: exactly one test run"
+pass "success passes through without clean or retry"
+rm -rf "$dir"
+
+# --- Case 2: corrupt-harness signature heals — clean once, retry once, exit 0 ---
+dir="$(mktemp -d)"
+make_shim "$dir"
+echo corrupt-once >"${dir}/mode"
+run_wrapper "$dir"
+[ "$WRAPPER_STATUS" -eq 0 ] || fail "heal case: expected exit 0, got $WRAPPER_STATUS"
+[ "$(clean_calls "$dir")" -eq 1 ] || fail "heal case: expected exactly one clean"
+[ "$(test_calls "$dir")" -eq 2 ] || fail "heal case: expected exactly two test runs"
+grep -q 'corrupt test-harness binary detected' "${dir}/out" ||
+    fail "heal case: warning must name the condition"
+pass "corrupt-harness signature triggers one clean + one retry, then succeeds"
+rm -rf "$dir"
+
+# --- Case 3: a normal test failure is NEVER retried or cleaned ---
+dir="$(mktemp -d)"
+make_shim "$dir"
+echo plain-failure >"${dir}/mode"
+run_wrapper "$dir"
+[ "$WRAPPER_STATUS" -ne 0 ] || fail "plain failure case: must exit nonzero"
+[ "$(clean_calls "$dir")" -eq 0 ] || fail "plain failure case: clean must not run"
+[ "$(test_calls "$dir")" -eq 1 ] || fail "plain failure case: no retry"
+pass "normal test failure exits nonzero with no clean and no retry"
+rm -rf "$dir"
+
+# --- Case 4: persistent corruption fails loudly after exactly one retry ---
+dir="$(mktemp -d)"
+make_shim "$dir"
+echo corrupt-always >"${dir}/mode"
+run_wrapper "$dir"
+[ "$WRAPPER_STATUS" -ne 0 ] || fail "persistent case: must exit nonzero"
+[ "$(clean_calls "$dir")" -eq 1 ] || fail "persistent case: exactly one clean (no loop)"
+[ "$(test_calls "$dir")" -eq 2 ] || fail "persistent case: exactly two test runs (no loop)"
+pass "persistent corruption fails loudly after a single retry"
+rm -rf "$dir"
+
+echo "All scripts/test guard tests passed."


### PR DESCRIPTION
## What changed

`scripts/test` is now the canonical test entry point (fmt --check, clippy -D warnings, cargo test — one command, exit code captured directly at every phase). It guards the #204 corrupt-harness class: on the exact two-part signature (cargo's \"test exited abnormally\" AND the CLI's own usage banner in captured output) it runs `cargo clean -p floo` and retries exactly once. A normal test failure can never produce that pair (libtest assertion failures panic and report FAILED; they never emit \"test exited abnormally\"), so nothing is masked; persistent corruption fails loudly on the second run.

- `tests/test_script_test.sh` pins all four guard branches via a cargo shim (pass-through, heal-and-retry, no-retry-on-normal-failure, no-loop-on-persistent-corruption). The tests caught a real $?-after-if bug in the first draft.
- CI runs the entry point, gains the guard tests and `bash -n` coverage, and sets `CARGO_INCREMENTAL: \"0\"` (the suspected trigger; worthless in CI, and the target/ cache would otherwise preserve a corrupt artifact forever).
- CLAUDE.md and README point at the one entry point (AGENTS.md stays a symlink).

## Review

Sensitive tier (ci.yml). Claude heavy review: clean, no P0-P2; two informational P3s accepted (immutable CI cache keys mean a poisoned cache re-heals per run rather than self-curing; shim tests don't pin the `-p floo` arg — a bare clean regression would be a harmless superset). Codex: clean. Guard tests 4/4, real `./scripts/test` run green with verified exit code.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)