### PR TITLE
fix: stop sending config-only preview_* fields in deploy body (#220)

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -8,6 +8,82 @@ use crate::config::{load_config, FlooConfig};
 use crate::errors::FlooApiError;
 use crate::project_config::ServiceConfig;
 
+/// Build the JSON request body for `POST /v1/apps/{id}/deploys`.
+///
+/// Pure (no I/O) so the wire contract is unit-testable. The one non-obvious
+/// rule it encodes: preview settings (`preview_environments` /
+/// `preview_ttl_hours`) are **config-only** — the API reads them server-side
+/// from the deploy tarball's `[github]` section and rejects a deploy body that
+/// carries either field (getfloo/floo#1460). The CLI parses those keys into
+/// `GitHubConfig` for validation and round-trip, but must never echo them into
+/// this body; doing so was the getfloo/floo-cli#220 `422`. `deploy_on_push`
+/// remains a live body field.
+#[allow(clippy::too_many_arguments)]
+fn build_deploy_body(
+    runtime: &str,
+    framework: Option<&str>,
+    services: Option<&[ServiceConfig]>,
+    access_mode: Option<&str>,
+    agent_mode: Option<&str>,
+    auth_redirect_uris: Option<&[String]>,
+    cron_jobs: Option<&[crate::project_config::CronJobEntry]>,
+    github_config: Option<&crate::project_config::GitHubConfig>,
+    skip_migrations: bool,
+) -> Result<Value, FlooApiError> {
+    let mut body = serde_json::json!({
+        "runtime": runtime,
+    });
+    if skip_migrations {
+        body["skip_migrations"] = Value::Bool(true);
+    }
+    if let Some(fw) = framework {
+        body["framework"] = Value::String(fw.to_string());
+    }
+    if let Some(svcs) = services {
+        body["services"] = serde_json::to_value(svcs).map_err(|e| {
+            FlooApiError::new(
+                0,
+                "SERIALIZATION_ERROR",
+                format!("Failed to serialize services: {e}"),
+            )
+        })?;
+    }
+    if let Some(mode) = access_mode {
+        body["access_mode"] = Value::String(mode.to_string());
+    }
+    if let Some(mode) = agent_mode {
+        body["agent_mode"] = Value::String(mode.to_string());
+    }
+    if let Some(uris) = auth_redirect_uris {
+        body["auth_redirect_uris"] = serde_json::to_value(uris).map_err(|e| {
+            FlooApiError::new(
+                0,
+                "SERIALIZATION_ERROR",
+                format!("Failed to serialize auth_redirect_uris: {e}"),
+            )
+        })?;
+    }
+    if let Some(crons) = cron_jobs {
+        if !crons.is_empty() {
+            body["cron_jobs"] = serde_json::to_value(crons).map_err(|e| {
+                FlooApiError::new(
+                    0,
+                    "SERIALIZATION_ERROR",
+                    format!("Failed to serialize cron_jobs: {e}"),
+                )
+            })?;
+        }
+    }
+    if let Some(gh) = github_config {
+        if let Some(v) = gh.deploy_on_push {
+            body["deploy_on_push"] = Value::Bool(v);
+        }
+        // preview_environments / preview_ttl_hours are intentionally NOT sent —
+        // see the doc comment above (getfloo/floo#1460, getfloo/floo-cli#220).
+    }
+    Ok(body)
+}
+
 pub struct FlooClient {
     client: Client,
     base_url: String,
@@ -381,61 +457,17 @@ impl FlooClient {
         github_config: Option<&crate::project_config::GitHubConfig>,
         skip_migrations: bool,
     ) -> Result<Deploy, FlooApiError> {
-        let mut body = serde_json::json!({
-            "runtime": runtime,
-        });
-        if skip_migrations {
-            body["skip_migrations"] = Value::Bool(true);
-        }
-        if let Some(fw) = framework {
-            body["framework"] = Value::String(fw.to_string());
-        }
-        if let Some(svcs) = services {
-            body["services"] = serde_json::to_value(svcs).map_err(|e| {
-                FlooApiError::new(
-                    0,
-                    "SERIALIZATION_ERROR",
-                    format!("Failed to serialize services: {e}"),
-                )
-            })?;
-        }
-        if let Some(mode) = access_mode {
-            body["access_mode"] = Value::String(mode.to_string());
-        }
-        if let Some(mode) = agent_mode {
-            body["agent_mode"] = Value::String(mode.to_string());
-        }
-        if let Some(uris) = auth_redirect_uris {
-            body["auth_redirect_uris"] = serde_json::to_value(uris).map_err(|e| {
-                FlooApiError::new(
-                    0,
-                    "SERIALIZATION_ERROR",
-                    format!("Failed to serialize auth_redirect_uris: {e}"),
-                )
-            })?;
-        }
-        if let Some(crons) = cron_jobs {
-            if !crons.is_empty() {
-                body["cron_jobs"] = serde_json::to_value(crons).map_err(|e| {
-                    FlooApiError::new(
-                        0,
-                        "SERIALIZATION_ERROR",
-                        format!("Failed to serialize cron_jobs: {e}"),
-                    )
-                })?;
-            }
-        }
-        if let Some(gh) = github_config {
-            if let Some(v) = gh.deploy_on_push {
-                body["deploy_on_push"] = Value::Bool(v);
-            }
-            if let Some(v) = gh.preview_environments {
-                body["preview_environments"] = Value::Bool(v);
-            }
-            if let Some(v) = gh.preview_ttl_hours {
-                body["preview_ttl_hours"] = Value::Number(v.into());
-            }
-        }
+        let body = build_deploy_body(
+            runtime,
+            framework,
+            services,
+            access_mode,
+            agent_mode,
+            auth_redirect_uris,
+            cron_jobs,
+            github_config,
+            skip_migrations,
+        )?;
         let resp = self.post_json(&format!("/v1/apps/{app_id}/deploys"), &body)?;
         self.handle_response(resp)
     }
@@ -1335,5 +1367,99 @@ impl FlooClient {
         let resp = self.post_json("/v1/feedback", &body)?;
         self.handle_response_value(resp)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project_config::GitHubConfig;
+
+    #[test]
+    fn build_deploy_body_omits_config_only_preview_fields() {
+        // A floo.app.toml [github] block declaring preview settings parses into
+        // GitHubConfig, but those fields are config-only (read server-side from
+        // the tarball). The deploy body must carry deploy_on_push yet NEVER the
+        // preview_* fields, which the API 422-rejects (getfloo/floo-cli#220).
+        let gh = GitHubConfig {
+            deploy_on_push: Some(true),
+            preview_environments: Some(true),
+            preview_ttl_hours: Some(48),
+        };
+        let body = build_deploy_body(
+            "nodejs",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&gh),
+            false,
+        )
+        .expect("body builds");
+        let obj = body.as_object().expect("body is a JSON object");
+
+        assert_eq!(obj.get("deploy_on_push"), Some(&Value::Bool(true)));
+        assert!(
+            !obj.contains_key("preview_environments"),
+            "deploy body must not carry config-only preview_environments: {body}"
+        );
+        assert!(
+            !obj.contains_key("preview_ttl_hours"),
+            "deploy body must not carry config-only preview_ttl_hours: {body}"
+        );
+    }
+
+    #[test]
+    fn build_deploy_body_omits_preview_fields_when_only_preview_declared() {
+        // Even when preview_* are the ONLY [github] keys (no deploy_on_push),
+        // neither leaks into the body, and no deploy_on_push key is invented.
+        let gh = GitHubConfig {
+            deploy_on_push: None,
+            preview_environments: Some(true),
+            preview_ttl_hours: Some(24),
+        };
+        let body = build_deploy_body(
+            "python",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&gh),
+            false,
+        )
+        .expect("body builds");
+        let obj = body.as_object().expect("body is a JSON object");
+
+        assert!(!obj.contains_key("preview_environments"), "{body}");
+        assert!(!obj.contains_key("preview_ttl_hours"), "{body}");
+        assert!(!obj.contains_key("deploy_on_push"), "{body}");
+    }
+
+    #[test]
+    fn build_deploy_body_sends_deploy_on_push_false() {
+        // deploy_on_push is a live body field and is sent even when false, so a
+        // caller cannot mistake "omitted" for "disabled".
+        let gh = GitHubConfig {
+            deploy_on_push: Some(false),
+            preview_environments: None,
+            preview_ttl_hours: None,
+        };
+        let body = build_deploy_body(
+            "nodejs",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&gh),
+            false,
+        )
+        .expect("body builds");
+        assert_eq!(body.get("deploy_on_push"), Some(&Value::Bool(false)));
     }
 }


### PR DESCRIPTION
## What changed
`create_deploy` no longer sends `preview_environments`/`preview_ttl_hours` in the `POST /v1/apps/{id}/deploys` body. Those preview settings are config-only — the API reads them server-side from the deploy tarball's `[github]` section and (since getfloo/floo#1514) rejects a body that carries them — so `floo redeploy` from a local dir whose `floo.app.toml` declares `[github] preview_*` hit a 422. The deploy-body construction is extracted into a pure, unit-testable `build_deploy_body()` helper; the two preview writers are removed.

## Why
Regression after getfloo/floo#1514 made preview settings config-only. floo-cli parsed `[github] preview_*` into `GitHubConfig` and echoed the values into the deploy body — now a dead, 422-rejected wire field. `deploy_on_push` stays (still a live body param); the `GitHubConfig` struct keeps the preview keys (valid `[github]` toml under `deny_unknown_fields`, round-trip tested). Paired with getfloo/floo#1524, which softens the API 422 to tolerate-and-ignore for already-released CLIs; the two are independently deployable in any order.

## Risk tier
standard (`src/api_client.rs`). Self-reviewed; also covered by the monorepo-gated combined review.

## Files reviewers should scrutinize
- `src/api_client.rs` — `build_deploy_body()` (behavior-equivalent to the old inline construction except the two removed preview writers) and the `create_deploy` call site.

## Tests run
- `./scripts/test` (fmt --check + clippy -D warnings + cargo test): 134 integration tests + 3 new unit tests pass. The new unit tests pin the wire contract: `preview_*` never appear in the body; `deploy_on_push` does (even when false).

## Known non-goals
- Only the deploy-body forwarding changes; `[github]` toml parsing/validation is unchanged.

## Issue Closure (Required)
Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
