### PR TITLE
feat: add app membership lifecycle commands

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -355,10 +355,80 @@ impl FlooClient {
 
     // --- Access ---
 
-    pub fn grant_app_access(&self, app_id: &str, email: &str) -> Result<Value, FlooApiError> {
-        let body = serde_json::json!({"email": email});
-        let resp = self.post_json(&format!("/v1/apps/{app_id}/access"), &body)?;
+    pub fn create_app_invite(
+        &self,
+        app_id: &str,
+        email: &str,
+        role: &str,
+    ) -> Result<Value, FlooApiError> {
+        let body = serde_json::json!({"email": email, "role": role});
+        let resp = self.post_json(&format!("/v1/apps/{app_id}/invites"), &body)?;
         self.handle_response(resp)
+    }
+
+    pub fn list_app_invites(
+        &self,
+        app_id: &str,
+        cursor: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let mut query = Vec::new();
+        if let Some(cursor) = cursor {
+            query.push(("cursor", cursor));
+        }
+        let resp = self.get_with_query(&format!("/v1/apps/{app_id}/invites"), &query)?;
+        self.handle_response(resp)
+    }
+
+    pub fn resend_app_invite(&self, app_id: &str, invite_id: &str) -> Result<Value, FlooApiError> {
+        let resp = self.post_json(
+            &format!("/v1/apps/{app_id}/invites/{invite_id}/resend"),
+            &serde_json::json!({}),
+        )?;
+        self.handle_response(resp)
+    }
+
+    pub fn revoke_app_invite(&self, app_id: &str, invite_id: &str) -> Result<(), FlooApiError> {
+        let resp = self.delete(&format!("/v1/apps/{app_id}/invites/{invite_id}"))?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        self.handle_response_value(resp)?;
+        Ok(())
+    }
+
+    pub fn list_app_members(
+        &self,
+        app_id: &str,
+        cursor: Option<&str>,
+    ) -> Result<Value, FlooApiError> {
+        let mut query = Vec::new();
+        if let Some(cursor) = cursor {
+            query.push(("cursor", cursor));
+        }
+        let resp = self.get_with_query(&format!("/v1/apps/{app_id}/members"), &query)?;
+        self.handle_response(resp)
+    }
+
+    pub fn update_app_member_role(
+        &self,
+        app_id: &str,
+        membership_id: &str,
+        role: &str,
+    ) -> Result<Value, FlooApiError> {
+        let resp = self.patch_json(
+            &format!("/v1/apps/{app_id}/members/{membership_id}"),
+            &serde_json::json!({"role": role}),
+        )?;
+        self.handle_response(resp)
+    }
+
+    pub fn remove_app_member(&self, app_id: &str, membership_id: &str) -> Result<(), FlooApiError> {
+        let resp = self.delete(&format!("/v1/apps/{app_id}/members/{membership_id}"))?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        self.handle_response_value(resp)?;
+        Ok(())
     }
 
     // --- Billing ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -691,12 +691,66 @@ pub enum AppsCommands {
         app_name: String,
     },
 
-    /// Invite a user to an app (grant email-based access).
+    /// Invite a floo identity to an app.
     Invite {
         /// Email address to invite.
         email: String,
 
         /// App name or ID (uses config file if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// App role to grant after acceptance.
+        #[arg(long, default_value = "member", value_parser = ["member", "admin"])]
+        role: String,
+    },
+
+    /// List app invitations.
+    Invites {
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Continue from a previous response's next_cursor.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+
+    /// Rotate and resend a pending app invitation.
+    InviteResend {
+        invite_id: String,
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Revoke a pending app invitation.
+    InviteRevoke {
+        invite_id: String,
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// List explicit app members.
+    Members {
+        #[arg(short, long)]
+        app: Option<String>,
+
+        /// Continue from a previous response's next_cursor.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+
+    /// Change an app member's tenant role and revoke their active sessions.
+    MemberRole {
+        membership_id: String,
+        #[arg(value_parser = ["member", "admin"])]
+        role: String,
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
+    /// Remove an app member and revoke their app sessions and user API keys.
+    MemberRemove {
+        membership_id: String,
         #[arg(short, long)]
         app: Option<String>,
     },
@@ -1842,7 +1896,13 @@ fn dry_run_is_unsupported(command: &Commands) -> bool {
                 OrgsCommands::Members(MembersCommands::SetRole { .. })
                     | OrgsCommands::Switch { .. },
             )
-            | Commands::Apps(AppsCommands::Invite { .. })
+            | Commands::Apps(
+                AppsCommands::Invite { .. }
+                    | AppsCommands::InviteResend { .. }
+                    | AppsCommands::InviteRevoke { .. }
+                    | AppsCommands::MemberRole { .. }
+                    | AppsCommands::MemberRemove { .. }
+            )
             | Commands::Billing(BillingCommands::SpendCap(SpendCapCommands::Set { .. }))
             | Commands::Run { .. }
             | Commands::Feedback { .. }
@@ -2169,7 +2229,29 @@ pub fn run() {
                 GitHubCommands::Status { app } => commands::github::status(app.as_deref()),
             },
             AppsCommands::Password { app_name } => commands::apps::show_password(&app_name),
-            AppsCommands::Invite { email, app } => commands::apps::invite(&email, app.as_deref()),
+            AppsCommands::Invite { email, app, role } => {
+                commands::apps::invite(&email, &role, app.as_deref())
+            }
+            AppsCommands::Invites { app, cursor } => {
+                commands::apps::invites(app.as_deref(), cursor.as_deref())
+            }
+            AppsCommands::InviteResend { invite_id, app } => {
+                commands::apps::resend_invite(&invite_id, app.as_deref())
+            }
+            AppsCommands::InviteRevoke { invite_id, app } => {
+                commands::apps::revoke_invite(&invite_id, app.as_deref())
+            }
+            AppsCommands::Members { app, cursor } => {
+                commands::apps::members(app.as_deref(), cursor.as_deref())
+            }
+            AppsCommands::MemberRole {
+                membership_id,
+                role,
+                app,
+            } => commands::apps::set_member_role(&membership_id, &role, app.as_deref()),
+            AppsCommands::MemberRemove { membership_id, app } => {
+                commands::apps::remove_member(&membership_id, app.as_deref())
+            }
         },
 
         Commands::Env(sub) => match sub {

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -248,15 +248,128 @@ pub fn show_password(app_name: &str) {
     }
 }
 
-pub fn invite(email: &str, app_flag: Option<&str>) {
+pub fn invite(email: &str, role: &str, app_flag: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
     let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
 
-    match client.grant_app_access(&app_id, email) {
+    match client.create_app_invite(&app_id, email, role) {
         Ok(result) => {
-            output::success(&format!("Invited {email} to '{app_name}'."), Some(result));
+            output::success(
+                &format!("Invited {email} to '{app_name}'."),
+                Some(result.clone()),
+            );
+            if !output::is_json_mode() {
+                if crate::redact::is_reveal_secrets() {
+                    if let Some(invite_url) =
+                        result.get("invite_url").and_then(|value| value.as_str())
+                    {
+                        output::info(&format!("Invitation URL (shown once): {invite_url}"), None);
+                    }
+                } else if result
+                    .get("delivery_status")
+                    .and_then(|value| value.as_str())
+                    != Some("sent")
+                {
+                    output::warn(
+                        "Email delivery was not confirmed. Resend with --reveal-secrets to copy the one-time URL.",
+                    );
+                }
+            }
         }
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+pub fn invites(app_flag: Option<&str>, cursor: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    match client.list_app_invites(&app_id, cursor) {
+        Ok(result) => output::success(&format!("Invitations for '{app_name}'."), Some(result)),
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+pub fn resend_invite(invite_id: &str, app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    match client.resend_app_invite(&app_id, invite_id) {
+        Ok(result) => output::success(
+            &format!("Resent invitation for '{app_name}'."),
+            Some(result),
+        ),
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+pub fn revoke_invite(invite_id: &str, app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    match client.revoke_app_invite(&app_id, invite_id) {
+        Ok(()) => output::success(
+            &format!("Revoked invitation for '{app_name}'."),
+            Some(serde_json::json!({"invite_id": invite_id, "app_id": app_id})),
+        ),
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+pub fn members(app_flag: Option<&str>, cursor: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    match client.list_app_members(&app_id, cursor) {
+        Ok(result) => output::success(&format!("Members for '{app_name}'."), Some(result)),
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+pub fn set_member_role(membership_id: &str, role: &str, app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    match client.update_app_member_role(&app_id, membership_id, role) {
+        Ok(result) => output::success(
+            &format!("Set member role to {role} for '{app_name}'."),
+            Some(result),
+        ),
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    }
+}
+
+pub fn remove_member(membership_id: &str, app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
+    match client.remove_app_member(&app_id, membership_id) {
+        Ok(()) => output::success(
+            &format!("Removed app member from '{app_name}'."),
+            Some(serde_json::json!({
+                "membership_id": membership_id,
+                "app_id": app_id,
+            })),
+        ),
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
             process::exit(1);

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -921,8 +921,8 @@ exchange to implement.
 
 ## What you get
 
-  - Hosted sign-in page (email magic link, Google, GitHub)
-    — branded; gateway redirects unauthenticated visitors to it
+  - Hosted WorkOS sign-in for floo identities, including Google and
+    other configured providers
   - Session cookie (__floo_session) validated on every request,
     rolled forward as users stay active, revoked on sign-out
   - Identity headers (X-Floo-User-Email/Id/Name/Role) injected on
@@ -935,23 +935,42 @@ exchange to implement.
                             would have allowed cross-origin drive-by sign-out.
                             Does NOT log the user out of WorkOS — federated
                             SLO is not yet supported.
-  - Per-app user list in the dashboard (first-seen, last-active,
-    sign-in count)
+  - Explicit per-app member list with member/admin tenant roles
+  - Immediate session and app-key revocation when app access is removed
 
-## Restricting who can sign in
+## Invite app users
 
-By default, anyone with a valid email can sign in. Restrict access
-in the dashboard or in floo.app.toml:
+Accounts-mode apps are invite-only. Invite a floo identity from the
+dashboard Access tab or the CLI:
 
-  [auth]
-  access_policy = \"domain\"          # \"open\", \"invite\", or \"domain\"
-  allowed_domains = [\"acme.com\"]    # required when access_policy = \"domain\"
+  floo apps invite teammate@acme.com --role member --app my-app
+  floo apps invites --app my-app
 
-  - open    — anyone with a valid email
-  - invite  — invited users only (manage in dashboard's per-app
-              Access tab, or assign on first deploy)
-  - domain  — restricted to allowed_domains (Pro+; consumer
-              mailboxes like gmail.com rejected by default)
+List responses include `next_cursor` when more results exist. Continue
+with `--cursor NEXT_CURSOR` for invitations or members.
+
+The recipient creates or reuses the matching global floo account, then
+accepts the app membership. App access never grants dashboard, deploy,
+organization, billing, or platform API-key authority.
+
+Invitation URLs are secret-shaped and redacted by default. When you need
+to hand off the URL yourself, add global `--reveal-secrets`; otherwise the
+provider email is the delivery path.
+
+Manage pending invitations:
+
+  floo apps invite-resend INVITE_ID --app my-app
+  floo apps invite-revoke INVITE_ID --app my-app
+
+Resending rotates the old link. List and manage active app members:
+
+  floo apps members --app my-app
+  floo apps member-role MEMBERSHIP_ID admin --app my-app
+  floo apps member-remove MEMBERSHIP_ID --app my-app
+
+Organization membership does not imply app membership. Invite operators
+to every app they should use. Changing a role revokes sessions carrying
+the old role; removing a member revokes their app sessions and keys.
 
 ## Access Modes
 

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -420,6 +420,80 @@ fn test_apps_list_human() {
 }
 
 #[test]
+fn test_apps_invite_posts_role_and_redacts_one_time_url() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _invite = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/invites").as_str(),
+        )
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "email": "app-user@example.com",
+            "role": "admin",
+        })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"invite-1","email":"app-user@example.com","role":"admin","status":"pending","invite_url":"https://app.getfloo.com/app-invite#token=secret-app-token"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "apps",
+            "invite",
+            "app-user@example.com",
+            "--role",
+            "admin",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""role":"admin""#))
+        .stdout(predicate::str::contains("secret-app-token").not())
+        .stdout(predicate::str::contains("contains_secrets"));
+}
+
+#[test]
+fn test_apps_member_role_uses_canonical_membership_endpoint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _role = server
+        .mock(
+            "PATCH",
+            format!("/v1/apps/{TEST_APP_ID}/members/membership-1").as_str(),
+        )
+        .match_body(Matcher::PartialJson(serde_json::json!({"role": "member"})))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"membership-1","email":"app-user@example.com","role":"member","status":"active"}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "apps",
+            "member-role",
+            "membership-1",
+            "member",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""role":"member""#));
+}
+
+#[test]
 fn test_apps_show_json() {
     let mut server = Server::new();
     let home = setup_config(&server);


### PR DESCRIPTION
## What changed
Adds CLI commands for inviting app users, listing and managing invitations, and listing, changing, or removing app members. Cursor pagination and one-time invitation URL handling follow the API contract.

## Tests run
- ./scripts/test (full suite)

Closes getfloo/floo#1741

Generated with Codex.