### PR TITLE
feat(dev): verify Postgres is actually reachable before handing off

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -305,6 +305,33 @@ pub fn dev(args: DevArgs) {
 
     let session_id = session.session_id.clone();
 
+    // --- Confirm Postgres reachability before handing off ---
+    //
+    // `postgres_authorized` means the API's Cloud SQL patch was ACCEPTED, not
+    // that the rule is in effect (Cloud SQL applies it asynchronously). Starting
+    // the developer's services now would race that apply and surface as a
+    // connection refused/timeout inside their app. So we ask the only
+    // authoritative source: can this machine open a socket to the instance?
+    //
+    // Runs outside the human-only block below because JSON mode reports it too.
+    let postgres_ready = if session.postgres_authorized {
+        let spinner = if output::is_json_mode() {
+            None
+        } else {
+            Some(output::Spinner::new(
+                "Waiting for Postgres authorization to take effect...",
+            ))
+        };
+        let outcome =
+            crate::postgres_ready::verify(&session.services, crate::postgres_ready::DEFAULT_BUDGET);
+        if let Some(s) = spinner {
+            s.finish();
+        }
+        outcome
+    } else {
+        None
+    };
+
     // --- Print status messages (human only) ---
     // `output::info` in JSON mode writes {"success":true,"data":null} to
     // stdout; unguarded, these status lines would emit stray JSON objects
@@ -316,11 +343,33 @@ pub fn dev(args: DevArgs) {
             None,
         );
 
-        if session.postgres_authorized {
-            output::info(
-                "  Postgres: your IP is authorized for direct connections",
-                None,
-            );
+        match &postgres_ready {
+            Some(crate::postgres_ready::Readiness::Authorized { waited }) => {
+                output::info(
+                    &format!(
+                        "  Postgres: your IP is authorized for direct connections (verified in {:.0}s)",
+                        waited.as_secs_f32()
+                    ),
+                    None,
+                );
+            }
+            Some(crate::postgres_ready::Readiness::TimedOut { waited }) => {
+                output::warn(&format!(
+                    "  Postgres: authorization was accepted but the database was still \
+unreachable after {:.0}s. Starting anyway — direct connections may fail until \
+Cloud SQL finishes applying it.",
+                    waited.as_secs_f32()
+                ));
+            }
+            // Accepted, but the session carries no direct-Postgres endpoint to
+            // probe (no managed Postgres, or no rewrite). Nothing to claim.
+            None if session.postgres_authorized => {
+                output::info(
+                    "  Postgres: your IP is authorized for direct connections",
+                    None,
+                );
+            }
+            None => {}
         }
 
         if !session.withheld_secret_keys.is_empty() {
@@ -425,6 +474,15 @@ pub fn dev(args: DevArgs) {
                 "session_id": session_id,
                 "app": app_name,
                 "postgres_authorized": session.postgres_authorized,
+                // Whether a TCP connection to Postgres actually succeeded.
+                // `postgres_authorized` only says the Cloud SQL patch was accepted;
+                // this says the rule is in effect. null when there was nothing to
+                // verify (no direct-Postgres endpoint in this session).
+                "postgres_reachable": match &postgres_ready {
+                    Some(crate::postgres_ready::Readiness::Authorized { .. }) => serde_json::Value::Bool(true),
+                    Some(crate::postgres_ready::Readiness::TimedOut { .. }) => serde_json::Value::Bool(false),
+                    None => serde_json::Value::Null,
+                },
                 "withheld_secret_keys": session.withheld_secret_keys,
                 "services": json_services,
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod dockerfile;
 mod errors;
 mod names;
 mod output;
+mod postgres_ready;
 mod project_config;
 mod redact;
 mod resolve;

--- a/src/postgres_ready.rs
+++ b/src/postgres_ready.rs
@@ -1,0 +1,252 @@
+//! Verify that a dev session's Postgres authorization is actually in effect.
+//!
+//! `POST /v1/apps/{id}/dev-session` returns `postgres_authorized: true` when the
+//! API's Cloud SQL patch was **accepted**. Cloud SQL applies it asynchronously —
+//! seconds on a quiet instance, tens of seconds under load, unbounded per
+//! Google's docs. So "accepted" is not "you can connect".
+//!
+//! We do not ask the control plane whether it thinks the rule is applied. Google
+//! publishes no guarantee about when a settings change becomes visible in
+//! `instances.get`, nor read-after-write once its Operation is DONE, and a
+//! control-plane read can never speak for the data plane anyway. The
+//! authoritative answer to "can this machine reach Postgres?" is observable at
+//! exactly one place: this machine, by opening a socket.
+//!
+//! Measured against prod on 2026-07-10: from a non-allow-listed IP a connect to
+//! the instance's public endpoint **times out** (the authorized-networks
+//! firewall silently drops the packets, so there is no RST); from an
+//! allow-listed IP it completes. A successful TCP connect is therefore a
+//! sufficient, premise-free signal, and it subsumes propagation delay for free.
+//!
+//! We connect and immediately drop. No TLS, no startup packet, no credentials:
+//! reaching the listener is the whole question. Postgres logs an aborted
+//! connection at most.
+
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
+
+/// How long a single connect attempt may block before we call it "not yet".
+///
+/// A blocked connect does not fail fast — the firewall drops packets, so the
+/// client waits out its own timeout. Keep it short enough that the overall
+/// budget is checked often, long enough that a slow network path is not
+/// mistaken for a firewall drop.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Delay between attempts. The authorized-networks operation is the thing we are
+/// waiting on; polling faster than it can possibly complete just burns syscalls.
+const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Total wall-clock budget. Generous: observed applies range from ~5s (quiet
+/// instance) to ~21s (under load), and Google documents no upper bound. Past
+/// this we stop blocking the developer and let their services start.
+pub const DEFAULT_BUDGET: Duration = Duration::from_secs(90);
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Readiness {
+    /// A TCP connection to the instance succeeded — the IP is allow-listed.
+    Authorized { waited: Duration },
+    /// The budget elapsed without a successful connection.
+    TimedOut { waited: Duration },
+}
+
+/// The Postgres endpoint the API rewrote into this session's env vars.
+///
+/// The API rewrites `PGHOST`/`PGPORT` (and `DATABASE_URL`) to the Cloud SQL
+/// public IP only when it accepted the authorized-network patch, so their
+/// presence is what marks a session as having direct-Postgres intent. Any one
+/// service's map carries them; they are identical across services.
+pub fn endpoint_from_env(
+    services: &std::collections::HashMap<String, std::collections::HashMap<String, String>>,
+) -> Option<(String, u16)> {
+    for env in services.values() {
+        let host = match env.get("PGHOST") {
+            Some(h) if !h.is_empty() => h,
+            _ => continue,
+        };
+        // Loopback means the API did not rewrite for direct access (no managed
+        // Postgres, or the rewrite was skipped) — there is nothing to verify.
+        if host == "127.0.0.1" || host == "localhost" {
+            continue;
+        }
+        let port = env
+            .get("PGPORT")
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(5432);
+        return Some((host.clone(), port));
+    }
+    None
+}
+
+/// True when a TCP connection to `host:port` completes within `ATTEMPT_TIMEOUT`.
+///
+/// Resolution failure and refusal are both "not reachable" — never a hard error.
+/// A refusal (RST) would mean something is listening but declining, which the
+/// authorized-networks firewall does not do; we treat it as not-yet regardless.
+fn tcp_reachable(host: &str, port: u16) -> bool {
+    let Ok(mut addrs) = (host, port).to_socket_addrs() else {
+        return false;
+    };
+    addrs.any(|addr| TcpStream::connect_timeout(&addr, ATTEMPT_TIMEOUT).is_ok())
+}
+
+/// Poll until the endpoint accepts a connection, or the budget elapses.
+///
+/// `probe` is injected so the retry/budget logic is testable without sockets.
+/// `sleep` likewise, so tests never actually wait.
+pub fn wait_until_reachable<P, S>(budget: Duration, mut probe: P, mut sleep: S) -> Readiness
+where
+    P: FnMut() -> bool,
+    S: FnMut(Duration),
+{
+    let start = Instant::now();
+    loop {
+        if probe() {
+            return Readiness::Authorized {
+                waited: start.elapsed(),
+            };
+        }
+        // Check the budget BEFORE sleeping: a probe that returns right at the
+        // deadline should not buy itself another RETRY_DELAY of the user's time.
+        if start.elapsed() >= budget {
+            return Readiness::TimedOut {
+                waited: start.elapsed(),
+            };
+        }
+        sleep(RETRY_DELAY);
+    }
+}
+
+/// Wait for a dev session's Postgres authorization to take effect.
+///
+/// Returns `None` when the session has no direct-Postgres endpoint to verify.
+pub fn verify(
+    services: &std::collections::HashMap<String, std::collections::HashMap<String, String>>,
+    budget: Duration,
+) -> Option<Readiness> {
+    let (host, port) = endpoint_from_env(services)?;
+    Some(wait_until_reachable(
+        budget,
+        || tcp_reachable(&host, port),
+        std::thread::sleep,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn services(pairs: &[(&str, &[(&str, &str)])]) -> HashMap<String, HashMap<String, String>> {
+        pairs
+            .iter()
+            .map(|(name, env)| {
+                let map = env
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect();
+                ((*name).to_string(), map)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn endpoint_is_read_from_the_rewritten_pg_vars() {
+        let svc = services(&[("api", &[("PGHOST", "35.202.217.249"), ("PGPORT", "5432")])]);
+        assert_eq!(
+            endpoint_from_env(&svc),
+            Some((String::from("35.202.217.249"), 5432))
+        );
+    }
+
+    #[test]
+    fn endpoint_defaults_the_port_when_absent() {
+        let svc = services(&[("api", &[("PGHOST", "35.202.217.249")])]);
+        assert_eq!(
+            endpoint_from_env(&svc),
+            Some((String::from("35.202.217.249"), 5432))
+        );
+    }
+
+    #[test]
+    fn loopback_endpoint_is_not_verifiable() {
+        // The API only rewrites PGHOST to the public IP when it accepted the
+        // authorized-network patch; a loopback value means there is nothing to wait on.
+        let svc = services(&[("api", &[("PGHOST", "127.0.0.1"), ("PGPORT", "5432")])]);
+        assert_eq!(endpoint_from_env(&svc), None);
+        let svc = services(&[("api", &[("PGHOST", "localhost")])]);
+        assert_eq!(endpoint_from_env(&svc), None);
+    }
+
+    #[test]
+    fn no_pg_vars_means_nothing_to_verify() {
+        let svc = services(&[("api", &[("MY_VAR", "hello")])]);
+        assert_eq!(endpoint_from_env(&svc), None);
+        assert!(verify(&svc, DEFAULT_BUDGET).is_none());
+    }
+
+    #[test]
+    fn empty_pghost_is_skipped() {
+        let svc = services(&[("api", &[("PGHOST", ""), ("PGPORT", "5432")])]);
+        assert_eq!(endpoint_from_env(&svc), None);
+    }
+
+    #[test]
+    fn a_service_without_pg_vars_does_not_shadow_one_with_them() {
+        let svc = services(&[
+            ("web", &[("MY_VAR", "hello")]),
+            ("api", &[("PGHOST", "35.202.217.249"), ("PGPORT", "6543")]),
+        ]);
+        assert_eq!(
+            endpoint_from_env(&svc),
+            Some((String::from("35.202.217.249"), 6543))
+        );
+    }
+
+    #[test]
+    fn succeeds_on_the_first_probe_without_sleeping() {
+        let mut slept = 0u32;
+        let out = wait_until_reachable(DEFAULT_BUDGET, || true, |_| slept += 1);
+        assert!(matches!(out, Readiness::Authorized { .. }));
+        assert_eq!(slept, 0, "a ready endpoint must not delay the developer");
+    }
+
+    #[test]
+    fn retries_until_the_endpoint_comes_up() {
+        let mut attempts = 0;
+        let mut slept = 0u32;
+        let out = wait_until_reachable(
+            DEFAULT_BUDGET,
+            || {
+                attempts += 1;
+                attempts >= 3
+            },
+            |_| slept += 1,
+        );
+        assert!(matches!(out, Readiness::Authorized { .. }));
+        assert_eq!(attempts, 3);
+        assert_eq!(slept, 2, "one sleep between each pair of attempts");
+    }
+
+    #[test]
+    fn gives_up_at_the_budget_instead_of_blocking_forever() {
+        // A zero budget still probes once: the endpoint may already be up, and a
+        // developer who set no patience should not be told "timed out" without a look.
+        let mut attempts = 0;
+        let out = wait_until_reachable(
+            Duration::ZERO,
+            || {
+                attempts += 1;
+                false
+            },
+            |_| panic!("must not sleep once the budget is spent"),
+        );
+        assert!(matches!(out, Readiness::TimedOut { .. }));
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn unresolvable_host_is_unreachable_not_a_panic() {
+        assert!(!tcp_reachable("this-host-does-not-exist.invalid", 5432));
+    }
+}


### PR DESCRIPTION
## What changed

`floo dev` printed **"your IP is authorized for direct connections"** the moment the API returned `postgres_authorized: true`. That flag means the Cloud SQL patch was **accepted**, not that it is in effect — Cloud SQL applies it asynchronously (~5s on a quiet instance, ~21s under load during the 2026-07-09 incident, unbounded per Google's docs). So the CLI handed control to the developer's services while the rule was still applying, and their app's first connection could be refused or hang.

`floo dev` now verifies before handing off:

- New `postgres_ready` module: resolve the endpoint from the `PGHOST`/`PGPORT` the API rewrote into the session env, then poll `TcpStream::connect_timeout` with backoff up to a 90s budget.
- Reports `Postgres: your IP is authorized for direct connections (verified in 4s)`, or **warns and starts anyway** if the budget elapses — it never silently blocks the developer forever.
- `--json` gains `postgres_reachable` (`true` / `false` / `null`). `postgres_authorized` keeps its existing meaning; `postgres_reachable` is the field an agent should gate on. `null` means there was nothing to verify.

No new dependencies (`std::net`, blocking — the CLI has no async runtime).

## Why

We deliberately do **not** ask the Cloud SQL control plane whether it thinks the rule is applied. Google publishes no guarantee about when a settings change becomes visible in `instances.get`, nor read-after-write once its Operation is `DONE` — and a control-plane read cannot speak for the data plane in any case.

The authoritative answer to *"can this machine reach Postgres?"* is observable at exactly one place: **this machine, by opening a socket.** Measured against prod on 2026-07-10 — from a non-allow-listed IP, connecting to the instance's public endpoint **times out** (the authorized-networks firewall drops packets silently, so there is no RST); from an allow-listed IP it completes. A bounded TCP connect is a sufficient, premise-free signal, and it covers firewall propagation for free, which even a perfect "authorized" answer from the API could not.

This supersedes the API-side status endpoint proposed in [getfloo/floo#1560](https://github.com/getfloo/floo/issues/1560). That endpoint was built and then abandoned: two independent review rounds each found a differently-shaped way it could report `authorized` for a network that was not live (a `DONE`-with-error operation, a removal completing between reads, an ABA re-add, first-page-only pagination). Each was a symptom of reading a non-authoritative source. The client-side check deletes the whole class rather than guarding it.

## Risk tier

standard (`src/postgres_ready.rs`, `src/commands/dev.rs`, `src/main.rs` — no auth, no deploy path).

## Files reviewers should scrutinize

- `src/postgres_ready.rs` — the budget/retry loop, and the decision that a refusal and a timeout are both "not yet".
- `src/commands/dev.rs` — verification runs **outside** the `!is_json_mode()` block, because JSON mode reports it too.

## Tests run

`./scripts/floo-cli-test.sh` (fmt --check + clippy -D warnings + cargo test) — **480 passed, 0 failed.** 10 new tests in `postgres_ready`, running in 0.01s: probe and sleep are injected, so the retry/budget logic is covered without sockets or real waiting.

Covered: endpoint resolution from env (including default port, empty `PGHOST`, loopback = nothing to verify, and a service without PG vars not shadowing one with them); first-probe success does not sleep; retry-until-up; give-up at budget still probes exactly once; unresolvable host is unreachable, not a panic.

## Known non-goals

- `floo run` is untouched. It creates a session too, but it is a one-shot command whose child process may not use Postgres at all; making it wait would be a regression for the common case. Worth a follow-up if a user hits it.
