### PR TITLE
fix(ci): run the canonical suite on every PR — pull_request triggers + pr-check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Superseded runs on the same PR are wasted minutes — cancel them. Push runs
-# on main are never cancelled (each merge gets its full verdict).
+# Superseded runs on the same PR are wasted minutes — cancel them. Non-PR
+# runs (push to main, dispatch) get a unique group per run so no verdict is
+# ever cancelled: with a shared group, GitHub keeps at most one running plus
+# one pending run, so a third rapid merge would silently drop a pending main
+# verdict even with cancel-in-progress off (codex review, #210).
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,16 @@
 name: CI
 
 on:
+  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
+
+# Superseded runs on the same PR are wasted minutes — cancel them. Push runs
+# on main are never cancelled (each merge gets its full verdict).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,6 +22,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v5
@@ -47,8 +57,14 @@ jobs:
       - name: Run fmt, clippy, and tests
         run: ./scripts/test
 
+  # Informational, not a merge gate: tarpaulin (compiled from source each run)
+  # is too slow for the PR lane, so it tracks coverage on merges only. Keeping
+  # it out of pr-check's `needs` is deliberate — see the speed targets in the
+  # monorepo's docs/knowledge/domains/testing.md.
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v5
 
@@ -69,3 +85,19 @@ jobs:
 
       - name: Run coverage
         run: cargo tarpaulin --out stdout --skip-clean
+
+  # Aggregated status for branch protection — the ONE required context, same
+  # name and role as the monorepo's pr-check.yml summary job, so
+  # scripts/ops/configure-branch-protection.sh (in getfloo/floo) protects both
+  # repos with the same required-check list. To add a merge gate, add the job
+  # to `needs:` and its result to the assertion — the context name never
+  # changes. `coverage` is intentionally absent (informational lane, above).
+  pr-check:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - name: report
+        run: |
+          echo "test: ${{ needs.test.result }}"
+          [ "${{ needs.test.result }}" = "success" ]


### PR DESCRIPTION
## What changed
- `ci.yml` now triggers on `pull_request` and `push: main` (was `workflow_dispatch`-only — no CI ever ran on a PR; #209 merged with zero checks).
- New aggregated `pr-check` job (`needs: [test]`, `if: always()`, strict-equality success assertion) — the ONE required context, same name/pattern as the monorepo's, so `scripts/ops/configure-branch-protection.sh` protects both repos with the same check list.
- `coverage` (tarpaulin) stays off the PR lane (`if: github.event_name != 'pull_request'`) — informational on merges, per the testing speed doctrine.
- PR-lane concurrency cancel for superseded pushes; non-PR runs get a unique group per run so a pending main verdict is never dropped (codex P2). Job timeouts added.

## Why
Merges (and therefore releases) had no mechanical test gate — the v2026.07.05 release gate was a manual local `scripts/test` run. This PR is self-proving: the `pull_request` trigger takes effect on this very PR.

## Review
Full `./scripts/test` green on the branch (fmt, clippy, 1656 tests). actionlint clean. Claude heavy review: no P1s, pr-check assertion confirmed fail-closed for all four `needs.*.result` values. codex round 1: P2 concurrency finding, fixed; codex rereview of the delta: clean.

Branch protection (requiring `pr-check`) is applied via the monorepo's `configure-branch-protection.sh` immediately after this merges — posture re-encoded + bats-pinned in the monorepo PR.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)