### PR TITLE
feat: add guardrail policy commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -232,6 +232,16 @@ impl FlooClient {
             .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
     }
 
+    fn put_json(
+        &self,
+        path: &str,
+        body: &Value,
+    ) -> Result<reqwest::blocking::Response, FlooApiError> {
+        let req = self.apply_headers(self.client.put(self.url(path)).json(body));
+        req.send()
+            .map_err(|e| FlooApiError::new(0, "CONNECTION_ERROR", e.to_string()))
+    }
+
     fn delete(&self, path: &str) -> Result<reqwest::blocking::Response, FlooApiError> {
         let req = self.apply_headers(self.client.delete(self.url(path)));
         req.send()
@@ -353,6 +363,36 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_org_guardrails(
+        &self,
+        org_id: &str,
+    ) -> Result<GuardrailPolicyResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/orgs/{org_id}/guardrails"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn set_org_guardrails(
+        &self,
+        org_id: &str,
+        gate_recoverable_dev: bool,
+        gate_recoverable_prod: bool,
+    ) -> Result<GuardrailPolicyResponse, FlooApiError> {
+        let body = serde_json::json!({
+            "gate_recoverable_dev": gate_recoverable_dev,
+            "gate_recoverable_prod": gate_recoverable_prod,
+        });
+        let resp = self.put_json(&format!("/v1/orgs/{org_id}/guardrails"), &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn reset_org_guardrails(
+        &self,
+        org_id: &str,
+    ) -> Result<GuardrailPolicyResponse, FlooApiError> {
+        let resp = self.delete(&format!("/v1/orgs/{org_id}/guardrails"))?;
+        self.handle_response(resp)
+    }
+
     // --- Access ---
 
     pub fn grant_app_access(&self, app_id: &str, email: &str) -> Result<Value, FlooApiError> {
@@ -406,6 +446,36 @@ impl FlooClient {
 
     pub fn get_app(&self, app_id: &str) -> Result<App, FlooApiError> {
         let resp = self.get(&format!("/v1/apps/{app_id}"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn get_app_guardrails(
+        &self,
+        app_id: &str,
+    ) -> Result<GuardrailPolicyResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/guardrails"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn set_app_guardrails(
+        &self,
+        app_id: &str,
+        gate_recoverable_dev: bool,
+        gate_recoverable_prod: bool,
+    ) -> Result<GuardrailPolicyResponse, FlooApiError> {
+        let body = serde_json::json!({
+            "gate_recoverable_dev": gate_recoverable_dev,
+            "gate_recoverable_prod": gate_recoverable_prod,
+        });
+        let resp = self.put_json(&format!("/v1/apps/{app_id}/guardrails"), &body)?;
+        self.handle_response(resp)
+    }
+
+    pub fn reset_app_guardrails(
+        &self,
+        app_id: &str,
+    ) -> Result<GuardrailPolicyResponse, FlooApiError> {
+        let resp = self.delete(&format!("/v1/apps/{app_id}/guardrails"))?;
         self.handle_response(resp)
     }
 

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -125,6 +125,18 @@ pub struct CreateInviteResponse {
     pub expires_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GuardrailPolicyResponse {
+    pub scope: String,
+    pub scope_id: String,
+    pub source: String,
+    pub configured: bool,
+    pub gate_recoverable_dev: bool,
+    pub gate_recoverable_prod: bool,
+    pub gate_data_loss: bool,
+    pub gate_reversible: bool,
+}
+
 // --- App ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::commands;
 use crate::constants::VERSION;
@@ -255,6 +255,21 @@ dirty local files are not uploaded."
     #[command(subcommand)]
     Orgs(OrgsCommands),
 
+    /// Inspect and set human-approval policy for consequential operations.
+    #[command(
+        subcommand,
+        after_help = "\
+Examples:
+  floo guardrails show --json
+  floo guardrails show --app my-app
+  floo guardrails set --dev automatic --prod approval
+  floo guardrails set --app my-app --inherit
+
+Without --app, commands target the current organization. Tier 3 always requires
+human approval and cannot be changed by this command."
+    )]
+    Guardrails(GuardrailsCommands),
+
     /// Manage billing and spend caps.
     #[command(subcommand)]
     Billing(BillingCommands),
@@ -372,7 +387,7 @@ Examples:
     #[command(after_help = "\
 Topics: golden-path, quickstart, build, nextjs, rails, fastapi, django,
 express, templates, services, edge, egress, previews, config, cron, deploy, auth,
-notifications, feedback.
+notifications, guardrails, feedback.
 Aliases: storage -> services, app-toml -> config.
 Run `floo docs` (no topic) for a one-line description of each topic.")]
     Docs {
@@ -618,6 +633,46 @@ pub enum OrgsCommands {
     Switch {
         /// Org slug or ID.
         org_slug: String,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum GuardrailPosture {
+    Automatic,
+    Approval,
+}
+
+impl GuardrailPosture {
+    fn gated(self) -> bool {
+        matches!(self, Self::Approval)
+    }
+}
+
+#[derive(Subcommand)]
+pub enum GuardrailsCommands {
+    /// Show the effective org or app approval policy.
+    Show {
+        /// App name or ID. Omit to inspect the current org default.
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+    /// Set recoverable-operation policy or reset it to inherit.
+    Set {
+        /// App name or ID. Omit to set the current org default.
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Dev posture for tier-2 recoverable operations.
+        #[arg(long, value_enum, conflicts_with = "inherit")]
+        dev: Option<GuardrailPosture>,
+
+        /// Prod and preview posture for tier-2 recoverable operations.
+        #[arg(long, value_enum, conflicts_with = "inherit")]
+        prod: Option<GuardrailPosture>,
+
+        /// Remove this scope's row and inherit the org or platform policy.
+        #[arg(long, conflicts_with_all = ["dev", "prod"])]
+        inherit: bool,
     },
 }
 
@@ -2138,6 +2193,21 @@ pub fn run() {
             },
             OrgsCommands::Invite { email, role } => commands::orgs::invite(&email, &role),
             OrgsCommands::Switch { org_slug } => commands::orgs::switch(&org_slug),
+        },
+
+        Commands::Guardrails(sub) => match sub {
+            GuardrailsCommands::Show { app } => commands::guardrails::show(app.as_deref()),
+            GuardrailsCommands::Set {
+                app,
+                dev,
+                prod,
+                inherit,
+            } => commands::guardrails::set(
+                app.as_deref(),
+                dev.map(GuardrailPosture::gated),
+                prod.map(GuardrailPosture::gated),
+                inherit,
+            ),
         },
 
         Commands::Apps(sub) => match sub {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -45,6 +45,7 @@ never uploads code.
   floo docs deploy     — detailed deploy flow and runtime detection
   floo docs auth       — add user authentication to your app
   floo docs notifications — control which emails floo sends you
+  floo docs guardrails — inspect and set recoverable-operation approval policy
   floo docs feedback   — report bugs, friction, or feature requests
   floo --help          — all available commands
   floo <command> --help — details for a specific command
@@ -335,6 +336,31 @@ All services share the same origin, so cookies and auth work without CORS.
   keeps the service until status=completed.
 
 Full guide: https://getfloo.com/docs/guides/managed-services
+";
+
+const GUARDRAILS: &str = "\
+floo guardrails
+
+Guardrails decide whether tier-2 recoverable operations need a human approval.
+The policy is server-owned, so a repository change cannot weaken its own gate.
+
+  floo guardrails show --json
+  floo guardrails show --app my-app
+  floo guardrails set --dev automatic --prod approval
+  floo guardrails set --app my-app --dev approval --prod approval
+  floo guardrails set --app my-app --inherit
+
+Without --app, show and set target the current organization. An app override
+inherits the org default after --inherit; an org default inherits the platform
+default. Preview uses the prod setting.
+
+Only tier 2 is configurable. Tier-1 additive work is always automatic. Tier-3
+irreversible work always requires approval from a current human session, and no
+CLI flag, API key, preset, or stored policy can disable that floor.
+
+The older readonly/supervised/autonomous agent modes govern database-command
+autonomy. They are intentionally not guardrail presets: risk policy and actor
+autonomy are separate axes, and coupling them would create a second policy model.
 ";
 
 const EDGE: &str = "\
@@ -1954,6 +1980,7 @@ pub(crate) const TOPICS: &[(&str, &str)] = &[
     ("deploy", DEPLOY),
     ("auth", AUTH),
     ("notifications", NOTIFICATIONS),
+    ("guardrails", GUARDRAILS),
     ("feedback", FEEDBACK),
 ];
 

--- a/src/commands/guardrails.rs
+++ b/src/commands/guardrails.rs
@@ -1,0 +1,139 @@
+use std::process;
+
+use crate::api_client::FlooClient;
+use crate::api_types::GuardrailPolicyResponse;
+use crate::errors::ErrorCode;
+use crate::output;
+
+enum Target {
+    Org { id: String, label: String },
+    App { id: String, label: String },
+}
+
+fn resolve_target(client: &FlooClient, app: Option<&str>) -> Target {
+    if let Some(app_name) = app {
+        let resolved = super::resolve_app_or_exit(client, app_name);
+        return Target::App {
+            id: resolved.id,
+            label: resolved.name,
+        };
+    }
+
+    match client.get_org_me() {
+        Ok(org) => Target::Org {
+            label: org.display_name().unwrap_or(&org.id).to_string(),
+            id: org.id,
+        },
+        Err(error) => {
+            output::error(&error.message, &ErrorCode::from_api(&error.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+fn fetch(client: &FlooClient, target: &Target) -> GuardrailPolicyResponse {
+    let result = match target {
+        Target::Org { id, .. } => client.get_org_guardrails(id),
+        Target::App { id, .. } => client.get_app_guardrails(id),
+    };
+    result.unwrap_or_else(|error| {
+        output::error(&error.message, &ErrorCode::from_api(&error.code), None);
+        process::exit(1);
+    })
+}
+
+fn posture(gated: bool) -> &'static str {
+    if gated {
+        "approval required"
+    } else {
+        "automatic"
+    }
+}
+
+fn render(policy: &GuardrailPolicyResponse, success_message: Option<&str>) {
+    let value = output::to_value(policy);
+    if output::is_json_mode() {
+        output::success(success_message.unwrap_or("Guardrail policy"), Some(value));
+        return;
+    }
+    if let Some(message) = success_message {
+        output::success(message, None);
+    }
+    output::table(
+        &["OPERATION", "DEV", "PROD / PREVIEW"],
+        &[
+            vec![
+                "Recoverable (tier 2)".to_string(),
+                posture(policy.gate_recoverable_dev).to_string(),
+                posture(policy.gate_recoverable_prod).to_string(),
+            ],
+            vec![
+                "Irreversible (tier 3)".to_string(),
+                "approval required (immutable)".to_string(),
+                "approval required (immutable)".to_string(),
+            ],
+            vec![
+                "Additive (tier 1)".to_string(),
+                "automatic (immutable)".to_string(),
+                "automatic (immutable)".to_string(),
+            ],
+        ],
+        None,
+    );
+    output::info(
+        &format!("Effective source: {}", policy.source.replace('_', " ")),
+        None,
+    );
+}
+
+pub fn show(app: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let target = resolve_target(&client, app);
+    render(&fetch(&client, &target), None);
+}
+
+pub fn set(app: Option<&str>, dev: Option<bool>, prod: Option<bool>, inherit: bool) {
+    super::require_auth();
+    let desired = if inherit {
+        None
+    } else {
+        Some(match (dev, prod) {
+            (Some(dev), Some(prod)) => (dev, prod),
+            _ => {
+                output::error(
+                    "Both --dev and --prod are required unless --inherit is used.",
+                    &ErrorCode::InvalidFormat,
+                    Some("Pass --dev <automatic|approval> --prod <automatic|approval>."),
+                );
+                process::exit(1);
+            }
+        })
+    };
+    let client = super::init_client(None);
+    let target = resolve_target(&client, app);
+    let result = if let Some((dev, prod)) = desired {
+        match &target {
+            Target::Org { id, .. } => client.set_org_guardrails(id, dev, prod),
+            Target::App { id, .. } => client.set_app_guardrails(id, dev, prod),
+        }
+    } else {
+        match &target {
+            Target::Org { id, .. } => client.reset_org_guardrails(id),
+            Target::App { id, .. } => client.reset_app_guardrails(id),
+        }
+    };
+    let policy = result.unwrap_or_else(|error| {
+        output::error(&error.message, &ErrorCode::from_api(&error.code), None);
+        process::exit(1);
+    });
+    let target_label = match target {
+        Target::Org { label, .. } => format!("org {label}"),
+        Target::App { label, .. } => format!("app {label}"),
+    };
+    let action = if inherit { "Reset" } else { "Updated" };
+    render(
+        &policy,
+        Some(&format!("{action} guardrail policy for {target_label}.")),
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod edge;
 pub mod env;
 pub mod feedback;
 pub mod github;
+pub mod guardrails;
 pub mod init;
 pub mod logs;
 pub mod notifications;

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -63,6 +63,20 @@ fn org_json() -> String {
     )
 }
 
+fn guardrail_policy_json(scope: &str, scope_id: &str, source: &str) -> String {
+    serde_json::json!({
+        "scope": scope,
+        "scope_id": scope_id,
+        "source": source,
+        "configured": source == "app_override" || (scope == "org" && source == "org_default"),
+        "gate_recoverable_dev": false,
+        "gate_recoverable_prod": true,
+        "gate_data_loss": true,
+        "gate_reversible": false,
+    })
+    .to_string()
+}
+
 /// Mock GET /v1/orgs/me for human-mode list.
 fn mock_org_me(server: &mut Server) -> Mock {
     server
@@ -406,6 +420,151 @@ fn test_orgs_invite_json_assigns_role_and_redacts_url() {
         // The one-time invite_url is secret-shaped: redacted, never raw.
         .stdout(predicate::str::contains("secret-token-xyz").not())
         .stdout(predicate::str::contains("contains_secrets"));
+}
+
+#[test]
+fn test_guardrails_show_org_json_is_exact() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _policy = server
+        .mock("GET", format!("/v1/orgs/{TEST_ORG_ID}/guardrails").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(guardrail_policy_json(
+            "org",
+            TEST_ORG_ID,
+            "platform_default",
+        ))
+        .create();
+
+    let output = floo()
+        .args(["--json", "guardrails", "show"])
+        .env("HOME", home.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "success": true,
+            "data": {
+                "scope": "org",
+                "scope_id": TEST_ORG_ID,
+                "source": "platform_default",
+                "configured": false,
+                "gate_recoverable_dev": false,
+                "gate_recoverable_prod": true,
+                "gate_data_loss": true,
+                "gate_reversible": false,
+            }
+        })
+    );
+}
+
+#[test]
+fn test_guardrails_set_app_sends_only_tier_two_policy() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _policy = server
+        .mock("PUT", format!("/v1/apps/{TEST_APP_ID}/guardrails").as_str())
+        .match_body(Matcher::JsonString(
+            r#"{"gate_recoverable_dev":true,"gate_recoverable_prod":false}"#.to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "scope": "app",
+                "scope_id": TEST_APP_ID,
+                "source": "app_override",
+                "configured": true,
+                "gate_recoverable_dev": true,
+                "gate_recoverable_prod": false,
+                "gate_data_loss": true,
+                "gate_reversible": false,
+            })
+            .to_string(),
+        )
+        .create();
+
+    let output = floo()
+        .args([
+            "--json",
+            "guardrails",
+            "set",
+            "--app",
+            TEST_APP_NAME,
+            "--dev",
+            "approval",
+            "--prod",
+            "automatic",
+        ])
+        .env("HOME", home.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["data"]["source"], "app_override");
+    assert_eq!(value["data"]["gate_data_loss"], true);
+    assert_eq!(value["data"]["gate_recoverable_prod"], false);
+}
+
+#[test]
+fn test_guardrails_set_inherit_deletes_app_override() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _policy = server
+        .mock(
+            "DELETE",
+            format!("/v1/apps/{TEST_APP_ID}/guardrails").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(guardrail_policy_json("app", TEST_APP_ID, "org_default"))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "guardrails",
+            "set",
+            "--app",
+            TEST_APP_NAME,
+            "--inherit",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""source":"org_default""#));
+}
+
+#[test]
+fn test_guardrails_set_requires_complete_posture() {
+    let server = Server::new();
+    let home = setup_config(&server);
+    floo()
+        .args(["--json", "guardrails", "set", "--dev", "approval"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Both --dev and --prod are required unless --inherit is used.",
+        ))
+        .stdout(predicate::str::contains(
+            "Pass --dev <automatic|approval> --prod <automatic|approval>.",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add org and app guardrail policy inspection and mutation
- expose exact structured JSON and human-readable immutable tier floors
- keep agent autonomy modes separate from consequence policy

## Verification
- full Rust, unit, mock API, and doc-link suite passed
- monorepo-owned floo-cli publication sentinel passed

Refs getfloo/floo#1728

Stacked on #225.