### PR TITLE
feat!: edge policy is config-only — remove set/clear, add read-only check (getfloo/floo#1456)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "colored 2.2.0",
  "comfy-table",
  "indicatif",
+ "ipnet",
  "libc",
  "mockito",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/main.rs"
 [dependencies]
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
+ipnet = "2"
 colored = "2"
 comfy-table = "7"
 indicatif = "0.18"

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ floo domains list --app my-app
 # Edge routes
 floo edge routes list --app my-app --json
 
-# Edge policy (IP/CIDR firewall, Team plan)
-floo edge policy set --env prod --rule allow:203.0.113.0/24 --default-action deny
+# Edge policy (IP/CIDR firewall, Team plan) — configured in floo.app.toml [edge], read via CLI
 floo edge policy get --env prod
+floo edge policy check 203.0.113.7 --env prod
 ```
 
 All commands are invoked with the production alias: `floo`.

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -156,16 +156,6 @@ impl FlooClient {
             .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
     }
 
-    fn put_json(
-        &self,
-        path: &str,
-        body: &Value,
-    ) -> Result<reqwest::blocking::Response, FlooApiError> {
-        let req = self.apply_headers(self.client.put(self.url(path)).json(body));
-        req.send()
-            .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
-    }
-
     fn delete(&self, path: &str) -> Result<reqwest::blocking::Response, FlooApiError> {
         let req = self.apply_headers(self.client.delete(self.url(path)));
         req.send()
@@ -364,35 +354,6 @@ impl FlooClient {
     pub fn get_edge_policy(&self, app_id: &str, env: &str) -> Result<EdgePolicyData, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}/environments/{env}/edge-policy"))?;
         self.handle_response(resp)
-    }
-
-    pub fn set_edge_policy(
-        &self,
-        app_id: &str,
-        env: &str,
-        rules: &[EdgePolicyRule],
-        default_action: &str,
-        enabled: bool,
-    ) -> Result<EdgePolicyData, FlooApiError> {
-        let body = serde_json::json!({
-            "rules": rules,
-            "default_action": default_action,
-            "enabled": enabled,
-        });
-        let resp = self.put_json(
-            &format!("/v1/apps/{app_id}/environments/{env}/edge-policy"),
-            &body,
-        )?;
-        self.handle_response(resp)
-    }
-
-    pub fn delete_edge_policy(&self, app_id: &str, env: &str) -> Result<(), FlooApiError> {
-        let resp = self.delete(&format!("/v1/apps/{app_id}/environments/{env}/edge-policy"))?;
-        if resp.status().as_u16() == 204 {
-            return Ok(());
-        }
-        self.handle_response_value(resp)?;
-        Ok(())
     }
 
     pub fn delete_app(&self, app_id: &str) -> Result<(), FlooApiError> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -918,7 +918,10 @@ pub enum EdgePolicyCommands {
   floo edge policy get --app my-app --env dev --json
 
 Shows the ordered allow/deny rules, the default action, and whether the
-policy is enabled. Previews inherit the dev policy automatically.")]
+policy is enabled. Previews inherit the dev policy automatically.
+
+The edge policy is configured in floo.app.toml under [edge] and applied on
+deploy — this command (and 'check') are read-only. See 'floo docs edge'.")]
     Get {
         /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
@@ -929,23 +932,19 @@ policy is enabled. Previews inherit the dev policy automatically.")]
         env: String,
     },
 
-    /// Create or replace the edge policy for an environment.
+    /// Check whether an IP would be admitted by the edge policy.
     #[command(after_help = "Examples:
-  # Office-only allowlist (everything else is denied):
-  floo edge policy set --env prod --rule allow:203.0.113.0/24 --default-action deny
+  floo edge policy check 203.0.113.7 --env prod
+  floo edge policy check 2001:db8::1 --env dev --json
 
-  # Block one abusive network, allow everyone else:
-  floo edge policy set --env prod --rule deny:198.51.100.0/24 --default-action allow
+Evaluates the IP against the live policy (first-match rules, then the default
+action) and prints admitted/denied plus the matching rule. Read-only — the
+gateway is the authoritative enforcer; this mirrors its logic for debugging.
+To CHANGE the policy, edit floo.app.toml [edge] and deploy.")]
+    Check {
+        /// The client IP to test (IPv4 or IPv6).
+        ip: String,
 
-  # Multiple rules — first match wins, top to bottom:
-  floo edge policy set --env prod \
-    --rule allow:203.0.113.7/32 --rule deny:203.0.113.0/24 --default-action allow
-
-Rules are evaluated in the order given; the default action applies when no
-rule matches. IPv4 and IPv6 CIDRs are accepted; bare IPs mean /32 (or /128).
-Replaces any existing policy for the environment. Requires the Team plan.
-Also configurable in floo.app.toml under [edge] — config wins on deploy.")]
-    Set {
         /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
         app: Option<String>,
@@ -953,39 +952,6 @@ Also configurable in floo.app.toml under [edge] — config wins on deploy.")]
         /// Environment: dev or prod. Previews inherit dev.
         #[arg(long, value_parser = ["dev", "prod"])]
         env: String,
-
-        /// Ordered rule as <allow|deny>:<CIDR>. Repeatable; first match wins.
-        #[arg(long = "rule", value_name = "ACTION:CIDR")]
-        rule: Vec<String>,
-
-        /// Action when no rule matches.
-        #[arg(long, default_value = "allow", value_parser = ["allow", "deny"])]
-        default_action: String,
-
-        /// Store the policy without enforcing it.
-        #[arg(long)]
-        disabled: bool,
-    },
-
-    /// Remove the edge policy for an environment (opens traffic back up).
-    #[command(after_help = "Examples:
-  floo edge policy clear --env prod --yes
-
-Deletes the policy entirely — all IPs are admitted again (subject to the
-app's auth). To keep the rules but stop enforcing them, use
-'floo edge policy set ... --disabled' instead.")]
-    Clear {
-        /// App name or ID (reads from config if omitted).
-        #[arg(short, long)]
-        app: Option<String>,
-
-        /// Environment: dev or prod.
-        #[arg(long, value_parser = ["dev", "prod"])]
-        env: String,
-
-        /// Skip the confirmation prompt.
-        #[arg(long)]
-        yes: bool,
     },
 }
 
@@ -1912,8 +1878,6 @@ const DRY_RUN_SUPPORTED_COMMANDS: &[&str] = &[
     "apps delete",
     "domains add",
     "domains remove",
-    "edge policy set",
-    "edge policy clear",
     "cron run",
     "deploys rollback",
     "db migrate",
@@ -2324,21 +2288,8 @@ pub fn run() {
                 EdgePolicyCommands::Get { app, env } => {
                     commands::edge::policy_get(app.as_deref(), &env)
                 }
-                EdgePolicyCommands::Set {
-                    app,
-                    env,
-                    rule,
-                    default_action,
-                    disabled,
-                } => commands::edge::policy_set(
-                    app.as_deref(),
-                    &env,
-                    &rule,
-                    &default_action,
-                    disabled,
-                ),
-                EdgePolicyCommands::Clear { app, env, yes } => {
-                    commands::edge::policy_clear(app.as_deref(), &env, yes)
+                EdgePolicyCommands::Check { ip, app, env } => {
+                    commands::edge::policy_check(&ip, app.as_deref(), &env)
                 }
             },
         },
@@ -2673,32 +2624,6 @@ mod tests {
             (
                 "domains add",
                 &["floo", "domains", "add", "x.com", "--dry-run"],
-            ),
-            (
-                "edge policy set",
-                &[
-                    "floo",
-                    "edge",
-                    "policy",
-                    "set",
-                    "--env",
-                    "prod",
-                    "--rule",
-                    "allow:10.0.0.0/8",
-                    "--dry-run",
-                ],
-            ),
-            (
-                "edge policy clear",
-                &[
-                    "floo",
-                    "edge",
-                    "policy",
-                    "clear",
-                    "--env",
-                    "prod",
-                    "--dry-run",
-                ],
             ),
             (
                 "domains remove",

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -366,25 +366,23 @@ edge BEFORE the request body is read and before any managed auth. Rules are
 evaluated top to bottom; first match wins; the default action applies when
 no rule matches. Previews inherit the dev policy.
 
-  # Office-only allowlist (everything else denied):
-  floo edge policy set --env prod --rule allow:203.0.113.0/24 --default-action deny
+The firewall is configured as code in floo.app.toml and applied on deploy —
+that is the single source of truth (version-controlled, reviewable, auditable).
+The CLI is read-only.
 
-  # Block one abusive network, allow everyone else:
-  floo edge policy set --env prod --rule deny:198.51.100.0/24 --default-action allow
-
-  floo edge policy get --env prod --json
-  floo edge policy clear --env prod --yes
-
-Also configurable in floo.app.toml (config wins on the next deploy):
-
-  [edge]
+  [edge]                       # office-only allowlist: deny everything else
   default_action = \"deny\"
 
   [[edge.rules]]
   action = \"allow\"
   cidr = \"203.0.113.0/24\"
 
-  [environments.prod.edge]   # per-env override
+  [environments.prod.edge]     # per-env override (previews inherit dev)
+
+Change the firewall by editing floo.app.toml and deploying. Read it with:
+
+  floo edge policy get --env prod --json
+  floo edge policy check 203.0.113.7 --env prod   # would this IP be admitted?
 
 Denied requests get 403 {\"code\":\"EDGE_POLICY_DENIED\"}; denial counts appear
 in `floo analytics` as the rejection breakdown.

--- a/src/commands/edge.rs
+++ b/src/commands/edge.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 use std::process;
 
-use ipnet::IpNet;
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 
 use crate::api_types::{EdgePolicyRule, EdgeRoute};
 use crate::errors::ErrorCode;
@@ -152,7 +152,7 @@ pub fn policy_get(app: Option<&str>, env: &str) {
 fn admits(ip: IpAddr, rules: &[EdgePolicyRule], default_allow: bool) -> (bool, Option<usize>) {
     let ip = normalize_ip(ip);
     for (i, rule) in rules.iter().enumerate() {
-        if let Ok(net) = rule.cidr.parse::<IpNet>() {
+        if let Some(net) = parse_rule_cidr(&rule.cidr) {
             // IpNet::contains returns false on version mismatch, matching the
             // gateway's explicit `address.version == network.version` guard.
             if net.contains(&ip) {
@@ -161,6 +161,21 @@ fn admits(ip: IpAddr, rules: &[EdgePolicyRule], default_allow: bool) -> (bool, O
         }
     }
     (default_allow, None)
+}
+
+/// Parse a stored rule CIDR, normalizing a bare IP to a host network (/32 or
+/// /128) — the gateway's `ipaddress.ip_network(strict=False)` accepts bare
+/// IPs, so `check` must too or it would disagree with enforcement on a rule
+/// that reached the DB un-normalized. Genuinely unparseable input is skipped.
+fn parse_rule_cidr(cidr: &str) -> Option<IpNet> {
+    if let Ok(net) = cidr.parse::<IpNet>() {
+        return Some(net);
+    }
+    match cidr.parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) => Ipv4Net::new(v4, 32).ok().map(IpNet::V4),
+        Ok(IpAddr::V6(v6)) => Ipv6Net::new(v6, 128).ok().map(IpNet::V6),
+        Err(_) => None,
+    }
 }
 
 /// An IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) evaluates as its IPv4 form,

--- a/src/commands/edge.rs
+++ b/src/commands/edge.rs
@@ -1,6 +1,9 @@
+use std::net::IpAddr;
 use std::process;
 
-use crate::api_types::EdgeRoute;
+use ipnet::IpNet;
+
+use crate::api_types::{EdgePolicyRule, EdgeRoute};
 use crate::errors::ErrorCode;
 use crate::output;
 
@@ -141,165 +144,111 @@ pub fn policy_get(app: Option<&str>, env: &str) {
     );
 }
 
-/// Parse `--rule allow:203.0.113.0/24` into an API rule. CIDR syntax is
-/// validated server-side (one validation authority); the CLI only splits
-/// the action prefix so typos fail fast with a local message.
-fn parse_rule_arg(raw: &str) -> Result<crate::api_types::EdgePolicyRule, String> {
-    let Some((action, cidr)) = raw.split_once(':') else {
-        return Err(format!(
-            "rule '{raw}' must be <allow|deny>:<CIDR>, e.g. allow:203.0.113.0/24"
-        ));
-    };
-    if action != "allow" && action != "deny" {
-        return Err(format!(
-            "rule '{raw}' has action '{action}' — must be 'allow' or 'deny'"
-        ));
-    }
-    if cidr.is_empty() {
-        return Err(format!("rule '{raw}' is missing a CIDR after the ':'"));
-    }
-    Ok(crate::api_types::EdgePolicyRule {
-        action: action.to_string(),
-        cidr: cidr.to_string(),
-    })
-}
-
-pub fn policy_set(
-    app: Option<&str>,
-    env: &str,
-    rules: &[String],
-    default_action: &str,
-    disabled: bool,
-) {
-    let mut parsed = Vec::with_capacity(rules.len());
-    for raw in rules {
-        match parse_rule_arg(raw) {
-            Ok(rule) => parsed.push(rule),
-            Err(msg) => {
-                output::error(
-                    &msg,
-                    &ErrorCode::InvalidFormat,
-                    Some("Rules are <allow|deny>:<CIDR>, evaluated in order; first match wins."),
-                );
-                process::exit(1);
+/// Mirror of the gateway's `CompiledEdgePolicy.admits` (gateway/app/edge_policy.py):
+/// ordered first-match CIDR containment, version-matched, else the default action.
+/// Returns (admitted, matched_rule_index). The gateway is the authoritative
+/// enforcer; this is a read-only preview, so a rule whose CIDR fails to parse
+/// (server-validated, so vanishingly rare) is skipped rather than erroring.
+fn admits(ip: IpAddr, rules: &[EdgePolicyRule], default_allow: bool) -> (bool, Option<usize>) {
+    let ip = normalize_ip(ip);
+    for (i, rule) in rules.iter().enumerate() {
+        if let Ok(net) = rule.cidr.parse::<IpNet>() {
+            // IpNet::contains returns false on version mismatch, matching the
+            // gateway's explicit `address.version == network.version` guard.
+            if net.contains(&ip) {
+                return (rule.action == "allow", Some(i));
             }
         }
     }
-    if parsed.is_empty() && default_action == "allow" {
-        output::error(
-            "This policy has no rules and default-action allow — it admits everything, same as no policy.",
-            &ErrorCode::InvalidFormat,
-            Some("Add at least one --rule, use --default-action deny, or run 'floo edge policy clear'."),
-        );
-        process::exit(1);
-    }
+    (default_allow, None)
+}
 
-    if output::is_dry_run_mode() {
-        let target = app.unwrap_or("(reads from config)");
-        output::dry_run_preview(
-            &format!(
-                "Would replace the {env} edge policy on {target}: {} rule(s), default {default_action}{}.",
-                parsed.len(),
-                if disabled { ", stored disabled" } else { "" }
-            ),
-            serde_json::json!({
-                "action": "edge_policy_set",
-                "app": app,
-                "environment": env,
-                "rules": parsed,
-                "default_action": default_action,
-                "enabled": !disabled,
-            }),
-        );
-        return;
+/// An IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) evaluates as its IPv4 form,
+/// matching the gateway's `_parse_client_ip`.
+fn normalize_ip(ip: IpAddr) -> IpAddr {
+    if let IpAddr::V6(v6) = ip {
+        if let Some(v4) = v6.to_ipv4_mapped() {
+            return IpAddr::V4(v4);
+        }
     }
+    ip
+}
+
+pub fn policy_check(ip_str: &str, app: Option<&str>, env: &str) {
+    let ip: IpAddr = match ip_str.parse() {
+        Ok(ip) => ip,
+        Err(_) => {
+            output::error(
+                &format!("'{ip_str}' is not a valid IP address."),
+                &ErrorCode::InvalidFormat,
+                Some("Pass an IPv4 or IPv6 address, e.g. 203.0.113.7 or 2001:db8::1."),
+            );
+            process::exit(1);
+        }
+    };
 
     super::require_auth();
     let client = super::init_client(None);
     let (app_id, app_name) = super::resolve_app_from_config(&client, app);
 
-    let policy = match client.set_edge_policy(&app_id, env, &parsed, default_action, !disabled) {
-        Ok(p) => p,
+    let policy = match client.get_edge_policy(&app_id, env) {
+        Ok(p) => Some(p),
+        Err(e) if e.code == "EDGE_POLICY_NOT_FOUND" => None,
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
             process::exit(1);
         }
     };
 
-    let note = if disabled {
-        " (stored DISABLED — not enforced)"
-    } else {
-        ""
+    // No policy, or a stored-but-disabled policy, admits every IP (the gateway
+    // only enforces an enabled policy).
+    let (admitted, matched_idx, enforced) = match &policy {
+        None => (true, None, false),
+        Some(p) if !p.enabled => (true, None, false),
+        Some(p) => {
+            let (a, m) = admits(ip, &p.rules, p.default_action == "allow");
+            (a, m, true)
+        }
     };
-    output::success(
-        &format!(
-            "Edge policy set for {app_name} in {env}: {} rule(s), default {}{note}.",
-            policy.rules.len(),
-            policy.default_action
-        ),
-        Some(output::to_value(&policy)),
-    );
-}
+    let matched_rule = matched_idx.and_then(|i| policy.as_ref().map(|p| &p.rules[i]));
 
-pub fn policy_clear(app: Option<&str>, env: &str, yes: bool) {
-    use crate::confirm::{confirm_tier2, ConfirmOutcome, RiskMetadata, Tier};
-
-    if output::is_dry_run_mode() {
-        let risk: RiskMetadata = Tier::Two.into();
-        let target = app.unwrap_or("(reads from config)");
-        output::dry_run_preview(
-            &format!("Would remove the {env} edge policy from {target} — all IPs admitted again."),
-            serde_json::json!({
-                "action": "edge_policy_clear",
-                "app": app,
+    if output::is_json_mode() {
+        let reason = if !enforced {
+            if policy.is_none() {
+                "no_policy"
+            } else {
+                "policy_disabled"
+            }
+        } else if matched_rule.is_some() {
+            "rule_match"
+        } else {
+            "default_action"
+        };
+        output::success(
+            &format!("Edge policy check for {app_name} in {env}."),
+            Some(serde_json::json!({
+                "ip": ip_str,
                 "environment": env,
-                "destructive": risk.destructive,
-                "data_loss": risk.data_loss,
-                "tier": risk.tier,
-            }),
+                "admitted": admitted,
+                "enforced": enforced,
+                "matched_rule": matched_rule,
+                "reason": reason,
+            })),
         );
         return;
     }
 
-    super::require_auth();
-    let client = super::init_client(None);
-    let (app_id, app_name) = super::resolve_app_from_config(&client, app);
-
-    match confirm_tier2(
-        "Remove edge policy",
-        &format!("the {env} IP firewall for {app_name} (all IPs admitted again)"),
-        yes,
-    ) {
-        ConfirmOutcome::Proceed => {}
-        ConfirmOutcome::Aborted => {
-            if !output::is_json_mode() {
-                output::info("Cancelled — edge policy unchanged.", None);
-            }
-            process::exit(0);
+    let verdict = if admitted { "ADMITTED" } else { "DENIED" };
+    let detail = match (&policy, matched_rule) {
+        (None, _) => "no edge policy, all IPs admitted".to_string(),
+        (Some(p), _) if !p.enabled => {
+            "policy is disabled (not enforced), all IPs admitted".to_string()
         }
-        ConfirmOutcome::Refused { suggestion } => {
-            crate::confirm::exit_refused(
-                &format!(
-                    "Refusing to remove the {env} edge policy for {app_name} without explicit confirmation."
-                ),
-                &suggestion,
-            );
-        }
-    }
-
-    if let Err(e) = client.delete_edge_policy(&app_id, env) {
-        output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-        process::exit(1);
-    }
-
-    let risk: RiskMetadata = Tier::Two.into();
-    output::success(
-        &format!("Edge policy removed for {app_name} in {env} — all IPs admitted again."),
-        Some(serde_json::json!({
-            "environment": env,
-            "destructive": risk.destructive,
-            "data_loss": risk.data_loss,
-            "tier": risk.tier,
-        })),
+        (Some(_), Some(rule)) => format!("matched rule {} {}", rule.action, rule.cidr),
+        (Some(p), None) => format!("no rule matched, default {}", p.default_action),
+    };
+    output::info(
+        &format!("{ip_str} in {app_name}/{env}: {verdict} ({detail})."),
+        None,
     );
 }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5137,196 +5137,63 @@ fn test_edge_policy_get_not_found_is_a_valid_state() {
 }
 
 #[test]
-fn test_edge_policy_set_json() {
+fn test_edge_policy_check_admitted_by_rule() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
     let _m = server
         .mock(
-            "PUT",
+            "GET",
             format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
         )
-        .match_body(Matcher::JsonString(
-            r#"{"rules":[{"action":"allow","cidr":"203.0.113.0/24"},{"action":"deny","cidr":"198.51.100.0/24"}],"default_action":"deny","enabled":true}"#.into(),
-        ))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(edge_policy_json())
         .create();
 
+    // edge_policy_json: allow 203.0.113.0/24, deny 198.51.100.0/24, default deny.
     floo()
         .args([
             "--json",
             "edge",
             "policy",
-            "set",
+            "check",
+            "203.0.113.7",
             "--app",
             TEST_APP_NAME,
             "--env",
             "prod",
-            "--rule",
-            "allow:203.0.113.0/24",
-            "--rule",
-            "deny:198.51.100.0/24",
-            "--default-action",
-            "deny",
         ])
         .env("HOME", home.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains(r#""success":true"#))
-        .stdout(predicate::str::contains(r#""enabled":true"#));
+        .stdout(predicate::str::contains(r#""admitted":true"#))
+        .stdout(predicate::str::contains(r#""reason":"rule_match""#))
+        .stdout(predicate::str::contains(r#""cidr":"203.0.113.0/24""#));
 }
 
 #[test]
-fn test_edge_policy_set_rejects_malformed_rule_locally() {
-    let server = Server::new();
-    let home = setup_config(&server);
-
-    // No API mocks — the parse error must fail before any HTTP call.
-    floo()
-        .args([
-            "--json",
-            "edge",
-            "policy",
-            "set",
-            "--app",
-            TEST_APP_NAME,
-            "--env",
-            "prod",
-            "--rule",
-            "permit:10.0.0.0/8",
-        ])
-        .env("HOME", home.path())
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("INVALID_FORMAT"))
-        .stdout(predicate::str::contains("permit"));
-}
-
-#[test]
-fn test_edge_policy_set_refuses_no_op_allow_all() {
-    let server = Server::new();
-    let home = setup_config(&server);
-
-    // Zero rules + default allow admits everything — same as no policy. Refuse.
-    floo()
-        .args([
-            "--json",
-            "edge",
-            "policy",
-            "set",
-            "--app",
-            TEST_APP_NAME,
-            "--env",
-            "prod",
-        ])
-        .env("HOME", home.path())
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("INVALID_FORMAT"))
-        .stdout(predicate::str::contains("admits everything"));
-}
-
-#[test]
-fn test_edge_policy_clear_refuses_without_yes_flag_in_json_mode() {
-    let mut server = Server::new();
-    let home = setup_config(&server);
-    let _resolve = mock_resolve_app(&mut server);
-
-    // No DELETE mock — command must refuse before reaching that endpoint.
-    floo()
-        .args([
-            "--json",
-            "edge",
-            "policy",
-            "clear",
-            "--app",
-            TEST_APP_NAME,
-            "--env",
-            "prod",
-        ])
-        .env("HOME", home.path())
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("CONFIRMATION_REQUIRED"));
-}
-
-#[test]
-fn test_edge_policy_clear_json_with_yes_flag() {
+fn test_edge_policy_check_denied_by_default() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
     let _m = server
         .mock(
-            "DELETE",
+            "GET",
             format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
         )
-        .with_status(204)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(edge_policy_json())
         .create();
 
+    // 10.0.0.1 matches no rule -> default deny.
     floo()
         .args([
-            "--json",
             "edge",
             "policy",
-            "clear",
-            "--app",
-            TEST_APP_NAME,
-            "--env",
-            "prod",
-            "--yes",
-        ])
-        .env("HOME", home.path())
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(r#""success":true"#))
-        .stdout(predicate::str::contains(r#""tier":2"#));
-}
-
-#[test]
-fn test_edge_policy_set_dry_run_never_calls_the_api() {
-    let mut server = Server::new();
-    let home = setup_config(&server);
-    let _resolve = mock_resolve_app(&mut server);
-
-    // No PUT mock — a real mutation under --dry-run would 501 and fail loudly.
-    floo()
-        .args([
-            "--json",
-            "--dry-run",
-            "edge",
-            "policy",
-            "set",
-            "--app",
-            TEST_APP_NAME,
-            "--env",
-            "prod",
-            "--rule",
-            "allow:203.0.113.0/24",
-            "--default-action",
-            "deny",
-        ])
-        .env("HOME", home.path())
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(r#""action":"edge_policy_set""#))
-        .stdout(predicate::str::contains(r#""enabled":true"#));
-}
-
-#[test]
-fn test_edge_policy_clear_dry_run_never_calls_the_api() {
-    let server = Server::new();
-    let home = setup_config(&server);
-
-    // No resolve/DELETE mocks — the preview must not touch the network.
-    floo()
-        .args([
-            "--json",
-            "--dry-run",
-            "edge",
-            "policy",
-            "clear",
+            "check",
+            "10.0.0.1",
             "--app",
             TEST_APP_NAME,
             "--env",
@@ -5335,25 +5202,24 @@ fn test_edge_policy_clear_dry_run_never_calls_the_api() {
         .env("HOME", home.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains(r#""action":"edge_policy_clear""#))
-        .stdout(predicate::str::contains(r#""tier":2"#));
+        .stderr(predicate::str::contains("DENIED"))
+        .stderr(predicate::str::contains("default deny"));
 }
 
 #[test]
-fn test_edge_policy_set_disabled_sends_enabled_false() {
+fn test_edge_policy_check_ipv6_first_match() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
     let _m = server
         .mock(
-            "PUT",
-            format!("/v1/apps/{TEST_APP_ID}/environments/dev/edge-policy").as_str(),
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
         )
-        .match_body(Matcher::PartialJsonString(r#"{"enabled":false}"#.into()))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            r#"{"id":"pol-3","app_id":"app-123","environment":"dev","rules":[{"action":"deny","cidr":"10.0.0.0/8"}],"default_action":"allow","enabled":false,"created_at":"2026-07-05T10:00:00Z","updated_at":"2026-07-05T10:00:00Z"}"#,
+            r#"{"id":"pol-6","app_id":"app-123","environment":"prod","rules":[{"action":"allow","cidr":"2001:db8::/32"}],"default_action":"deny","enabled":true,"created_at":"2026-07-05T10:00:00Z","updated_at":"2026-07-05T10:00:00Z"}"#,
         )
         .create();
 
@@ -5362,60 +5228,113 @@ fn test_edge_policy_set_disabled_sends_enabled_false() {
             "--json",
             "edge",
             "policy",
-            "set",
-            "--app",
-            TEST_APP_NAME,
-            "--env",
-            "dev",
-            "--rule",
-            "deny:10.0.0.0/8",
-            "--disabled",
-        ])
-        .env("HOME", home.path())
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(r#""enabled":false"#));
-}
-
-#[test]
-fn test_edge_policy_set_ipv6_rule_parses_on_first_colon() {
-    let mut server = Server::new();
-    let home = setup_config(&server);
-    let _resolve = mock_resolve_app(&mut server);
-    let _m = server
-        .mock(
-            "PUT",
-            format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
-        )
-        .match_body(Matcher::PartialJsonString(
-            r#"{"rules":[{"action":"allow","cidr":"2001:db8::/32"}]}"#.into(),
-        ))
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            r#"{"id":"pol-4","app_id":"app-123","environment":"prod","rules":[{"action":"allow","cidr":"2001:db8::/32"}],"default_action":"deny","enabled":true,"created_at":"2026-07-05T10:00:00Z","updated_at":"2026-07-05T10:00:00Z"}"#,
-        )
-        .create();
-
-    floo()
-        .args([
-            "--json",
-            "edge",
-            "policy",
-            "set",
+            "check",
+            "2001:db8::1",
             "--app",
             TEST_APP_NAME,
             "--env",
             "prod",
-            "--rule",
-            "allow:2001:db8::/32",
-            "--default-action",
-            "deny",
         ])
         .env("HOME", home.path())
         .assert()
         .success()
+        .stdout(predicate::str::contains(r#""admitted":true"#))
         .stdout(predicate::str::contains(r#""cidr":"2001:db8::/32""#));
+}
+
+#[test]
+fn test_edge_policy_check_no_policy_admits_all() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _m = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
+        )
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"EDGE_POLICY_NOT_FOUND","message":"No edge policy."}}"#)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "edge",
+            "policy",
+            "check",
+            "1.2.3.4",
+            "--app",
+            TEST_APP_NAME,
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""admitted":true"#))
+        .stdout(predicate::str::contains(r#""reason":"no_policy""#));
+}
+
+#[test]
+fn test_edge_policy_check_disabled_admits_all() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _m = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"pol-7","app_id":"app-123","environment":"prod","rules":[{"action":"deny","cidr":"0.0.0.0/0"}],"default_action":"deny","enabled":false,"created_at":"2026-07-05T10:00:00Z","updated_at":"2026-07-05T10:00:00Z"}"#,
+        )
+        .create();
+
+    // Even a deny-all policy admits when disabled (not enforced).
+    floo()
+        .args([
+            "--json",
+            "edge",
+            "policy",
+            "check",
+            "1.2.3.4",
+            "--app",
+            TEST_APP_NAME,
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""admitted":true"#))
+        .stdout(predicate::str::contains(r#""reason":"policy_disabled""#));
+}
+
+#[test]
+fn test_edge_policy_check_rejects_bad_ip_locally() {
+    let server = Server::new();
+    let home = setup_config(&server);
+
+    // No API mocks — a malformed IP fails before any auth/HTTP.
+    floo()
+        .args([
+            "--json",
+            "edge",
+            "policy",
+            "check",
+            "not-an-ip",
+            "--app",
+            TEST_APP_NAME,
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("INVALID_FORMAT"));
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5173,6 +5173,44 @@ fn test_edge_policy_check_admitted_by_rule() {
 }
 
 #[test]
+fn test_edge_policy_check_matches_bare_ip_rule() {
+    // codex #1456: a bare-IP rule (gateway treats as /32) must match — check
+    // must not disagree with the gateway on an un-normalized stored rule.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _m = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/environments/prod/edge-policy").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"pol-8","app_id":"app-123","environment":"prod","rules":[{"action":"allow","cidr":"203.0.113.7"}],"default_action":"deny","enabled":true,"created_at":"2026-07-05T10:00:00Z","updated_at":"2026-07-05T10:00:00Z"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "edge",
+            "policy",
+            "check",
+            "203.0.113.7",
+            "--app",
+            TEST_APP_NAME,
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""admitted":true"#))
+        .stdout(predicate::str::contains(r#""reason":"rule_match""#));
+}
+
+#[test]
 fn test_edge_policy_check_denied_by_default() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## Why
Corrects the drift the #1358 arc shipped: the firewall was writable via BOTH `floo edge policy set` and `floo.app.toml` `[edge]`, config silently winning on deploy. A security control's source of truth must be version-controlled and reviewable (config-source-of-truth doctrine, getfloo/floo#1455). Decision with @pdonohoe02: config-as-code is the single authoritative writer; the CLI is read-only.

## What changed
- **Removed** `floo edge policy set` and `clear` (BREAKING) + the API set/delete client methods + the `put_json` helper.
- **Added** `floo edge policy check <ip> --env <env>` — mirrors the gateway's first-match `admits()` (via `ipnet`, bare IPs normalized to /32 · /128) to answer 'would this IP be admitted?' without a write. The gateway stays authoritative; read-only preview.
- `get` and `[edge]` config parsing unchanged; `floo docs edge` + README lead with config-as-code.

## Review (Claude + codex, 2 rounds)
codex R1 P2: `check` skipped bare-IP rules (`IpNet::from_str` needs a prefix), disagreeing with the gateway — fixed with `parse_rule_cidr` + regression. R2: clean.

## Tests
9 edge-policy tests (3 get + 6 check). Full suite green (fmt + clippy -D warnings).

Companion: getfloo/floo API PR (removes PUT/DELETE, keeps GET + deploy upsert). Closes getfloo/floo#1456 (CLI half).