### PR TITLE
feat: edge-policy docs topic + analytics rejection breakdown (getfloo/floo#1358 PR 4)

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -884,6 +884,11 @@ pub struct AnalyticsSummary {
     #[serde(default)]
     pub gateway_handled_requests: Option<i64>,
     pub status_code_breakdown: Option<HashMap<String, i64>>,
+    // {rejection_reason: count} over gateway-rejected requests (#1358), e.g.
+    // {"edge_policy": 42}. `default` keeps the CLI working against an API
+    // that predates the field.
+    #[serde(default)]
+    pub rejection_breakdown: Option<HashMap<String, i64>>,
     pub total_apps_with_traffic: Option<i64>,
 }
 

--- a/src/commands/analytics.rs
+++ b/src/commands/analytics.rs
@@ -109,6 +109,18 @@ fn render_app_analytics(name: &str, period: &str, data: &AppAnalyticsResponse) {
         }
     }
 
+    if let Some(rejections) = &summary.rejection_breakdown {
+        if !rejections.is_empty() {
+            eprintln!();
+            eprintln!("Gateway Rejections");
+            let mut rows: Vec<(&String, &i64)> = rejections.iter().collect();
+            rows.sort_by(|a, b| b.1.cmp(a.1));
+            for (reason, count) in rows {
+                eprintln!("  {:14}{:>10}", reason, format_number(*count));
+            }
+        }
+    }
+
     if !data.time_series.is_empty() {
         eprintln!();
         eprintln!("Traffic");
@@ -162,6 +174,18 @@ fn render_org_analytics(period: &str, data: &AppAnalyticsResponse) {
             eprintln!();
             eprintln!("Status Codes");
             render_status_code_chart(breakdown, total_requests);
+        }
+    }
+
+    if let Some(rejections) = &summary.rejection_breakdown {
+        if !rejections.is_empty() {
+            eprintln!();
+            eprintln!("Gateway Rejections");
+            let mut rows: Vec<(&String, &i64)> = rejections.iter().collect();
+            rows.sort_by(|a, b| b.1.cmp(a.1));
+            for (reason, count) in rows {
+                eprintln!("  {:14}{:>10}", reason, format_number(*count));
+            }
         }
     }
 

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -37,7 +37,7 @@ never uploads code.
   floo docs express    — build and deploy an Express app on floo (end-to-end)
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services (alias: storage)
-  floo docs edge       — inspect edge routes, services, and access policy
+  floo docs edge       — edge routes, the IP/CIDR firewall, enforcement order
   floo docs previews   — command-line preview sandboxes for remote branches
   floo docs config     — config file formats with examples (alias: app-toml)
   floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
@@ -358,6 +358,47 @@ JSON output is stable for agents:
 
 The output deliberately omits raw Cloud Run backend URLs. Treat floo hosts and
 custom domains as the public contract.
+
+## Edge policy (IP/CIDR firewall, Team plan)
+
+An ordered allow/deny rule list per app + environment, enforced at floo's
+edge BEFORE the request body is read and before any managed auth. Rules are
+evaluated top to bottom; first match wins; the default action applies when
+no rule matches. Previews inherit the dev policy.
+
+  # Office-only allowlist (everything else denied):
+  floo edge policy set --env prod --rule allow:203.0.113.0/24 --default-action deny
+
+  # Block one abusive network, allow everyone else:
+  floo edge policy set --env prod --rule deny:198.51.100.0/24 --default-action allow
+
+  floo edge policy get --env prod --json
+  floo edge policy clear --env prod --yes
+
+Also configurable in floo.app.toml (config wins on the next deploy):
+
+  [edge]
+  default_action = \"deny\"
+
+  [[edge.rules]]
+  action = \"allow\"
+  cidr = \"203.0.113.0/24\"
+
+  [environments.prod.edge]   # per-env override
+
+Denied requests get 403 {\"code\":\"EDGE_POLICY_DENIED\"}; denial counts appear
+in `floo analytics` as the rejection breakdown.
+
+## Enforcement order
+
+Requests pass gates in this order — an earlier denial short-circuits:
+
+  1. Cloud provider edge (TLS, volumetric DDoS)   [floo-managed]
+  2. Edge policy (this firewall)                  [yours]
+  3. Managed auth (access_mode, app API keys)     [yours]
+  4. Your app
+
+The edge policy cannot see or bypass auth; auth never runs for a denied IP.
 
 Full reference: https://getfloo.com/docs/cli/edge
 ";

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5462,3 +5462,27 @@ fn test_analytics_renders_rejection_breakdown() {
             r#""rejection_breakdown":{"edge_policy":42}"#,
         ));
 }
+
+#[test]
+fn test_org_analytics_renders_rejection_breakdown() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _m = server
+        .mock("GET", "/v1/orgs/analytics")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"app_id":null,"period":"7d","summary":{"total_requests":100,"total_errors":42,"error_rate":0.42,"avg_latency_ms":10,"p95_latency_ms":20,"unique_users":null,"gateway_handled_requests":42,"status_code_breakdown":{"2xx":58,"4xx":42},"rejection_breakdown":{"edge_policy":42},"total_apps_with_traffic":1},"time_series":[],"top_users":[]}"#,
+        )
+        .create();
+
+    // The org render path shares the section — pin it independently.
+    floo()
+        .args(["analytics", "--period", "7d"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Gateway Rejections"))
+        .stderr(predicate::str::contains("edge_policy"));
+}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5417,3 +5417,48 @@ fn test_edge_policy_set_ipv6_rule_parses_on_first_colon() {
         .success()
         .stdout(predicate::str::contains(r#""cidr":"2001:db8::/32""#));
 }
+
+#[test]
+fn test_analytics_renders_rejection_breakdown() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _m = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/analytics").as_str(),
+        )
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"app_id":"app-123","period":"7d","summary":{"total_requests":100,"total_errors":42,"error_rate":0.42,"avg_latency_ms":10,"p95_latency_ms":20,"unique_users":3,"gateway_handled_requests":42,"status_code_breakdown":{"2xx":58,"4xx":42},"rejection_breakdown":{"edge_policy":42},"total_apps_with_traffic":null},"time_series":[],"top_users":[]}"#,
+        )
+        .create();
+
+    // Human render surfaces the firewall's denial count.
+    floo()
+        .args(["analytics", "--app", TEST_APP_NAME, "--period", "7d"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Gateway Rejections"))
+        .stderr(predicate::str::contains("edge_policy"));
+
+    // JSON passes the field through untouched for agents.
+    floo()
+        .args([
+            "--json",
+            "analytics",
+            "--app",
+            TEST_APP_NAME,
+            "--period",
+            "7d",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#""rejection_breakdown":{"edge_policy":42}"#,
+        ));
+}


### PR DESCRIPTION
## What changed
- `floo docs edge` now covers the IP/CIDR firewall: set/get/clear examples, the floo.app.toml `[edge]` shape, and the enforcement-order table (provider edge → edge policy → managed auth → app) — docs routed to the moment of action.
- `floo analytics` renders the new `rejection_breakdown` as a Gateway Rejections section (sorted desc) on both app and org paths, with `serde(default)` compat against older APIs, so a firewall's denials are visible from the terminal.

## Review (Claude + codex parallel)
Claude: SHIP + P3 (org-path render untested — pinned via the org endpoint mock). codex: clean both rounds. Docs content verified flag-for-flag against the real CLI and the API toml resolver.

## Tests
3 analytics mock tests (app human/JSON + org) + docs topic invariants; full suite green (fmt + clippy -D warnings).

Companion: getfloo/floo analytics PR (rollup + migration backfill + API responses). Part of getfloo/floo#1360; closes the getfloo/floo#1358 PR 4 CLI half.