### PR TITLE
feat(sdlc): self-contained pre-push test gate (#217)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# pre-push — floo-cli local test gate (getfloo/floo-cli#217).
+#
+# Runs the canonical suite (./scripts/test: fmt --check, clippy -D warnings,
+# cargo test) before a push that changes Rust code, and blocks on failure. This
+# is the fast-feedback gate that catches breakage before a CI round. It is fully
+# self-contained — no dependency on the private floo monorepo — so it works for
+# external contributors and anyone working directly in floo-cli.
+#
+# Internal note: monorepo-driven CLI work (via floo's scripts/floo-cli-worktree.sh)
+# is ALSO gated from the monorepo session (getfloo/floo#1448); this hook is the
+# repo-local complement for everyone else. The two are independent.
+#
+# Install: ./scripts/install-hooks.sh (sets core.hooksPath = .githooks).
+# Bypass:  git push --no-verify   (use when you trust CI to catch it).
+#
+# Only Rust/build changes trigger the suite; docs/config/CI/script-only pushes
+# skip it. Branch deletions and up-to-date pushes are no-ops.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+ZERO='0000000000000000000000000000000000000000'
+
+# Collect the changed-file set across every ref being pushed (stdin lines:
+# <local ref> <local sha> <remote ref> <remote sha>).
+changed=""
+force_test=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$ZERO" ] && continue          # branch deletion — nothing to test
+  if [ "$remote_sha" = "$ZERO" ]; then
+    # New branch on the remote: diff against origin/main when we have it.
+    if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+      range="origin/main..$local_sha"
+    else
+      range=""                                     # unknown base → force a run below
+    fi
+  else
+    range="$remote_sha..$local_sha"
+  fi
+  if [ -z "$range" ]; then
+    force_test=1                                   # brand-new branch, no base → gate
+    continue
+  fi
+  # --no-renames so a Rust file renamed AWAY (src/x.rs -> src/x.bak) still shows
+  # the old .rs path and gates. If the range can't be diffed at all (e.g. a
+  # force-push from a stale clone whose remote_sha isn't in our object DB, which
+  # errors with "bad object"), FAIL CLOSED — run the suite rather than skip it on
+  # an empty result.
+  if diff_out=$(git diff --name-only --no-renames "$range" 2>/dev/null); then
+    changed+="$diff_out"$'\n'
+  else
+    force_test=1
+  fi
+done
+
+# Does the push touch Rust/build files? (Everything else — docs, .github, scripts,
+# .githooks, *.md, *.toml that isn't Cargo.toml — is a no-op for the test suite.)
+# An unresolvable/new range already forced needs_test above.
+needs_test="$force_test"
+if [ "$needs_test" -eq 0 ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    # *.rs covers build.rs; Cargo.toml/Cargo.lock cover dependency + manifest edits.
+    case "$f" in
+      *.rs|Cargo.toml|Cargo.lock) needs_test=1; break ;;
+    esac
+  done <<EOF
+$changed
+EOF
+fi
+
+if [ "$needs_test" -eq 0 ]; then
+  exit 0
+fi
+
+echo "pre-push: Rust changes detected — running ./scripts/test (bypass: git push --no-verify)" >&2
+if ! ./scripts/test; then
+  echo "" >&2
+  echo "pre-push: ./scripts/test failed — push blocked. Fix the failures, or push with" >&2
+  echo "          --no-verify if you are intentionally deferring to CI." >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check script syntax
-        run: bash -n install.sh && bash -n scripts/test
+        run: bash -n install.sh && bash -n scripts/test && bash -n .githooks/pre-push && bash -n scripts/install-hooks.sh
 
       - name: Run installer script tests
         run: bash tests/install_script_test.sh
@@ -53,6 +53,9 @@ jobs:
 
       - name: Run test-harness guard tests
         run: bash tests/test_script_test.sh
+
+      - name: Run pre-push hook tests
+        run: bash tests/pre_push_hook_test.sh
 
       # fmt + clippy + cargo test via the canonical entry point, which also
       # self-heals the corrupt-harness artifact class (floo-cli#204) that the

--- a/README.md
+++ b/README.md
@@ -117,13 +117,19 @@ cargo build
 Contributions are welcome! Please:
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feat/my-feature`)
-3. Run tests and lint before committing:
+2. Install the git hooks once (a pre-push gate runs `./scripts/test` on Rust changes):
+   ```bash
+   ./scripts/install-hooks.sh
+   ```
+3. Create a feature branch (`git checkout -b feat/my-feature`)
+4. Run tests and lint before committing:
    ```bash
    ./scripts/test
    ```
-4. Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
-5. Open a pull request
+5. Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
+6. Open a pull request
+
+The pre-push hook blocks a push whose Rust changes fail `./scripts/test`; bypass an individual push with `git push --no-verify` when you're deferring to CI.
 
 ## Documentation
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# install-hooks.sh — point this checkout's git hooks at the tracked .githooks/
+# directory (getfloo/floo-cli#217). Run once after cloning.
+#
+#   ./scripts/install-hooks.sh
+#
+# Installs a pre-push gate that runs ./scripts/test (fmt + clippy + cargo test)
+# on Rust changes before a push, blocking on failure. Bypass an individual push
+# with `git push --no-verify`.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+git -C "$ROOT" config core.hooksPath .githooks
+
+echo "floo-cli git hooks installed (core.hooksPath = .githooks)."
+echo "  pre-push runs ./scripts/test on Rust changes; bypass with 'git push --no-verify'."

--- a/tests/pre_push_hook_test.sh
+++ b/tests/pre_push_hook_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for .githooks/pre-push (getfloo/floo-cli#217): a Rust change runs
+# ./scripts/test (block on fail, allow on pass); docs-only pushes skip the
+# suite; branch deletions are no-ops.
+set -euo pipefail
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/.githooks/pre-push"
+ZERO='0000000000000000000000000000000000000000'
+PASS=0
+FAIL=0
+
+check() {  # label  got  want
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s\n' "$1"; PASS=$((PASS + 1))
+  else
+    printf '  FAIL %s (got rc=%s, want rc=%s)\n' "$1" "$2" "$3" >&2; FAIL=$((FAIL + 1))
+  fi
+}
+
+# make_repo TEST_EXIT — a git repo with the hook installed and a scripts/test
+# stub that exits TEST_EXIT. Echoes the repo dir. Leaves an init commit.
+make_repo() {
+  local d; d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" config user.email t@e.com
+  git -C "$d" config user.name t
+  git -C "$d" config commit.gpgsign false
+  mkdir -p "$d/.githooks" "$d/scripts" "$d/src"
+  cp "$HOOK_SRC" "$d/.githooks/pre-push"; chmod +x "$d/.githooks/pre-push"
+  printf '#!/usr/bin/env bash\nexit %s\n' "$1" > "$d/scripts/test"; chmod +x "$d/scripts/test"
+  printf 'fn main() {}\n' > "$d/src/main.rs"
+  printf '# floo-cli\n' > "$d/README.md"
+  git -C "$d" add -A
+  git -C "$d" commit -qm init
+  printf '%s' "$d"
+}
+
+# run_hook REPO LOCAL_SHA REMOTE_SHA — feed the pre-push stdin line and echo the
+# hook's exit code. Stdin format: <local ref> <local sha> <remote ref> <remote sha>.
+run_hook() {
+  local rc=0
+  printf 'refs/heads/feat %s refs/heads/feat %s\n' "$2" "$3" \
+    | ( cd "$1" && ./.githooks/pre-push ) >/dev/null 2>&1 || rc=$?
+  printf '%s' "$rc"
+}
+
+echo "pre-push hook tests"
+
+# 1. Rust change + passing suite → allow (rc 0).
+d=$(make_repo 0); base=$(git -C "$d" rev-parse HEAD)
+printf 'fn main() { let _ = 1; }\n' > "$d/src/main.rs"; git -C "$d" add -A && git -C "$d" commit -qm "feat: rust"
+head=$(git -C "$d" rev-parse HEAD)
+check "rust change, suite passes -> allow" "$(run_hook "$d" "$head" "$base")" "0"
+rm -rf "$d"
+
+# 2. Rust change + failing suite → block (rc 1).
+d=$(make_repo 1); base=$(git -C "$d" rev-parse HEAD)
+printf 'fn main() { let _ = 2; }\n' > "$d/src/main.rs"; git -C "$d" add -A && git -C "$d" commit -qm "feat: rust"
+head=$(git -C "$d" rev-parse HEAD)
+check "rust change, suite fails -> block" "$(run_hook "$d" "$head" "$base")" "1"
+rm -rf "$d"
+
+# 3. Docs-only change + failing suite → allow (suite not run).
+d=$(make_repo 1); base=$(git -C "$d" rev-parse HEAD)
+printf '# floo-cli\nmore docs\n' > "$d/README.md"; git -C "$d" add -A && git -C "$d" commit -qm "docs: readme"
+head=$(git -C "$d" rev-parse HEAD)
+check "docs-only change -> skip suite (allow)" "$(run_hook "$d" "$head" "$base")" "0"
+rm -rf "$d"
+
+# 4. Cargo.toml change is Rust/build → gated.
+d=$(make_repo 1); base=$(git -C "$d" rev-parse HEAD)
+printf '[package]\nname="x"\n' > "$d/Cargo.toml"; git -C "$d" add -A && git -C "$d" commit -qm "build: cargo.toml"
+head=$(git -C "$d" rev-parse HEAD)
+check "Cargo.toml change, suite fails -> block" "$(run_hook "$d" "$head" "$base")" "1"
+rm -rf "$d"
+
+# 5. Branch deletion (local sha = zeros) → no-op (allow), suite never runs.
+d=$(make_repo 1); base=$(git -C "$d" rev-parse HEAD)
+check "branch deletion -> no-op (allow)" "$(run_hook "$d" "$ZERO" "$base")" "0"
+rm -rf "$d"
+
+# 6. New branch (remote sha = zeros) with no origin/main → force a run. Rust or
+#    not, the base is unknown, so the suite MUST run (fail-closed). Suite fails.
+d=$(make_repo 1)
+printf '# docs only\n' > "$d/README.md"; git -C "$d" add -A && git -C "$d" commit -qm "docs"
+head=$(git -C "$d" rev-parse HEAD)
+check "new branch, unknown base -> force run (block)" "$(run_hook "$d" "$head" "$ZERO")" "1"
+rm -rf "$d"
+
+# 7. FAIL-CLOSED on an unresolvable range: an existing-branch update whose
+#    remote_sha is a commit not in the local object DB (force-push from a stale
+#    clone) must run the suite, not silently skip. Suite fails → block.
+d=$(make_repo 1)
+printf 'fn main() { let _ = 3; }\n' > "$d/src/main.rs"; git -C "$d" add -A && git -C "$d" commit -qm "feat: rust"
+head=$(git -C "$d" rev-parse HEAD)
+bogus="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+check "unresolvable range (unknown remote sha) -> force run (block)" "$(run_hook "$d" "$head" "$bogus")" "1"
+rm -rf "$d"
+
+# 8. Rust file renamed AWAY (src/main.rs -> src/main.bak): --no-renames surfaces
+#    the removed .rs path, so the suite still runs. Suite fails → block.
+d=$(make_repo 1); base=$(git -C "$d" rev-parse HEAD)
+git -C "$d" mv src/main.rs src/main.bak; git -C "$d" commit -qm "refactor: rename away rust"
+head=$(git -C "$d" rev-parse HEAD)
+check "rust renamed away -> suite still runs (block)" "$(run_hook "$d" "$head" "$base")" "1"
+rm -rf "$d"
+
+echo
+printf "  %d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "✓ pre-push hook tests green"


### PR DESCRIPTION
## What changed

floo-cli's `.git/hooks/pre-push` was a disabled `exit 0` stub, so external contributors — and anyone working directly in floo-cli, outside the monorepo-driven flow — had **no local test gate**; only CI caught failures. This adds a tracked, self-contained one.

- **`.githooks/pre-push`** — on a push that changes Rust/build files (`*.rs`, `Cargo.toml`, `Cargo.lock`), runs `./scripts/test` (fmt + clippy + cargo test) and blocks on failure. `--no-renames` so a Rust file renamed away still gates; an unresolvable/new range fails **closed** (runs the suite). Docs/config/script-only pushes and branch deletions are no-ops. Bypass with `git push --no-verify`. **No dependency on the private floo monorepo.**
- **`scripts/install-hooks.sh`** — sets `core.hooksPath = .githooks` (run once after cloning).
- **`tests/pre_push_hook_test.sh`** — 8 cases: block-on-fail / allow-on-pass / skip-docs / Cargo.toml-gated / deletion-noop, plus the three fail-open regressions (new-branch force, unresolvable-remote-sha force, rename-away). Wired into `ci.yml` + the script-syntax check.
- **README Contributing** — install-hooks step + the `--no-verify` note.

## Why

Belt-and-suspenders local gate. Independent of getfloo/floo#1448, which gates *monorepo-driven* CLI work from the monorepo session; this is the repo-local complement for everyone else. CI remains the backstop.

## Review

Adversarially reviewed (Claude + Codex, cross-family). Both independently caught the unresolvable-range fail-open; Codex also caught the rename-away fail-open. Both fixed and regression-pinned (tests fail against the pre-fix hook), re-reviewed clean.

## Tests

`bash tests/pre_push_hook_test.sh` → 8 passed. shellcheck clean; `install-hooks.sh` verified to set `core.hooksPath`. No Rust changed, so fmt/clippy/cargo test are unaffected (CI runs the full suite).

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
