### PR TITLE
feat: diagnose managed Redis health

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -582,6 +582,14 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn diagnose_managed_services(
+        &self,
+        app_id: &str,
+    ) -> Result<crate::api_types::ManagedServicesDoctorResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/apps/{app_id}/doctor/managed-services"))?;
+        self.handle_response(resp)
+    }
+
     // --- Cron Jobs ---
 
     pub fn list_cron_jobs(&self, app_id: &str) -> Result<CronJobListResponse, FlooApiError> {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -355,6 +355,14 @@ pub struct ListServicesResponse {
 // Mirrors api/app/schemas/managed_services.py. Keep these in lock-step.
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedRedisEnvironmentHealth {
+    pub status: String,
+    pub reason: String,
+    pub observed_at: Option<String>,
+    pub remediation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManagedServiceSummary {
     pub id: String,
     pub app_id: String,
@@ -366,6 +374,10 @@ pub struct ManagedServiceSummary {
     pub env_var_keys: Vec<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
+    #[serde(default)]
+    pub dev_health: Option<ManagedRedisEnvironmentHealth>,
+    #[serde(default)]
+    pub prod_health: Option<ManagedRedisEnvironmentHealth>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -397,6 +409,10 @@ pub struct ManagedServiceDetail {
     pub env_var_keys: Vec<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
+    #[serde(default)]
+    pub dev_health: Option<ManagedRedisEnvironmentHealth>,
+    #[serde(default)]
+    pub prod_health: Option<ManagedRedisEnvironmentHealth>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -877,6 +893,29 @@ pub struct AccountsDoctorResponse {
     pub drift: Vec<AccountsDoctorDrift>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedServiceDoctorIssue {
+    pub resource_id: String,
+    pub resource_kind: String,
+    #[serde(rename = "type")]
+    pub service_type: String,
+    pub name: String,
+    pub environment: String,
+    pub status: String,
+    pub reason: String,
+    pub observed_at: Option<String>,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedServicesDoctorResponse {
+    pub app_id: String,
+    pub app_name: String,
+    pub checked_environments: usize,
+    pub degraded_detected: bool,
+    pub issues: Vec<ManagedServiceDoctorIssue>,
+}
+
 // --- Analytics ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -959,4 +998,67 @@ pub struct NotificationPreference {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotificationPreferencesResponse {
     pub preferences: Vec<NotificationPreference>,
+}
+
+#[cfg(test)]
+mod managed_services_doctor_tests {
+    use super::{ManagedServiceSummary, ManagedServicesDoctorResponse};
+
+    #[test]
+    fn response_deserializes_redacted_issue_contract() {
+        let response: ManagedServicesDoctorResponse = serde_json::from_value(serde_json::json!({
+            "app_id": "app-1",
+            "app_name": "payments",
+            "checked_environments": 2,
+            "degraded_detected": true,
+            "issues": [{
+                "resource_id": "redis-1",
+                "resource_kind": "managed_service",
+                "type": "redis",
+                "name": "default",
+                "environment": "prod",
+                "status": "throttled",
+                "reason": "throttle_daily_limit",
+                "observed_at": "2026-07-24T17:00:00Z",
+                "remediation": "Increase the Upstash daily request allowance."
+            }]
+        }))
+        .expect("doctor response deserializes");
+
+        assert!(response.degraded_detected);
+        assert_eq!(response.issues[0].service_type, "redis");
+        assert_eq!(response.issues[0].reason, "throttle_daily_limit");
+    }
+
+    #[test]
+    fn services_response_deserializes_redis_environment_health() {
+        let service: ManagedServiceSummary = serde_json::from_value(serde_json::json!({
+            "id": "redis-1",
+            "app_id": "app-1",
+            "type": "redis",
+            "name": "default",
+            "status": "ready",
+            "env_var_keys": ["REDIS_URL"],
+            "created_at": "2026-07-24T17:00:00Z",
+            "updated_at": "2026-07-24T17:00:00Z",
+            "dev_health": {
+                "status": "healthy",
+                "reason": "healthy",
+                "observed_at": "2026-07-24T17:00:00Z",
+                "remediation": null
+            },
+            "prod_health": {
+                "status": "throttled",
+                "reason": "throttle_daily_limit",
+                "observed_at": "2026-07-24T17:00:00Z",
+                "remediation": "Contact floo support."
+            }
+        }))
+        .expect("managed service response deserializes");
+
+        assert_eq!(
+            service.prod_health.expect("prod health").status,
+            "throttled"
+        );
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -371,7 +371,7 @@ Examples:
     /// full list of topics with one-line descriptions.
     #[command(after_help = "\
 Topics: golden-path, quickstart, build, nextjs, rails, fastapi, django,
-express, templates, services, edge, egress, previews, config, cron, deploy, auth,
+express, templates, services, doctor, edge, egress, previews, config, cron, deploy, auth,
 notifications, feedback.
 Aliases: storage -> services, app-toml -> config.
 Run `floo docs` (no topic) for a one-line description of each topic.")]
@@ -1754,6 +1754,20 @@ pub enum ReparoCommands {
 
 #[derive(Subcommand)]
 pub enum DoctorCommands {
+    /// Check managed-service data-plane health.
+    #[command(after_help = "\
+Examples:
+  floo doctor managed-services                Use the app from floo.app.toml
+  floo doctor managed-services --app foo      Diagnose a specific app
+  floo doctor managed-services --json         Machine-readable output for agents
+
+Exit code is non-zero when a managed-service issue is detected.")]
+    ManagedServices {
+        /// App name or ID (reads from config if omitted).
+        #[arg(short, long)]
+        app: Option<String>,
+    },
+
     /// Diagnose an app's accounts-mode posture (feedback 64268e05).
     #[command(after_help = "\
 Examples:
@@ -2517,6 +2531,9 @@ pub fn run() {
 
         Commands::Doctor(sub) => match sub {
             DoctorCommands::Accounts { app } => commands::doctor::accounts(app.as_deref()),
+            DoctorCommands::ManagedServices { app } => {
+                commands::doctor::managed_services(app.as_deref())
+            }
         },
 
         Commands::Feedback {
@@ -3096,5 +3113,23 @@ mod tests {
         // to JSON, whereas `--help`/`--version` are stdout displays that don't.
         assert!(parse_err(&["floo", "doctor", "--json"]).use_stderr());
         assert!(!parse_err(&["floo", "--help"]).use_stderr());
+    }
+
+    #[test]
+    fn doctor_managed_services_parses_app_and_json_flags() {
+        let cli = Cli::try_parse_from([
+            "floo",
+            "doctor",
+            "managed-services",
+            "--app",
+            "payments",
+            "--json",
+        ])
+        .expect("managed-services doctor command parses");
+        assert!(cli.json);
+        let Commands::Doctor(DoctorCommands::ManagedServices { app }) = cli.command else {
+            panic!("expected Doctor::ManagedServices");
+        };
+        assert_eq!(app.as_deref(), Some("payments"));
     }
 }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -37,6 +37,7 @@ never uploads code.
   floo docs express    — build and deploy an Express app on floo (end-to-end)
   floo docs templates  — copy-paste app structures (React+FastAPI, Next.js, etc.)
   floo docs services   — service types and managed services (alias: storage)
+  floo docs doctor     — diagnose managed Redis health and accounts drift
   floo docs edge       — edge routes, the IP/CIDR firewall, enforcement order
   floo docs egress     — outbound egress and private-network status
   floo docs previews   — command-line preview sandboxes for remote branches
@@ -341,6 +342,40 @@ default behind an explicit development-only guard.
   floo services add <type> --app <name>      — provision a managed service
   floo services remove <type> --app <name>   — permanently destroy (tier-3)
   floo services migrate --app <name>         — move legacy TOML → CLI state
+";
+
+const DOCTOR: &str = "\
+Floo Doctor
+
+Doctor commands return one verdict plus the evidence behind it. Every command
+supports --json and exits non-zero when it detects an issue.
+
+## Managed Redis data-plane health
+
+  floo doctor managed-services --app <name>
+  floo doctor managed-services --app <name> --json
+
+floo executes one short-lived read/write canary against every ready dev, prod,
+and preview Redis resource each minute. The doctor reports throttling, auth or
+permission rejection, unreachable providers, command rejection, configuration
+errors, and missing or stale observations.
+
+Each issue includes service, environment, stable status and reason, observation
+time, and remediation. It never includes Redis credentials, raw provider
+responses, or customer keys.
+
+For request-rate or quota throttling, reduce Redis traffic and contact
+team@getfloo.com to raise managed capacity.
+
+## Accounts-mode drift
+
+  floo doctor accounts --app <name>
+  floo doctor accounts --app <name> --json
+
+The accounts doctor compares requested access config with the gateway state
+currently serving it. It exits non-zero when the drift list is non-empty.
+
+Full guide: https://getfloo.com/docs/cli/doctor
 ";
 
 const EDGE: &str = "\
@@ -1971,6 +2006,7 @@ pub(crate) const TOPICS: &[(&str, &str)] = &[
     ("express", EXPRESS),
     ("templates", TEMPLATES),
     ("services", SERVICES),
+    ("doctor", DOCTOR),
     ("edge", EDGE),
     ("egress", EGRESS),
     ("previews", PREVIEWS),
@@ -2040,6 +2076,7 @@ mod tests {
         assert!(!OVERVIEW.is_empty());
         assert!(!QUICKSTART.is_empty());
         assert!(!SERVICES.is_empty());
+        assert!(!DOCTOR.is_empty());
         assert!(!PREVIEWS.is_empty());
         assert!(!CONFIG.is_empty());
         assert!(!CRON.is_empty());

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,7 +7,9 @@
 
 use std::process;
 
-use crate::api_types::{AccountsDoctorDrift, AccountsDoctorResponse};
+use crate::api_types::{
+    AccountsDoctorDrift, AccountsDoctorResponse, ManagedServicesDoctorResponse,
+};
 use crate::errors::ErrorCode;
 use crate::output;
 
@@ -52,6 +54,83 @@ pub fn accounts(app_flag: Option<&str>) {
     // convention as `preflight` and `db migrate --dry-run`.
     if drift_detected {
         process::exit(1);
+    }
+}
+
+pub fn managed_services(app_flag: Option<&str>) {
+    super::require_auth();
+    let client = super::init_client(None);
+    let (app_id, _app_name) = super::resolve_app_from_config(&client, app_flag);
+
+    let mut result = match client.diagnose_managed_services(&app_id) {
+        Ok(response) => response,
+        Err(error) => {
+            output::error(&error.message, &ErrorCode::from_api(&error.code), None);
+            process::exit(1);
+        }
+    };
+    let degraded_detected = !result.issues.is_empty();
+    result.degraded_detected = degraded_detected;
+
+    if output::is_json_mode() {
+        output::success(
+            "Managed-service doctor diagnosis.",
+            Some(output::to_value(&result)),
+        );
+    } else {
+        render_managed_services(&result);
+    }
+
+    if degraded_detected {
+        process::exit(1);
+    }
+}
+
+fn render_managed_services(result: &ManagedServicesDoctorResponse) {
+    output::info(
+        &format!("App: {} ({})", result.app_name, result.app_id),
+        None,
+    );
+    eprintln!(
+        "Checked Redis environments: {}",
+        result.checked_environments
+    );
+
+    if result.issues.is_empty() {
+        output::info("Managed Redis data planes are healthy.", None);
+        return;
+    }
+
+    output::info(
+        &format!("Managed-service issues detected ({}):", result.issues.len()),
+        None,
+    );
+    let rows: Vec<Vec<String>> = result
+        .issues
+        .iter()
+        .map(|issue| {
+            vec![
+                issue.name.clone(),
+                issue.environment.clone(),
+                issue.status.clone(),
+                issue.reason.clone(),
+                issue
+                    .observed_at
+                    .clone()
+                    .unwrap_or_else(|| "not observed".to_string()),
+            ]
+        })
+        .collect();
+    output::table(
+        &["Service", "Environment", "Status", "Reason", "Observed"],
+        &rows,
+        None,
+    );
+    for issue in &result.issues {
+        eprintln!(
+            "  {} ({}): {}",
+            issue.name, issue.environment, issue.remediation
+        );
     }
 }
 

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -86,10 +86,17 @@ pub fn list(app: Option<&str>, env: &str) {
         ]);
     }
     for ms in &managed_services {
+        let environment_health = match env {
+            "prod" => ms.prod_health.as_ref(),
+            _ => ms.dev_health.as_ref(),
+        };
+        let status = environment_health
+            .filter(|health| health.status != "healthy")
+            .map_or(ms.status.as_str(), |_| "degraded");
         rows.push(vec![
             ms.name.clone(),
             ms.service_type.clone(),
-            ms.status.clone(),
+            status.to_string(),
             "managed".to_string(),
             "\u{2014}".to_string(),
         ]);
@@ -245,6 +252,8 @@ fn render_managed_service(
     );
     output::info(&format!("  Status:   {}", detail.status), None);
     output::info(&format!("  Created:  {created}"), None);
+    render_redis_health("Dev health", detail.dev_health.as_ref());
+    render_redis_health("Prod health", detail.prod_health.as_ref());
     if !detail.env_var_keys.is_empty() {
         output::info(
             &format!("  Env vars: {}", detail.env_var_keys.join(", ")),
@@ -254,6 +263,27 @@ fn render_managed_service(
             "  (credentials are injected at runtime; use 'floo env list' to see keys)",
             None,
         );
+    }
+}
+
+fn render_redis_health(
+    label: &str,
+    health: Option<&crate::api_types::ManagedRedisEnvironmentHealth>,
+) {
+    let Some(health) = health else {
+        return;
+    };
+    output::info(
+        &format!(
+            "  {label}: {} ({}, observed {})",
+            health.status,
+            health.reason,
+            health.observed_at.as_deref().unwrap_or("not yet")
+        ),
+        None,
+    );
+    if let Some(remediation) = &health.remediation {
+        output::info(&format!("    Remediation: {remediation}"), None);
     }
 }
 

--- a/src/services_lock.rs
+++ b/src/services_lock.rs
@@ -246,6 +246,8 @@ mod tests {
             env_var_keys: vec![],
             created_at: None,
             updated_at: None,
+            dev_health: None,
+            prod_health: None,
         }
     }
 

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5002,6 +5002,73 @@ fn test_doctor_accounts_json_old_api_no_field_derives_from_drift_list() {
         .stdout(predicate::str::contains(r#""drift_detected":true"#));
 }
 
+fn mock_doctor_managed_services(server: &mut Server, body: &str) -> Mock {
+    server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/doctor/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .create()
+}
+
+#[test]
+fn test_doctor_managed_services_json_healthy_exits_zero() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _doctor = mock_doctor_managed_services(
+        &mut server,
+        &format!(
+            r#"{{"app_id":"{TEST_APP_ID}","app_name":"{TEST_APP_NAME}","checked_environments":2,"degraded_detected":false,"issues":[]}}"#
+        ),
+    );
+
+    floo()
+        .args([
+            "--json",
+            "doctor",
+            "managed-services",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""degraded_detected":false"#));
+}
+
+#[test]
+fn test_doctor_managed_services_json_issue_exits_one_and_redacts_credentials() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _doctor = mock_doctor_managed_services(
+        &mut server,
+        &format!(
+            r#"{{"app_id":"{TEST_APP_ID}","app_name":"{TEST_APP_NAME}","checked_environments":2,"degraded_detected":false,"issues":[{{"resource_id":"redis-1","resource_kind":"managed_service","type":"redis","name":"default","environment":"prod","status":"throttled","reason":"throttle_daily_limit","observed_at":"2026-07-24T17:00:00Z","remediation":"Contact floo support to raise managed capacity."}}]}}"#
+        ),
+    );
+
+    floo()
+        .args([
+            "--json",
+            "doctor",
+            "managed-services",
+            "--app",
+            TEST_APP_NAME,
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(r#""degraded_detected":true"#))
+        .stdout(predicate::str::contains("throttle_daily_limit"))
+        .stdout(predicate::str::contains("redis://").not())
+        .stdout(predicate::str::contains("password").not());
+}
+
 // --- env multi-target JSON contract (#203) ---
 //
 // One invocation emits exactly ONE JSON object on stdout. The per-service


### PR DESCRIPTION
## What changed

Adds `floo doctor managed-services` with human and JSON verdicts, non-zero exit semantics for degraded state, managed Redis health fields in API types, degraded rendering in `floo services`, and an offline `floo docs doctor` topic.

## Why

The platform-side #1774 canary needs a first-class agent and operator surface. Stable reason codes and exit semantics let users diagnose throttling, auth rejection, reachability, command rejection, configuration errors, and missing/stale evidence without parsing logs or exposing credentials.

## User impact

Users and agents can diagnose managed Redis data-plane health directly; existing managed-service payloads remain backward-compatible through optional health fields.

## Tests run

Canonical `./scripts/test` green: 483 unit tests, 144 command tests, 140 mock-API tests, and the documentation-link test. The monorepo test wrapper wrote the required tree-bound floo-cli sentinel, and the standard-tier correctness/security/silent-failure self-review is recorded.

Closes getfloo/floo#1774