### PR TITLE
fix: settle stream-returned deploys to terminal before final-status handling (#208)

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1001,7 +1001,7 @@ pub fn deploy(
         // Phase 2 human mode: try SSE streaming, fall back to polling
         let deploy_id = deploy_data.id.clone();
         match stream_deploy(&client, &app_id, &deploy_id) {
-            Ok(final_data) => deploy_data = final_data,
+            Ok(final_data) => deploy_data = settle_to_terminal(&client, &app_id, final_data),
             Err(e) => {
                 // SSE failed — fall back to polling
                 eprintln!(
@@ -1184,7 +1184,7 @@ fn deploy_restart(
         let deploy_id = deploy_data.id.clone();
         deploy_data = if !output::is_json_mode() {
             match stream_deploy(client, app_id, &deploy_id) {
-                Ok(d) => d,
+                Ok(d) => settle_to_terminal(client, app_id, d),
                 Err(e) => {
                     eprintln!(
                         "Stream unavailable ({}), falling back to polling...",
@@ -1326,7 +1326,7 @@ fn deploy_rebuild(
     } else if !output::is_json_mode() {
         let deploy_id = deploy_data.id.clone();
         match stream_deploy(client, app_id, &deploy_id) {
-            Ok(final_data) => deploy_data = final_data,
+            Ok(final_data) => deploy_data = settle_to_terminal(client, app_id, final_data),
             Err(e) => {
                 eprintln!(
                     "Stream unavailable ({}), falling back to polling...",
@@ -2646,6 +2646,23 @@ pub(crate) fn stream_deploy_json(
 }
 
 /// Poll the deploy endpoint until it reaches a terminal status.
+/// Settle a stream-returned deploy to a TERMINAL status before anyone acts
+/// on it. The SSE stream closes when the executor job exits, which can race
+/// the worker's LIVE commit by seconds — a successful deploy briefly reads
+/// status=deploying at stream end (floo-cli#208: reported as "Deploy ended in
+/// unexpected state: deploying" on a healthy rollout). Every stream consumer
+/// funnels through here; only the watch command had this fallback before.
+pub(crate) fn settle_to_terminal(client: &FlooClient, app_id: &str, streamed: Deploy) -> Deploy {
+    let status = streamed.status.as_deref().unwrap_or("");
+    if deploy_status::is_terminal(status) {
+        return streamed;
+    }
+    if !output::is_json_mode() {
+        eprintln!("Stream ended in non-terminal state ({status}), falling back to polling...");
+    }
+    poll_deploy(client, app_id, &streamed)
+}
+
 pub(crate) fn poll_deploy(client: &FlooClient, app_id: &str, initial_data: &Deploy) -> Deploy {
     let deploy_id = initial_data.id.clone();
     let poll_start = Instant::now();
@@ -2979,6 +2996,58 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    fn mock_client(url: &str) -> FlooClient {
+        FlooClient::new(Some(crate::config::FlooConfig {
+            api_key: Some("floo_test123".to_string()),
+            api_url: url.to_string(),
+            ..Default::default()
+        }))
+        .unwrap()
+    }
+
+    fn deploy_with_status(status: &str) -> Deploy {
+        serde_json::from_str::<Deploy>(&format!(
+            r#"{{"id":"dep-1","status":"{status}","created_at":"2024-01-01T00:00:00Z"}}"#
+        ))
+        .unwrap()
+    }
+
+    // floo-cli#208: the SSE stream closes when the executor job exits, which
+    // races the worker's LIVE commit — the post-stream read can say
+    // "deploying" on a deploy that is seconds from LIVE. settle_to_terminal
+    // must POLL that to terminal, never hand a non-terminal deploy to the
+    // final-status printers (which exit 1 with "unexpected state").
+    #[test]
+    fn settle_to_terminal_polls_a_non_terminal_stream_result() {
+        let mut server = mockito::Server::new();
+        let m = server
+            .mock("GET", "/v1/apps/app-1/deploys/dep-1")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"id":"dep-1","status":"live","url":"https://x.floo.app","created_at":"2024-01-01T00:00:00Z"}"#)
+            .expect(1)
+            .create();
+
+        let client = mock_client(&server.url());
+        let settled = settle_to_terminal(&client, "app-1", deploy_with_status("deploying"));
+
+        assert_eq!(settled.status.as_deref(), Some("live"));
+        m.assert();
+    }
+
+    #[test]
+    fn settle_to_terminal_passes_terminal_results_through_without_http() {
+        let mut server = mockito::Server::new();
+        let m = server.mock("GET", mockito::Matcher::Any).expect(0).create();
+
+        let client = mock_client(&server.url());
+        for status in ["live", "failed", "superseded"] {
+            let settled = settle_to_terminal(&client, "app-1", deploy_with_status(status));
+            assert_eq!(settled.status.as_deref(), Some(status));
+        }
+        m.assert();
+    }
 
     fn write_lock(dir: &Path, body: &str) {
         let lock_dir = dir.join(".floo");

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -2616,13 +2616,10 @@ pub(crate) fn stream_deploy_json(
                     }
                 }
                 "done" => {
-                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&data_buf) {
-                        let status = parsed.get("status").and_then(|v| v.as_str()).unwrap_or("");
-                        let url = parsed.get("url").and_then(|v| v.as_str()).unwrap_or("");
-                        output::print_json(
-                            &serde_json::json!({"event": "done", "status": status, "url": url}),
-                        );
-                    }
+                    // The server's done payload can carry the raced non-terminal
+                    // status (#208). Emission moved below the loop: the done
+                    // event is built from the SETTLED deploy, so agents never
+                    // see "done" with status=deploying.
                     break;
                 }
                 "error" => {
@@ -2642,10 +2639,19 @@ pub(crate) fn stream_deploy_json(
         }
     }
 
-    client.get_deploy(app_id, deploy_id)
+    // Settle BEFORE the done event exists anywhere: the stream closes when
+    // the executor job exits, racing the worker's LIVE commit (#208). One
+    // emission point, always terminal — also covers streams that EOF without
+    // a server done event (previously: no done event at all).
+    let final_deploy = settle_to_terminal(client, app_id, client.get_deploy(app_id, deploy_id)?);
+    output::print_json(&serde_json::json!({
+        "event": "done",
+        "status": final_deploy.status.as_deref().unwrap_or(""),
+        "url": final_deploy.url.as_deref().unwrap_or(""),
+    }));
+    Ok(final_deploy)
 }
 
-/// Poll the deploy endpoint until it reaches a terminal status.
 /// Settle a stream-returned deploy to a TERMINAL status before anyone acts
 /// on it. The SSE stream closes when the executor job exits, which can race
 /// the worker's LIVE commit by seconds — a successful deploy briefly reads
@@ -2663,6 +2669,7 @@ pub(crate) fn settle_to_terminal(client: &FlooClient, app_id: &str, streamed: De
     poll_deploy(client, app_id, &streamed)
 }
 
+/// Poll the deploy endpoint until it reaches a terminal status.
 pub(crate) fn poll_deploy(client: &FlooClient, app_id: &str, initial_data: &Deploy) -> Deploy {
     let deploy_id = initial_data.id.clone();
     let poll_start = Instant::now();

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -2643,7 +2643,20 @@ pub(crate) fn stream_deploy_json(
     // the executor job exits, racing the worker's LIVE commit (#208). One
     // emission point, always terminal — also covers streams that EOF without
     // a server done event (previously: no done event at all).
-    let final_deploy = settle_to_terminal(client, app_id, client.get_deploy(app_id, deploy_id)?);
+    //
+    // Retry the post-stream read once: a transient blip here would otherwise
+    // return Err before the done event is emitted while the caller's poll
+    // fallback still succeeds — an NDJSON stream with no done on a green
+    // deploy (codex #208 round 3). A persistent failure still returns Err,
+    // and the caller's poll exits loudly.
+    let fetched = match client.get_deploy(app_id, deploy_id) {
+        Ok(d) => d,
+        Err(_) => {
+            thread::sleep(POLL_INTERVAL);
+            client.get_deploy(app_id, deploy_id)?
+        }
+    };
+    let final_deploy = settle_to_terminal(client, app_id, fetched);
     output::print_json(&serde_json::json!({
         "event": "done",
         "status": final_deploy.status.as_deref().unwrap_or(""),

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 
 use crate::api_client::FlooClient;
 use crate::api_types::Deploy;
-use crate::commands::deploy::{poll_deploy, stream_deploy, stream_deploy_json};
+use crate::commands::deploy::{poll_deploy, settle_to_terminal, stream_deploy, stream_deploy_json};
 use crate::deploy_status;
 use crate::errors::ErrorCode;
 use crate::output;
@@ -471,6 +471,7 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
             // Try SSE stream as fallback for missing logs
             match stream_deploy(&client, &app_id, &deploy.id) {
                 Ok(final_deploy) => {
+                    let final_deploy = settle_to_terminal(&client, &app_id, final_deploy);
                     if deploy_status::is_failure(final_deploy.status.as_deref().unwrap_or("")) {
                         process::exit(1);
                     }
@@ -491,7 +492,7 @@ pub fn logs(deploy_id: Option<&str>, app: Option<&str>, follow: bool) {
     } else if follow {
         // Active deploy + --follow: stream live
         let final_deploy = match stream_deploy(&client, &app_id, &deploy.id) {
-            Ok(d) => d,
+            Ok(d) => settle_to_terminal(&client, &app_id, d),
             Err(e) => {
                 output::warn(&format!(
                     "Stream unavailable ({}), falling back to polling...",
@@ -709,8 +710,10 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
     // Stream the active deploy
     let deploy_id = deploy.id.clone();
     let final_deploy = if !output::is_json_mode() {
-        let streamed = match stream_deploy(&client, &app_id, &deploy_id) {
-            Ok(d) => d,
+        match stream_deploy(&client, &app_id, &deploy_id) {
+            // settle_to_terminal owns the stream-ends-non-terminal race for
+            // EVERY stream consumer now — this inline fallback moved there.
+            Ok(d) => settle_to_terminal(&client, &app_id, d),
             Err(e) => {
                 eprintln!(
                     "Stream unavailable ({}), falling back to polling...",
@@ -718,15 +721,6 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
                 );
                 poll_deploy(&client, &app_id, &deploy)
             }
-        };
-        // SSE stream may end before the deploy reaches a terminal state (e.g. connection
-        // drop, server restart). If so, fall back to polling to wait for completion.
-        let streamed_status = streamed.status.as_deref().unwrap_or("");
-        if !deploy_status::is_terminal(streamed_status) {
-            eprintln!("Stream ended in non-terminal state ({streamed_status}), falling back to polling...");
-            poll_deploy(&client, &app_id, &streamed)
-        } else {
-            streamed
         }
     } else {
         match stream_deploy_json(&client, &app_id, &deploy_id) {

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -730,10 +730,14 @@ fn run_initial_deploy(
 
         if !output::is_json_mode() {
             match super::deploy::stream_deploy(client, app_id, &deploy_id) {
-                Ok(d) => deploy_data = d,
+                // Unsettled, this site INVERTED the #208 race: classify(None)
+                // on a raced "deploying" reported a healthy first deploy as
+                // FAILED with a  hint — the onboarding surface.
+                Ok(d) => deploy_data = super::deploy::settle_to_terminal(client, app_id, d),
                 Err(_) => deploy_data = super::deploy::poll_deploy(client, app_id, &deploy_data),
             }
         } else {
+            // stream_deploy_json settles internally before emitting done (#208).
             match super::deploy::stream_deploy_json(client, app_id, &deploy_id) {
                 Ok(d) => deploy_data = d,
                 Err(_) => deploy_data = super::deploy::poll_deploy(client, app_id, &deploy_data),


### PR DESCRIPTION
## What changed
One `settle_to_terminal` helper owns the SSE-stream/LIVE-commit race for EVERY stream consumer: a non-terminal stream result polls to terminal before any final-status handling; terminal results pass through untouched. Applied at all eight consumer sites — the six human-mode paths (watch's inline fallback folded into the helper), the `apps github connect` deploy path (which INVERTED the race: a healthy first deploy classified as FAILED with exit 1), and `stream_deploy_json` itself, which now settles BEFORE emitting its single `done` event — agents never see `done` with `status=deploying`, and streams that EOF without a server done event now emit a terminal one. A bounded retry keeps the done event alive across a transient post-stream read blip.

## Why
Feedback a117f92b (2026-07-04, floo-crm): a deploy completed rollout+migration and served healthy 200s, but the CLI exited 1 with 'Deploy ended in unexpected state: deploying'. Platform-side the row went LIVE 20 seconds before the report — the SSE stream closes when the executor job exits, racing the worker's LIVE commit, and the post-stream read caught the gap. Closes #208.

## Tests
Two unit tests pin the helper contract (non-terminal input polls to terminal; terminal input passes through with zero HTTP — expect(0)). Full ./scripts/test green (fmt + clippy -D warnings + 463 tests). Site-wiring coverage is a named gap (the mock harness cannot sequence SSE-then-poll responses); sites were enumerated independently by both reviewers.

## Review
3 rounds, Claude + codex parallel. R1: both flagged the incomplete site inventory (github connect P1, JSON paths P2) + doc-attachment nit. R2: settle-inside-stream_deploy_json + github fix; codex found the transient-read done-event gap. R3: bounded retry; codex: 'does not appear to break existing behavior'.