### PR TITLE
ci: pin GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ concurrency:
   group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Least-privilege token, matching release.yml's discipline. The test job
+# executes code from fork PRs (cargo test, installer e2e); nothing in this
+# workflow needs write access.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Suspected trigger for the corrupt test-harness class (floo-cli#204) is


### PR DESCRIPTION
## Summary

Follow-up hardening to #211. The CI workflow executes code from fork PRs (`cargo test`, installer e2e scripts) but declares no `permissions` block, so jobs inherit the repository default token grant — which may be the legacy read/write set. Nothing in this workflow needs write access.

Pins the workflow token to `contents: read`, matching `release.yml`'s least-privilege discipline.

Flagged as the one should-fix in the sensitive-tier heavy review (Claude reviewer + Codex, both attested via the hub; Codex re-confirmed post-rebase).

## Test plan

- `actionlint` clean
- All steps (checkout, cache, toolchain, tests) are read-only — nothing in `ci.yml` writes via `GITHUB_TOKEN`
- CI on this PR exercises the pinned token end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)