### PR TITLE
docs: add egress CLI topic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -371,7 +371,7 @@ Examples:
     /// full list of topics with one-line descriptions.
     #[command(after_help = "\
 Topics: golden-path, quickstart, build, nextjs, rails, fastapi, django,
-express, templates, services, edge, previews, config, cron, deploy, auth,
+express, templates, services, edge, egress, previews, config, cron, deploy, auth,
 notifications, feedback.
 Aliases: storage -> services, app-toml -> config.
 Run `floo docs` (no topic) for a one-line description of each topic.")]

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -38,6 +38,7 @@ never uploads code.
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services (alias: storage)
   floo docs edge       — edge routes, the IP/CIDR firewall, enforcement order
+  floo docs egress     — outbound egress and private-network status
   floo docs previews   — command-line preview sandboxes for remote branches
   floo docs config     — config file formats with examples (alias: app-toml)
   floo docs cron       — [cron.<name>] schema, schedules, and CLI surface
@@ -399,6 +400,61 @@ Requests pass gates in this order — an earlier denial short-circuits:
 The edge policy cannot see or bypass auth; auth never runs for a denied IP.
 
 Full reference: https://getfloo.com/docs/cli/edge
+";
+
+const EGRESS: &str = "\
+Floo Egress and Networking
+
+floo puts your app behind the floo gateway for inbound traffic. Your app's
+outbound traffic uses Cloud Run's normal internet egress today.
+
+## Inbound traffic
+
+  client
+    -> *.on.getfloo.com or custom domain
+    -> floo gateway
+    -> edge policy and managed auth
+    -> your Cloud Run app service
+
+Do not expose or depend on raw *.run.app backend URLs. Treat floo hosts and
+custom domains as the public contract.
+
+Inspect the live route table with:
+
+  floo edge routes list --app my-app --env prod
+  floo edge routes list --app my-app --env prod --json
+
+## Outbound egress
+
+Current contract:
+
+  Public HTTPS APIs             supported
+  Slack/payment/webhook calls   supported through normal SDKs or HTTP clients
+  Stable outbound source IP     not provided today
+  SMTP port 25                  not available
+  SMTP submission               use 587 or 465 with provider auth
+  Private VPC or tailnet apps   not generally available today
+
+If a vendor requires source-IP allowlisting, do not assume floo has a fixed
+egress IP for your app. Prefer API-token auth, OAuth, mutual TLS, or the
+vendor's HTTPS API. If fixed egress is mandatory, email team@getfloo.com before
+designing around it.
+
+## Private network deployments
+
+Private network deployments are planned as an enterprise connector model, not a
+current config toggle:
+
+  - floo control plane stays public
+  - app traffic to private backends stays inside the customer network
+  - a customer-side connector opens an outbound-only tunnel to floo
+  - floo gateway remains the auth, edge-policy, and audit boundary
+  - tailnet is one possible transport, not the whole product model
+
+The connector lifecycle, routing model, auth model, and tunnel-down behavior
+will be documented before this is enabled for production workloads.
+
+Full guide: https://getfloo.com/docs/guides/networking
 ";
 
 const PREVIEWS: &str = "\
@@ -1883,6 +1939,7 @@ pub(crate) const TOPICS: &[(&str, &str)] = &[
     ("templates", TEMPLATES),
     ("services", SERVICES),
     ("edge", EDGE),
+    ("egress", EGRESS),
     ("previews", PREVIEWS),
     ("config", CONFIG),
     ("cron", CRON),
@@ -2073,6 +2130,16 @@ mod tests {
         assert!(PREVIEWS.contains("PREVIEW_MANAGED_SERVICE_ISOLATION_UNAVAILABLE"));
         assert!(PREVIEWS.contains("floo previews delete"));
         assert!(PREVIEWS.contains("getfloo.com/docs/cli/previews"));
+    }
+
+    #[test]
+    fn test_egress_topic_documents_network_boundary_contract() {
+        assert!(OVERVIEW.contains("floo docs egress"));
+        assert!(EGRESS.contains("Cloud Run's normal internet egress"));
+        assert!(EGRESS.contains("Stable outbound source IP"));
+        assert!(EGRESS.contains("SMTP port 25"));
+        assert!(EGRESS.contains("customer-side connector"));
+        assert!(EGRESS.contains("getfloo.com/docs/guides/networking"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed
- Adds `floo docs egress` covering inbound edge routing, outbound egress, source-IP expectations, SMTP guidance, and private-network status.
- Lists the topic in `floo docs` and `floo docs --help`.
- Adds a regression test for the network-boundary docs contract.

## Why
Mirrors the new customer docs guide for terminal-first agents. Supports getfloo/floo#1019 and getfloo/floo#486 as part of getfloo/floo#1360.

## Tests run
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
