### PR TITLE
feat: add edge route inspection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ floo env list --app my-app
 # Custom domains
 floo domains add app.example.com --app my-app
 floo domains list --app my-app
+
+# Edge routes
+floo edge routes list --app my-app --json
 ```
 
 All commands are invoked with the production alias: `floo`.

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -338,6 +338,19 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn list_edge_routes(
+        &self,
+        app_id: &str,
+        environment: Option<&str>,
+    ) -> Result<EdgeRouteListResponse, FlooApiError> {
+        let mut path = format!("/v1/apps/{app_id}/edge/routes");
+        if let Some(env) = environment {
+            path.push_str(&format!("?environment_name={env}"));
+        }
+        let resp = self.get(&path)?;
+        self.handle_response(resp)
+    }
+
     pub fn delete_app(&self, app_id: &str) -> Result<(), FlooApiError> {
         let resp = self.delete(&format!("/v1/apps/{app_id}"))?;
         if resp.status().as_u16() == 204 {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -156,6 +156,35 @@ pub struct ListAppsResponse {
     pub total: Option<u64>,
 }
 
+// --- Edge ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgeRoute {
+    pub id: String,
+    pub host: String,
+    pub path_prefix: String,
+    pub environment_id: Option<String>,
+    pub environment_name: Option<String>,
+    pub environment_slug: Option<String>,
+    pub service_id: Option<String>,
+    pub service_name: Option<String>,
+    pub service_type: Option<String>,
+    pub access_mode: String,
+    pub api_key_enabled: bool,
+    pub required_scope: Option<String>,
+    pub source: String,
+    pub source_of_truth: String,
+    pub propagation_status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgeRouteListResponse {
+    pub routes: Vec<EdgeRoute>,
+    pub total: u64,
+}
+
 // --- Deploy ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -309,6 +309,16 @@ Run `floo notifications list` to see the available categories."
     #[command(subcommand)]
     Domains(DomainsCommands),
 
+    /// Inspect edge routing and access policy for an app.
+    #[command(
+        subcommand,
+        after_help = "\
+Examples:
+  floo edge routes list --app my-app
+  floo edge routes list --app my-app --env prod --json"
+    )]
+    Edge(EdgeCommands),
+
     /// Manage releases and promote to prod.
     #[command(subcommand)]
     Releases(ReleasesCommands),
@@ -361,7 +371,7 @@ Examples:
     /// full list of topics with one-line descriptions.
     #[command(after_help = "\
 Topics: golden-path, quickstart, build, nextjs, rails, fastapi, django,
-express, templates, services, previews, config, cron, deploy, auth,
+express, templates, services, edge, previews, config, cron, deploy, auth,
 notifications, feedback.
 Aliases: storage -> services, app-toml -> config.
 Run `floo docs` (no topic) for a one-line description of each topic.")]
@@ -886,6 +896,34 @@ pub enum NotificationsCommands {
         /// Whether to receive this category.
         #[arg(value_parser = ["on", "off"])]
         value: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum EdgeCommands {
+    /// Inspect effective edge routes.
+    #[command(subcommand)]
+    Routes(EdgeRoutesCommands),
+}
+
+#[derive(Subcommand)]
+pub enum EdgeRoutesCommands {
+    /// List the effective route table for an app.
+    #[command(after_help = "\
+Examples:
+  floo edge routes list --app my-app
+  floo edge routes list --app my-app --env prod --json
+
+Shows the customer-safe route table served by floo's edge: host, path,
+environment, target service, access policy, source, and freshness marker.")]
+    List {
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Environment filter: dev, prod, or preview. Omit to list all routes.
+        #[arg(long, value_parser = ["dev", "prod", "preview"])]
+        env: Option<String>,
     },
 }
 
@@ -2189,6 +2227,14 @@ pub fn run() {
             ServicesCommands::Migrate { app, path } => {
                 commands::services::migrate(app.as_deref(), &path)
             }
+        },
+
+        Commands::Edge(sub) => match sub {
+            EdgeCommands::Routes(routes_sub) => match routes_sub {
+                EdgeRoutesCommands::List { app, env } => {
+                    commands::edge::list_routes(app.as_deref(), env.as_deref())
+                }
+            },
         },
 
         Commands::Storage(sub) => match sub {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -37,6 +37,7 @@ never uploads code.
   floo docs express    — build and deploy an Express app on floo (end-to-end)
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services (alias: storage)
+  floo docs edge       — inspect edge routes, services, and access policy
   floo docs previews   — command-line preview sandboxes for remote branches
   floo docs config     — config file formats with examples (alias: app-toml)
   floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
@@ -325,6 +326,40 @@ All services share the same origin, so cookies and auth work without CORS.
   floo services add <type> --app <name>      — provision a managed service
   floo services remove <type> --app <name>   — permanently destroy (tier-3)
   floo services migrate --app <name>         — move legacy TOML → CLI state
+";
+
+const EDGE: &str = "\
+Floo Edge Routes
+
+Inspect the route table floo's edge is serving for an app. Use this when a
+host, path, target service, access mode, or custom domain does not behave the
+way you expected.
+
+## List routes
+
+  floo edge routes list --app my-app
+  floo edge routes list --app my-app --env prod
+  floo edge routes list --app my-app --env preview --json
+
+The route table shows:
+
+  host              Customer-facing floo host or custom domain
+  path_prefix       Path prefix matched by the gateway
+  environment       dev, prod, preview, or unscoped legacy route
+  service           Target app service name and type
+  policy            Effective access mode and app API-key requirement
+  source            deploy, custom_domain, toml, or system
+  source_of_truth   gateway_routes
+
+JSON output is stable for agents:
+
+  floo edge routes list --app my-app --env prod --json 2>/dev/null |
+    jq '.data.routes[] | {host, path_prefix, access_mode, api_key_enabled, required_scope}'
+
+The output deliberately omits raw Cloud Run backend URLs. Treat floo hosts and
+custom domains as the public contract.
+
+Full reference: https://getfloo.com/docs/cli/edge
 ";
 
 const PREVIEWS: &str = "\
@@ -1808,6 +1843,7 @@ pub(crate) const TOPICS: &[(&str, &str)] = &[
     ("express", EXPRESS),
     ("templates", TEMPLATES),
     ("services", SERVICES),
+    ("edge", EDGE),
     ("previews", PREVIEWS),
     ("config", CONFIG),
     ("cron", CRON),

--- a/src/commands/edge.rs
+++ b/src/commands/edge.rs
@@ -1,0 +1,76 @@
+use std::process;
+
+use crate::api_types::EdgeRoute;
+use crate::errors::ErrorCode;
+use crate::output;
+
+pub fn list_routes(app: Option<&str>, env: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
+
+    let response = match client.list_edge_routes(&app_id, env) {
+        Ok(r) => r,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    if output::is_json_mode() {
+        output::success(
+            &format!("Edge routes for {app_name}."),
+            Some(output::to_value(&response)),
+        );
+        return;
+    }
+
+    if response.routes.is_empty() {
+        let scope = env.map(|value| format!(" in {value}")).unwrap_or_default();
+        output::info(&format!("No edge routes for {app_name}{scope}."), None);
+        return;
+    }
+
+    let rows: Vec<Vec<String>> = response.routes.iter().map(route_row).collect();
+    output::table(
+        &[
+            "Host", "Path", "Env", "Service", "Policy", "Source", "Updated",
+        ],
+        &rows,
+        Some(output::to_value(&response)),
+    );
+}
+
+fn route_row(route: &EdgeRoute) -> Vec<String> {
+    vec![
+        route.host.clone(),
+        route.path_prefix.clone(),
+        route
+            .environment_slug
+            .as_deref()
+            .or(route.environment_name.as_deref())
+            .unwrap_or("unscoped")
+            .to_string(),
+        service_label(route),
+        policy_label(route),
+        route.source.clone(),
+        route.updated_at.clone(),
+    ]
+}
+
+fn service_label(route: &EdgeRoute) -> String {
+    match (route.service_name.as_deref(), route.service_type.as_deref()) {
+        (Some(name), Some(service_type)) => format!("{name} ({service_type})"),
+        (Some(name), None) => name.to_string(),
+        _ => "app".to_string(),
+    }
+}
+
+fn policy_label(route: &EdgeRoute) -> String {
+    match (route.api_key_enabled, route.required_scope.as_deref()) {
+        (true, Some(scope)) => format!("{} + key:{scope}", route.access_mode),
+        (true, None) => format!("{} + key", route.access_mode),
+        (false, Some(scope)) => format!("{}:{scope}", route.access_mode),
+        (false, None) => route.access_mode.clone(),
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod dev;
 pub mod docs;
 pub mod doctor;
 pub mod domains;
+pub mod edge;
 pub mod env;
 pub mod feedback;
 pub mod github;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -325,6 +325,16 @@ fn test_services_help() {
 }
 
 #[test]
+fn test_edge_routes_help() {
+    floo()
+        .args(["edge", "routes", "list", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("List the effective route table"))
+        .stdout(predicate::str::contains("--env"));
+}
+
+#[test]
 fn test_deploy_help() {
     floo()
         .args(["deploys", "--help"])

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -130,6 +130,10 @@ fn mock_services_single(server: &mut Server) -> Mock {
         .create()
 }
 
+fn edge_routes_json() -> &'static str {
+    r#"{"routes":[{"id":"route-1","host":"my-app.on.getfloo.com","path_prefix":"/","environment_id":"env-prod","environment_name":"prod","environment_slug":"prod","service_id":"svc-web-1","service_name":"web","service_type":"web","access_mode":"accounts","api_key_enabled":true,"required_scope":"app:read","source":"deploy","source_of_truth":"gateway_routes","propagation_status":"unknown","created_at":"2026-07-03T10:00:00Z","updated_at":"2026-07-03T10:05:00Z"}],"total":1}"#
+}
+
 fn preview_branch_json(name: &str, status: &str, reset_eligible: bool) -> String {
     let blocked = if reset_eligible {
         "null".to_string()
@@ -2813,6 +2817,76 @@ fn test_services_list_empty_when_no_services_of_either_kind() {
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains(r#""app_services":[]"#))
         .stdout(predicate::str::contains(r#""managed_services":[]"#));
+}
+
+#[test]
+fn test_edge_routes_list_json_uses_customer_safe_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _routes = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/edge/routes").as_str(),
+        )
+        .match_query(Matcher::UrlEncoded(
+            "environment_name".into(),
+            "prod".into(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(edge_routes_json())
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "edge",
+            "routes",
+            "list",
+            "--app",
+            TEST_APP_NAME,
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""host":"my-app.on.getfloo.com""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""source_of_truth":"gateway_routes""#,
+        ))
+        .stdout(predicate::str::contains(r#""required_scope":"app:read""#))
+        .stdout(predicate::str::contains("raw-backend").not());
+}
+
+#[test]
+fn test_edge_routes_list_human_renders_route_table() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _routes = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/edge/routes").as_str(),
+        )
+        .match_query(Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(edge_routes_json())
+        .create();
+
+    floo()
+        .args(["edge", "routes", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("my-app.on.getfloo.com"))
+        .stderr(predicate::str::contains("accounts + key:app:read"))
+        .stderr(predicate::str::contains("web (web)"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `floo edge routes list` with optional `--env dev|prod|preview`
- mirror the new `/v1/apps/{app_id}/edge/routes` response into typed CLI structs
- return stable `--json` output for agents and a compact human route table
- add offline `floo docs edge` and README discovery for the command

## Why
The platform API/dashboard route inspection surface landed in getfloo/floo#1415, but #1359 also requires CLI JSON parity so agents can diagnose route drift without platform-admin access or dashboard scraping.

## Verification
- `cargo test edge_routes`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`

Closes getfloo/floo#1359
