### PR TITLE
docs: document opt-in pull request previews in the offline corpus

### DIFF
--- a/docs/offline/previews.md
+++ b/docs/offline/previews.md
@@ -3,6 +3,37 @@ floo Preview Sandboxes
 Use `floo previews` when an agent needs an isolated, real floo environment for a
 pushed feature branch before opening or relying on a pull request preview.
 
+## Pull request previews are opt-in
+
+Opening a pull request does not deploy a preview unless the app turns them on.
+There are two controls, and the per-PR one wins.
+
+App default, in `floo.app.toml`:
+
+  [github]
+  preview_environments = true
+  preview_ttl_hours = 72
+
+A missing `preview_environments` key means previews are off. `[preview] enabled`
+and `[preview] ttl_hours` are deprecated aliases that still work for one
+migration window and log a `legacy_preview_toml` warning on every deploy.
+
+Per-PR override, as a comment on the pull request itself:
+
+  /floo preview on
+  /floo preview off
+
+`on` opts one PR in when the app default is off; `off` opts one PR out when the
+app default is on. floo reconciles the comment immediately, so opting in does
+not require pushing another commit.
+
+The comment must contain the command and nothing else, and its author must be a
+repository owner, member, or collaborator. The most recently updated authorized
+command wins; editing or deleting it returns the PR to the app default.
+
+`floo previews up` reaches the same kind of environment from the CLI and needs
+neither a pull request nor the app-level setting.
+
 ## Source contract
 
 Preview sandboxes deploy remote GitHub source only:

--- a/src/cli/guidance_tests.rs
+++ b/src/cli/guidance_tests.rs
@@ -49,6 +49,24 @@ fn is_command_start(candidate: &str) -> bool {
         })
 }
 
+/// `/floo …` at a word boundary is a pull request comment command, not CLI
+/// syntax. floo's PR previews are driven by `/floo preview on` / `/floo preview
+/// off`, and `preview` is a compatibility alias of the `previews` subcommand, so
+/// without this the comment command cannot be documented in first-party guidance
+/// at all. A slash that follows a path character (`bin/floo deploy`) is still a
+/// real invocation and stays validated.
+fn is_pr_comment_command(text: &str, start: usize) -> bool {
+    let Some(before_slash) = text
+        .get(..start)
+        .and_then(|prefix| prefix.strip_suffix('/'))
+    else {
+        return false;
+    };
+    !before_slash.chars().last().is_some_and(|character| {
+        character.is_alphanumeric() || matches!(character, '.' | '-' | '_' | '~')
+    })
+}
+
 fn push_occurrences(
     text: &str,
     source: &str,
@@ -58,6 +76,10 @@ fn push_occurrences(
 ) {
     let mut remainder = text;
     while let Some(start) = remainder.find("floo ") {
+        if is_pr_comment_command(remainder, start) {
+            remainder = &remainder[start + "floo ".len()..];
+            continue;
+        }
         let delimiter = remainder[..start]
             .chars()
             .last()
@@ -444,6 +466,48 @@ fn guidance_validator_rejects_stale_syntax() {
     );
     assert_eq!(prose.len(), 1);
     assert!(validate_path_and_options(&prose[0].invocation).is_err());
+}
+
+#[test]
+fn guidance_validator_skips_pr_comment_commands() {
+    // `/floo preview on` is a pull request comment command. `preview` is a
+    // compatibility alias of `previews`, so treating it as CLI syntax would
+    // make the comment command undocumentable in first-party guidance.
+    let mut comment = Vec::new();
+    push_occurrences(
+        "Comment `/floo preview on` on the pull request to opt it in.",
+        "comment-fixture.md",
+        1,
+        false,
+        &mut comment,
+    );
+    assert!(
+        comment.is_empty(),
+        "pull request comment commands must not be validated as CLI syntax: {comment:?}"
+    );
+
+    // A slash that continues a path is still a real invocation.
+    let mut path_invocation = Vec::new();
+    push_occurrences(
+        "Run /usr/local/bin/floo apps status my-app to inspect it.",
+        "path-fixture.md",
+        1,
+        false,
+        &mut path_invocation,
+    );
+    assert_eq!(path_invocation.len(), 1);
+    assert!(validate_path_and_options(&path_invocation[0].invocation).is_err());
+
+    // A bare `floo …` next to a slash-delimited sentence is unaffected.
+    let mut plain = Vec::new();
+    push_occurrences(
+        "Deploy/promote, then run floo apps status my-app.",
+        "plain-fixture.md",
+        1,
+        false,
+        &mut plain,
+    );
+    assert_eq!(plain.len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## What changed

`docs/offline/previews.md` referenced "pull request previews" twice but never explained how to get one. It now documents both enablement controls:

- the app default, `[github] preview_environments` / `preview_ttl_hours` in `floo.app.toml`, with the deprecated `[preview] enabled` / `ttl_hours` aliases called out
- the per-PR override, `/floo preview on` and `/floo preview off` as a pull request comment, including the three rules that decide whether a comment counts: the body must be the command and nothing else, the author must be a repository owner/member/collaborator, and the most recently updated authorized command wins

The guidance validator rejected that text, which is the second half of this PR. `push_occurrences` scans for the literal `floo ` anywhere in first-party guidance, and `preview` is a compatibility alias of the `previews` subcommand, so `/floo preview on` was read as stale CLI syntax:

```
docs/offline/previews.md:23 `floo preview on`: `preview` is a compatibility alias; use canonical `previews`
```

That made the PR comment command **undocumentable in any first-party guidance file** — offline topic, bundled skill, or Rust doc string. `push_occurrences` now skips an occurrence preceded by a word-boundary slash, which is a PR comment command rather than an invocation. A slash that continues a path (`bin/floo deploy`, `/usr/local/bin/floo apps status`) is still a real invocation and stays validated.

## Why

Companion to getfloo/floo#1836, which flips floo's own app to `preview_environments = false` so previews are opt-in per PR. The four-surface alignment contract requires the offline mirror to carry the same contract as the web docs, and the corresponding `floo-docs` change is getfloo/floo-docs#32.

The comment command has existed for some time and was documented on zero surfaces: not in `floo-docs`, not in the offline corpus, not in the bundled routers. The validator collision is why.

## Risk tier

**standard.** `docs/offline/previews.md` is corpus text; `src/cli/guidance_tests.rs` is test-harness code with no runtime path.

## Files reviewers should scrutinize

- `src/cli/guidance_tests.rs`: `is_pr_comment_command`. The exclusion must not silently widen to real invocations. It fires only when the byte before `floo ` is `/` **and** the character before that slash is not path-like (alphanumeric, `.`, `-`, `_`, `~`).

## Tests run

`./scripts/floo-cli-test.sh` (fmt --check + clippy -D warnings + cargo test): **500 passed, 0 failed**, sentinel written.

New test `guidance_validator_skips_pr_comment_commands` pins all three directions:

| Input | Expected |
|---|---|
| ``Comment `/floo preview on` on the pull request`` | no guidance emitted |
| `Run /usr/local/bin/floo apps status my-app` | one guidance, still validated (and still rejected as stale) |
| `Deploy/promote, then run floo apps status my-app` | one guidance, unaffected by a nearby slash |

`first_party_guidance_matches_clap` fails on the parent commit with the two `preview` alias errors quoted above and passes here, so the corpus change is covered by the same test that blocked it.

## Known non-goals

- **The bundled routers are unchanged.** `skills/floo/SKILL.md` routes to `floo docs previews`, which now carries this content. No catalog duplication, per the docs-alignment contract.
- **No new offline topic.** The typed registry in `src/commands/docs.rs` is untouched; this edits an existing topic body.
- **The `previews`/`preview` naming collision itself is not resolved.** The CLI subcommand is `floo previews` with `preview` as a compat alias, while the PR comment command is `/floo preview` singular. They are distinct surfaces that happen to collide in a text scanner; renaming either is a breaking change and out of scope.

## Issue Closure (Required)

N/A. Documentation alignment for the preview opt-in posture change in getfloo/floo#1836; no tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)