### PR TITLE
fix: report partial env restart failures

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -185,7 +185,11 @@ impl FlooClient {
             return Err(self.handle_error(response));
         }
         response.json::<T>().map_err(|e| {
-            FlooApiError::new(500, "PARSE_ERROR", format!("Failed to parse response: {e}"))
+            FlooApiError::new(
+                status,
+                "PARSE_ERROR",
+                format!("Failed to parse response: {e}"),
+            )
         })
     }
 
@@ -1277,6 +1281,23 @@ impl FlooClient {
         };
         let resp = self.post_json(&format!("/v1/apps/{app_id}/restart"), &body)?;
         self.handle_response(resp)
+    }
+
+    pub fn preflight_restart(
+        &self,
+        app_id: &str,
+        services: Option<&[String]>,
+    ) -> Result<(), FlooApiError> {
+        let query: Vec<(&str, &str)> = services
+            .unwrap_or_default()
+            .iter()
+            .map(|service| ("services", service.as_str()))
+            .collect();
+        let resp = self.get_with_query(&format!("/v1/apps/{app_id}/restart/preflight"), &query)?;
+        if resp.status().as_u16() >= 400 {
+            return Err(self.handle_error(resp));
+        }
+        Ok(())
     }
 
     pub fn rebuild_app(

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -8,10 +8,10 @@ use crate::deploy_status;
 use crate::errors::ErrorCode;
 use crate::output;
 use crate::project_config;
+use serde::Serialize;
 
 const DEPLOY_HINT: &str =
     "Push a commit to trigger a deploy with the updated env vars, or run: floo redeploy";
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -54,6 +54,86 @@ fn format_target(app_name: &str, service_name: Option<&str>) -> String {
     match service_name {
         Some(sn) => format!("{app_name}/{sn}"),
         None => app_name.to_string(),
+    }
+}
+
+#[derive(Serialize)]
+struct FailedEnvTarget {
+    target: String,
+    outcome: TargetOutcome,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TargetOutcome {
+    Rejected,
+    Unknown,
+    CommittedResponseUnreadable,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EnvUpdateState {
+    NotStarted,
+    NotUpdated,
+    Partial,
+    Complete,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RestartState {
+    NotRequested,
+    PreflightFailed,
+    NotStarted,
+    AttemptCreated,
+    Started,
+    Failed,
+    Unknown,
+}
+
+impl RestartState {
+    fn started(self) -> Option<bool> {
+        match self {
+            Self::NotStarted | Self::PreflightFailed => Some(false),
+            Self::Started | Self::Failed => Some(true),
+            Self::NotRequested | Self::AttemptCreated | Self::Unknown => None,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct EnvSetFailureData {
+    env_updated: Option<bool>,
+    env_update_state: EnvUpdateState,
+    restart_started: Option<bool>,
+    restart_state: RestartState,
+    results: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failed_target: Option<FailedEnvTarget>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unattempted_targets: Vec<String>,
+}
+
+impl EnvSetFailureData {
+    fn new(
+        env_updated: Option<bool>,
+        env_update_state: EnvUpdateState,
+        restart_state: RestartState,
+        results: Vec<serde_json::Value>,
+        failed_target: Option<FailedEnvTarget>,
+        unattempted_targets: Vec<String>,
+    ) -> Self {
+        Self {
+            env_updated,
+            env_update_state,
+            restart_started: restart_state.started(),
+            restart_state,
+            results,
+            failed_target,
+            unattempted_targets,
+        }
     }
 }
 
@@ -356,6 +436,15 @@ pub fn set(
         key_value.split_once('=').unwrap().0.to_uppercase()
     };
 
+    if restart && env != "dev" {
+        output::error(
+            "`--restart` only targets dev, so it cannot be combined with another `--env`.",
+            &ErrorCode::InvalidArguments,
+            Some("Set the value without `--restart`. The next release applies prod env changes."),
+        );
+        process::exit(1);
+    }
+
     if output::is_dry_run_mode() {
         // Dry-run mutates nothing, so it must NOT consume stdin or read the
         // file — it previews the key/target only.
@@ -395,12 +484,58 @@ pub fn set(
     let client = super::init_client(None);
     let (app_id, app_name) = super::resolve_app_from_config(&client, app_flag);
     let targets = resolve_service_ids(&client, &app_id, &app_name, service_names);
+    let target_names: Vec<String> = targets
+        .iter()
+        .map(|(_, service_name)| format_target(&app_name, service_name.as_deref()))
+        .collect();
+
+    if restart {
+        let services = (!service_names.is_empty()).then_some(service_names);
+        match client.preflight_restart(&app_id, services) {
+            Ok(()) => {}
+            // Compatibility with API revisions that predate restart preflight:
+            // fall back only for FastAPI's generic missing-route response.
+            Err(e) if e.is_missing_route() => {}
+            Err(e) => {
+                let is_active_deploy = e.code == "DEPLOY_IN_PROGRESS";
+                let message = if is_active_deploy {
+                    "Restart did not start because a deploy is already in progress. No env values were changed."
+                } else {
+                    "Restart preflight failed. No env values were changed."
+                };
+                let suggestion = if is_active_deploy {
+                    "Wait for the active deploy to finish, then retry."
+                } else {
+                    "Resolve the restart error, then retry."
+                };
+                output::error_with_data(
+                    message,
+                    &ErrorCode::from_api(&e.code),
+                    Some(suggestion),
+                    Some(output::to_value(&EnvSetFailureData::new(
+                        Some(false),
+                        EnvUpdateState::NotStarted,
+                        if is_active_deploy {
+                            RestartState::NotStarted
+                        } else {
+                            RestartState::PreflightFailed
+                        },
+                        Vec::new(),
+                        None,
+                        target_names.clone(),
+                    ))),
+                );
+                process::exit(1);
+            }
+        }
+    }
 
     // Read the side-channel value only AFTER every "this set can't run" check
-    // (auth, app/target resolution) has passed. Reading first would block an
-    // interactive `--stdin` on EOF — or consume a secret file/FIFO — for a
-    // logged-out user or a multi-service app with no `--services`, then error
-    // anyway (codex #1152). Dry-run already returned above without reading.
+    // (auth, app/target resolution, restart preflight) has passed. Reading first
+    // would block an interactive `--stdin` on EOF — or consume a secret
+    // file/FIFO — for a logged-out user, an invalid target, or a blocked
+    // restart, then error anyway (codex #1152, getfloo/floo#1779). Dry-run
+    // already returned above without reading.
     let value: String = match value_source {
         ValueSource::Stdin => read_stdin_value(),
         ValueSource::File(path) => read_value_file(path),
@@ -408,7 +543,7 @@ pub fn set(
     };
 
     let mut results: Vec<serde_json::Value> = Vec::new();
-    for (service_id, service_name) in &targets {
+    for (index, (service_id, service_name)) in targets.iter().enumerate() {
         match client.set_env_var(&app_id, &key, &value, service_id.as_deref(), env, secret) {
             Ok(result) => {
                 let target = format_target(&app_name, service_name.as_deref());
@@ -423,7 +558,84 @@ pub fn set(
                 }
             }
             Err(e) => {
-                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                let target = target_names[index].clone();
+                let unattempted_targets = target_names[index + 1..].to_vec();
+                let prior_count = results.len();
+                let outcome = if e.code == "PARSE_ERROR" && (200..400).contains(&e.status_code) {
+                    TargetOutcome::CommittedResponseUnreadable
+                } else if (400..500).contains(&e.status_code) {
+                    TargetOutcome::Rejected
+                } else {
+                    TargetOutcome::Unknown
+                };
+                let current_committed = outcome == TargetOutcome::CommittedResponseUnreadable;
+                let has_confirmed_write = prior_count > 0 || current_committed;
+                let env_updated = if has_confirmed_write {
+                    Some(true)
+                } else if outcome == TargetOutcome::Unknown {
+                    None
+                } else {
+                    Some(false)
+                };
+                let env_update_state = if outcome == TargetOutcome::Unknown {
+                    EnvUpdateState::Unknown
+                } else if outcome == TargetOutcome::Rejected && has_confirmed_write {
+                    EnvUpdateState::Partial
+                } else if has_confirmed_write && unattempted_targets.is_empty() {
+                    EnvUpdateState::Complete
+                } else if has_confirmed_write {
+                    EnvUpdateState::Partial
+                } else {
+                    EnvUpdateState::NotUpdated
+                };
+                let restart_suffix = if restart {
+                    " Restart did not start."
+                } else {
+                    ""
+                };
+                let message = match outcome {
+                    TargetOutcome::CommittedResponseUnreadable => format!(
+                        "Saved {key} on {target}, but its response could not be read.{restart_suffix}"
+                    ),
+                    TargetOutcome::Rejected if prior_count > 0 => format!(
+                        "Saved {key} on {prior_count} target(s), then the update failed on {target}: {}{restart_suffix}",
+                        e.message
+                    ),
+                    TargetOutcome::Rejected => format!(
+                        "Could not save {key} on {target}: {}{restart_suffix}",
+                        e.message
+                    ),
+                    TargetOutcome::Unknown if prior_count > 0 => format!(
+                        "Saved {key} on {prior_count} target(s). The update outcome for {target} is unknown: {}{restart_suffix}",
+                        e.message
+                    ),
+                    TargetOutcome::Unknown => format!(
+                        "The update outcome for {target} is unknown: {}{restart_suffix}",
+                        e.message
+                    ),
+                };
+                let suggestion = if outcome == TargetOutcome::Unknown {
+                    Some("Check `floo env list` before retrying.")
+                } else {
+                    None
+                };
+                output::error_with_data(
+                    &message,
+                    &ErrorCode::from_api(&e.code),
+                    suggestion,
+                    Some(output::to_value(&EnvSetFailureData::new(
+                        env_updated,
+                        env_update_state,
+                        if restart {
+                            RestartState::NotStarted
+                        } else {
+                            RestartState::NotRequested
+                        },
+                        results,
+                        Some(FailedEnvTarget { target, outcome }),
+                        unattempted_targets,
+                    ))),
+                );
                 process::exit(1);
             }
         }
@@ -461,7 +673,65 @@ pub fn set(
             }
             Err(e) => {
                 spinner.finish();
-                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                let (restart_state, message, suggestion) = match e.code.as_str() {
+                        "DEPLOY_IN_PROGRESS" => (
+                            RestartState::NotStarted,
+                            format!(
+                                "Saved {key} on {} target(s), but restart did not start: {}",
+                                results.len(),
+                                e.message
+                            ),
+                            Some("Wait for the active deploy to finish, then run `floo redeploy`."),
+                        ),
+                        "RESTART_DISPATCH_FAILED" => (
+                            RestartState::AttemptCreated,
+                            format!(
+                                "Saved {key} on {} target(s). A restart attempt was created, but dispatch outcome is unknown: {}",
+                                results.len(),
+                                e.message
+                            ),
+                            Some("Check `floo deploys list` before retrying."),
+                        ),
+                        "RESTART_PIPELINE_FAILED" => (
+                            RestartState::Failed,
+                            format!(
+                                "Saved {key} on {} target(s). Restart started and failed: {}",
+                                results.len(),
+                                e.message
+                            ),
+                            Some("Run `floo logs` for details."),
+                        ),
+                        "PARSE_ERROR" if (200..400).contains(&e.status_code) => (
+                            RestartState::Started,
+                            format!(
+                                "Saved {key} on {} target(s). Restart started, but its response could not be read.",
+                                results.len()
+                            ),
+                            Some("Check `floo deploys list` before retrying."),
+                        ),
+                        _ => (
+                            RestartState::Unknown,
+                            format!(
+                                "Saved {key} on {} target(s). Restart outcome is unknown: {}",
+                                results.len(),
+                                e.message
+                            ),
+                            Some("Check `floo deploys list` before retrying."),
+                        ),
+                    };
+                output::error_with_data(
+                    &message,
+                    &ErrorCode::from_api(&e.code),
+                    suggestion,
+                    Some(output::to_value(&EnvSetFailureData::new(
+                        Some(true),
+                        EnvUpdateState::Complete,
+                        restart_state,
+                        results,
+                        None,
+                        Vec::new(),
+                    ))),
+                );
                 process::exit(1);
             }
         };
@@ -492,12 +762,16 @@ pub fn set(
             process::exit(1);
         }
 
-        // cancelled = the target env was torn down before the restart ran: a moot
-        // terminal (not a failure — exit 0), but don't claim it "Restarted".
-        let restart_msg = if final_status == "cancelled" {
-            "Restart cancelled: its target environment was removed before it ran.".to_string()
-        } else {
-            format!("Restarted {url}")
+        // A 202 response confirms the restart attempt started, not that it has
+        // already reached LIVE. Keep this command to one JSON document and let
+        // `floo deploys watch` own completion streaming.
+        let restart_msg = match final_status {
+            "cancelled" => {
+                "Restart cancelled: its target environment was removed before it ran.".to_string()
+            }
+            "superseded" => "Restart superseded by a newer deploy.".to_string(),
+            "live" => format!("Restarted {url}"),
+            _ => "Restart started.".to_string(),
         };
         output::success(
             &restart_msg,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -302,6 +302,15 @@ impl FlooApiError {
     pub fn is_not_found(&self) -> bool {
         self.status_code == 404
     }
+
+    /// True only for FastAPI's generic missing-route response.
+    ///
+    /// This is deliberately narrower than `is_not_found`: a structured
+    /// `APP_NOT_FOUND` or ownership 404 from a real endpoint is authoritative
+    /// and must never be mistaken for an older server that lacks the route.
+    pub fn is_missing_route(&self) -> bool {
+        self.status_code == 404 && self.code == "API_ERROR" && self.message == "Not Found"
+    }
 }
 
 #[cfg(test)]
@@ -352,6 +361,13 @@ mod tests {
         // A non-404 status must stay not-found=false even if some unrelated
         // payload happened to carry a NOT_FOUND-ish code.
         assert!(!FlooApiError::new(400, "NOT_FOUND", "weird").is_not_found());
+    }
+
+    #[test]
+    fn test_is_missing_route_matches_only_generic_fastapi_404() {
+        assert!(FlooApiError::new(404, "API_ERROR", "Not Found").is_missing_route());
+        assert!(!FlooApiError::new(404, "APP_NOT_FOUND", "App not found.").is_missing_route());
+        assert!(!FlooApiError::new(404, "API_ERROR", "App not found.").is_missing_route());
     }
 
     #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -775,6 +775,814 @@ fn set_env_response_body() -> &'static str {
     }"#
 }
 
+fn env_set_response(key: &str, service_id: Option<&str>, id: &str) -> String {
+    let service_id = service_id
+        .map(|value| format!(r#""{value}""#))
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        r#"{{
+            "id":"{id}",
+            "app_id":"00000000-0000-0000-0000-0000000000aa",
+            "environment_id":"00000000-0000-0000-0000-0000000000ee",
+            "service_id":{service_id},
+            "key":"{key}",
+            "masked_value":"value****",
+            "created_at":"2026-04-24T00:00:00Z",
+            "updated_at":"2026-04-24T00:00:00Z"
+        }}"#
+    )
+}
+
+fn mock_restart_preflight(server: &mut Server, status: usize, body: impl Into<String>) -> Mock {
+    server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/restart/preflight").as_str(),
+        )
+        .with_status(status)
+        .with_header("content-type", "application/json")
+        .with_body(body.into())
+        .create()
+}
+
+fn mock_empty_restart_preflight(server: &mut Server) -> Mock {
+    mock_restart_preflight(server, 204, "")
+}
+
+fn mock_multi_service_restart_preflight(server: &mut Server) -> Mock {
+    server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/restart/preflight").as_str(),
+        )
+        .match_query(Matcher::Exact("services=web&services=api".into()))
+        .with_status(204)
+        .create()
+}
+
+fn mock_env_set(
+    server: &mut Server,
+    service_id: &str,
+    status: usize,
+    body: impl Into<String>,
+) -> Mock {
+    server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
+        .match_body(Matcher::Regex(format!(r#""service_id":"{service_id}""#)))
+        .with_status(status)
+        .with_header("content-type", "application/json")
+        .with_body(body.into())
+        .create()
+}
+
+#[test]
+fn test_env_set_restart_preflight_blocks_before_write() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_restart_preflight(
+        &mut server,
+        409,
+        r#"{"detail":{"code":"DEPLOY_IN_PROGRESS","message":"A deploy is already in progress."}}"#,
+    );
+    let _no_set = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
+        .expect(0)
+        .create();
+    let _no_restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .expect(0)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(
+        output,
+        serde_json::json!({
+            "success": false,
+            "error": {
+                "code": "DEPLOY_IN_PROGRESS",
+                "message": "Restart did not start because a deploy is already in progress. No env values were changed.",
+                "suggestion": "Wait for the active deploy to finish, then retry."
+            },
+            "data": {
+                "env_updated": false,
+                "env_update_state": "not_started",
+                "restart_started": false,
+                "restart_state": "not_started",
+                "results": [],
+                "unattempted_targets": ["my-app/web"]
+            }
+        })
+    );
+}
+
+#[test]
+fn test_env_set_restart_refusal_reports_single_persisted_write() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/restart").as_str(),
+        )
+        .with_status(409)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"DEPLOY_IN_PROGRESS","message":"A deploy is already in progress."}}"#,
+        )
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["success"], false);
+    assert_eq!(output["error"]["code"], "DEPLOY_IN_PROGRESS");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["env_update_state"], "complete");
+    assert_eq!(output["data"]["restart_started"], false);
+    assert_eq!(output["data"]["restart_state"], "not_started");
+    assert_eq!(output["data"]["results"].as_array().unwrap().len(), 1);
+    assert_eq!(output["data"]["results"][0]["service_id"], TEST_SERVICE_ID);
+}
+
+#[test]
+fn test_env_set_restart_refusal_reports_every_persisted_service_write() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_two(&mut server);
+    let _preflight = mock_multi_service_restart_preflight(&mut server);
+    let _set_web = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _set_api = mock_env_set(
+        &mut server,
+        "svc-uuid-5678",
+        200,
+        env_set_response("MY_KEY", Some("svc-uuid-5678"), "env-api"),
+    );
+    let _restart = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/restart").as_str(),
+        )
+        .with_status(409)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"DEPLOY_IN_PROGRESS","message":"A deploy is already in progress."}}"#,
+        )
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--services",
+            "web,api",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "DEPLOY_IN_PROGRESS");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["restart_started"], false);
+    assert_eq!(output["data"]["results"].as_array().unwrap().len(), 2);
+    assert_eq!(output["data"]["results"][0]["service_id"], TEST_SERVICE_ID);
+    assert_eq!(output["data"]["results"][1]["service_id"], "svc-uuid-5678");
+}
+
+#[test]
+fn test_env_set_restart_refusal_human_output_names_saved_state() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/restart").as_str(),
+        )
+        .with_status(409)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"DEPLOY_IN_PROGRESS","message":"A deploy is already in progress."}}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Set MY_KEY on my-app/web."))
+        .stderr(predicate::str::contains(
+            "Saved MY_KEY on 1 target(s), but restart did not start",
+        ));
+}
+
+#[test]
+fn test_env_set_restart_rejects_prod_before_dry_run_or_io() {
+    let server = Server::new();
+    let home = setup_config(&server);
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY",
+            "--stdin",
+            "--env",
+            "prod",
+            "--restart",
+            "--dry-run",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .write_stdin("must-not-be-consumed")
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "INVALID_ARGUMENTS");
+    assert!(output["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("only targets dev"));
+}
+
+#[test]
+fn test_env_set_restart_preflight_falls_back_only_when_route_is_missing() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_restart_preflight(&mut server, 404, r#"{"detail":"Not Found"}"#);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"restart-new","status":"pending","url":null}"#)
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_env_set_restart_preflight_keeps_structured_app_not_found_terminal() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_restart_preflight(
+        &mut server,
+        404,
+        r#"{"detail":{"code":"APP_NOT_FOUND","message":"App not found."}}"#,
+    );
+    let _no_set = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .expect(0)
+        .create();
+    let _no_restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .expect(0)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "APP_NOT_FOUND");
+    assert_eq!(output["data"]["env_updated"], false);
+    assert_eq!(output["data"]["restart_state"], "preflight_failed");
+}
+
+#[test]
+fn test_env_set_restart_preflight_failure_mutates_nothing() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_restart_preflight(
+        &mut server,
+        503,
+        r#"{"detail":{"code":"SERVICE_UNAVAILABLE","message":"Deploy state is unavailable."}}"#,
+    );
+    let _no_set = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/env").as_str())
+        .match_query(Matcher::UrlEncoded("env".into(), "dev".into()))
+        .expect(0)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY",
+            "--stdin",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .write_stdin("must-not-be-used")
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "SERVICE_UNAVAILABLE");
+    assert_eq!(output["data"]["env_updated"], false);
+    assert_eq!(output["data"]["restart_started"], false);
+    assert_eq!(output["data"]["restart_state"], "preflight_failed");
+}
+
+#[test]
+fn test_env_set_reports_partial_multi_service_write_failure() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_two(&mut server);
+    let _preflight = mock_multi_service_restart_preflight(&mut server);
+    let _set_web = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _set_api = mock_env_set(
+        &mut server,
+        "svc-uuid-5678",
+        422,
+        r#"{"detail":{"code":"INVALID_ENV_VALUE","message":"Value rejected."}}"#,
+    );
+    let _no_restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .expect(0)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--services",
+            "web,api",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "INVALID_ENV_VALUE");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["env_update_state"], "partial");
+    assert_eq!(output["data"]["restart_started"], false);
+    assert_eq!(
+        output["data"]["failed_target"],
+        serde_json::json!({"target": "my-app/api", "outcome": "rejected"})
+    );
+    assert_eq!(output["data"]["results"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn test_env_set_reports_unknown_single_write_without_claiming_no_update() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        503,
+        r#"{"detail":{"code":"SERVICE_UNAVAILABLE","message":"Write response unavailable."}}"#,
+    );
+    let _no_restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .expect(0)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "SERVICE_UNAVAILABLE");
+    assert_eq!(output["data"]["env_updated"], serde_json::Value::Null);
+    assert_eq!(output["data"]["env_update_state"], "unknown");
+    assert_eq!(output["data"]["restart_started"], false);
+    assert_eq!(
+        output["data"]["failed_target"],
+        serde_json::json!({"target": "my-app/web", "outcome": "unknown"})
+    );
+}
+
+#[test]
+fn test_env_set_restart_unknown_error_does_not_claim_rollback_or_refusal() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"RESTART_BACKEND_ERROR","message":"Restart response failed."}}"#,
+        )
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["restart_started"], serde_json::Value::Null);
+    assert_eq!(output["data"]["restart_state"], "unknown");
+    assert!(output["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("outcome is unknown"));
+}
+
+#[test]
+fn test_env_set_restart_dispatch_failure_reports_created_attempt() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(503)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"RESTART_DISPATCH_FAILED","message":"Dispatch failed."}}"#)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "RESTART_DISPATCH_FAILED");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["restart_started"], serde_json::Value::Null);
+    assert_eq!(output["data"]["restart_state"], "attempt_created");
+}
+
+#[test]
+fn test_env_set_restart_pipeline_failure_reports_started_and_failed() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"RESTART_PIPELINE_FAILED","message":"Restart pipeline failed unexpectedly."}}"#,
+        )
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "RESTART_PIPELINE_FAILED");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["restart_started"], true);
+    assert_eq!(output["data"]["restart_state"], "failed");
+}
+
+#[test]
+fn test_env_set_restart_parse_error_reports_started() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"restart-new","status":"pending""#)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "PARSE_ERROR");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["restart_started"], true);
+    assert_eq!(output["data"]["restart_state"], "started");
+}
+
+#[test]
+fn test_env_set_parse_error_reports_committed_write_before_restart() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        r#"{"id":"env-web","key":"MY_KEY""#,
+    );
+    let _no_restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .expect(0)
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    assert_eq!(output["error"]["code"], "PARSE_ERROR");
+    assert_eq!(output["data"]["env_updated"], true);
+    assert_eq!(output["data"]["env_update_state"], "complete");
+    assert_eq!(output["data"]["restart_started"], false);
+    assert_eq!(
+        output["data"]["failed_target"],
+        serde_json::json!({
+            "target": "my-app/web",
+            "outcome": "committed_response_unreadable"
+        })
+    );
+}
+
+#[test]
+fn test_env_set_pending_restart_reports_started_and_preserves_success_shape() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let env_result = env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web");
+    let _set = mock_env_set(&mut server, TEST_SERVICE_ID, 200, env_result.clone());
+    let deploy_result = serde_json::json!({"id": "restart-new", "status": "pending", "url": null});
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(deploy_result.to_string())
+        .create();
+
+    let assert = floo()
+        .args([
+            "--json",
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success();
+
+    let output: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout).unwrap();
+    let mut expected_env: serde_json::Value = serde_json::from_str(&env_result).unwrap();
+    expected_env["is_secret"] = serde_json::Value::Bool(false);
+    assert_eq!(
+        output,
+        serde_json::json!({
+            "success": true,
+            "data": {
+                "env": expected_env,
+                "deploy": deploy_result
+            }
+        })
+    );
+}
+
+#[test]
+fn test_env_set_pending_restart_human_output_says_started_not_completed() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_list_services_one(&mut server);
+    let _preflight = mock_empty_restart_preflight(&mut server);
+    let _set = mock_env_set(
+        &mut server,
+        TEST_SERVICE_ID,
+        200,
+        env_set_response("MY_KEY", Some(TEST_SERVICE_ID), "env-web"),
+    );
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(202)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"id":"restart-new","status":"pending","url":null}"#)
+        .create();
+
+    floo()
+        .args([
+            "env",
+            "set",
+            "MY_KEY=my_value",
+            "--restart",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Restart started."))
+        .stderr(predicate::str::contains("Restarted").not());
+}
+
 #[test]
 fn test_env_set_stdin() {
     // #1152: a secret value piped on stdin keeps it out of argv / shell history.


### PR DESCRIPTION
## Summary

- preflight restart eligibility before consuming env values or persisting writes
- report every confirmed single-service and multi-service env update when restart later fails
- distinguish restart refusal, created-but-ambiguous dispatch, started failure, and unknown outcomes without implying rollback
- preserve API error codes and the existing successful JSON shape

## Verification

- canonical floo-cli suite passed after rebase: 780 tests
- focused env-set contract suite: 24 tests passed
- independent review finding on unknown write state fixed and re-verified

## Dependency

Requires getfloo/floo#1785 to land first.

Closes getfloo/floo#1779