### PR TITLE
fix: follow coalesced deploy lineage

### DIFF
--- a/docs/offline/deploy.md
+++ b/docs/offline/deploy.md
@@ -20,6 +20,16 @@ floo Deploy Flow
 
   The push triggers a deploy automatically via GitHub webhook.
 
+  To follow one pushed commit, pass its full or abbreviated SHA:
+
+    floo deploys watch --app <name> --commit <sha>
+
+  If rapid pushes arrive while another deploy is active, floo may coalesce an
+  intermediate commit into the later authoritative deploy. Watch follows that
+  recorded effective deploy and emits `commit_coalesced` in JSON mode before
+  the ordinary deploy lifecycle events. An exact deploy for the requested SHA
+  always takes precedence.
+
 ## Force Redeploy
 
   Use `floo redeploy` only when you need to apply an operational change
@@ -105,5 +115,6 @@ floo Deploy Flow
   floo deploys list --app <name>    - list past deploys without build logs
   floo deploys logs <id> --app <n>  - build logs for a specific deploy
   floo deploys watch --app <name>   - stream deploy progress in real-time
+  floo deploys watch --app <name> --commit <sha>  - follow exact or coalesced commit lineage
   floo deploys rollback <app> <id>  - rollback to a previous deploy
   floo releases rollback --app <name> --to <id>  - same, alias under releases

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -218,6 +218,16 @@ pub struct FailureRootCause {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoalescedCommit {
+    pub requested_commit_sha: String,
+    pub source_repo_full_name: String,
+    pub github_ref: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub resolved_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Deploy {
     pub id: String,
     #[serde(default)]
@@ -232,6 +242,8 @@ pub struct Deploy {
     pub generated_password: Option<String>,
     pub triggered_by: Option<String>,
     pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub coalesced_commits: Vec<CoalescedCommit>,
     #[serde(default)]
     pub github_ref: Option<String>,
     #[serde(default)]

--- a/src/commands/deploys.rs
+++ b/src/commands/deploys.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use colored::Colorize;
 
 use crate::api_client::FlooClient;
-use crate::api_types::Deploy;
+use crate::api_types::{CoalescedCommit, Deploy};
 use crate::commands::deploy::{poll_deploy, settle_to_terminal, stream_deploy, stream_deploy_json};
 use crate::deploy_status;
 use crate::errors::ErrorCode;
@@ -684,13 +684,13 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
 
     let (app_id, app_name) = super::resolve_app_from_config(&client, app);
 
-    let deploy = match commit {
+    let matched = match commit {
         Some(sha) => find_deploy_by_commit(&client, &app_id, sha),
-        None => find_latest_deploy(&client, &app_id),
+        None => find_latest_deploy(&client, &app_id).map(|deploy| (deploy, None)),
     };
 
-    let deploy = match deploy {
-        Some(d) => d,
+    let (deploy, coalesced_commit) = match matched {
+        Some(found) => found,
         None => {
             output::error(
                 "No deploy found.",
@@ -701,6 +701,9 @@ pub fn watch(app: Option<&str>, commit: Option<&str>) {
         }
     };
 
+    if let Some(lineage) = coalesced_commit.as_ref() {
+        emit_commit_coalesced(lineage, &deploy);
+    }
     emit_deploy_found(&deploy, &app_name);
 
     let status = deploy.status.as_deref().unwrap_or("");
@@ -753,7 +756,11 @@ fn find_latest_deploy(client: &FlooClient, app_id: &str) -> Option<Deploy> {
     result.deploys.into_iter().next()
 }
 
-fn find_deploy_by_commit(client: &FlooClient, app_id: &str, sha_prefix: &str) -> Option<Deploy> {
+fn find_deploy_by_commit(
+    client: &FlooClient,
+    app_id: &str,
+    sha_prefix: &str,
+) -> Option<(Deploy, Option<CoalescedCommit>)> {
     let start = Instant::now();
     let spinner = if !output::is_json_mode() {
         Some(output::Spinner::new(&format!(
@@ -764,26 +771,58 @@ fn find_deploy_by_commit(client: &FlooClient, app_id: &str, sha_prefix: &str) ->
     };
 
     loop {
-        let result = match client.list_deploys(app_id) {
-            Ok(r) => r,
-            Err(e) => {
-                if let Some(s) = spinner.as_ref() {
-                    s.finish();
-                }
-                output::error(&e.message, &ErrorCode::from_api(&e.code), None);
-                process::exit(1);
-            }
-        };
+        let mut cursor: Option<String> = None;
+        let mut coalesced_match: Option<(Deploy, CoalescedCommit)> = None;
 
-        if let Some(deploy) = result.deploys.into_iter().find(|d| {
-            d.commit_sha
-                .as_deref()
-                .is_some_and(|s| s.starts_with(sha_prefix))
-        }) {
+        loop {
+            let result = match client.list_deploys_paginated(app_id, 100, cursor.as_deref()) {
+                Ok(r) => r,
+                Err(e) => {
+                    if let Some(s) = spinner.as_ref() {
+                        s.finish();
+                    }
+                    output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+                    process::exit(1);
+                }
+            };
+
+            for deploy in result.deploys {
+                if deploy
+                    .commit_sha
+                    .as_deref()
+                    .is_some_and(|sha| sha.starts_with(sha_prefix))
+                {
+                    if let Some(s) = spinner.as_ref() {
+                        s.finish();
+                    }
+                    return Some((deploy, None));
+                }
+
+                if coalesced_match.is_none() {
+                    if let Some(lineage) = deploy
+                        .coalesced_commits
+                        .iter()
+                        .find(|lineage| lineage.requested_commit_sha.starts_with(sha_prefix))
+                    {
+                        coalesced_match = Some((deploy.clone(), lineage.clone()));
+                    }
+                }
+            }
+
+            if !result.has_more {
+                break;
+            }
+            let Some(next_cursor) = result.next_cursor else {
+                break;
+            };
+            cursor = Some(next_cursor);
+        }
+
+        if let Some((deploy, lineage)) = coalesced_match {
             if let Some(s) = spinner.as_ref() {
                 s.finish();
             }
-            return Some(deploy);
+            return Some((deploy, Some(lineage)));
         }
 
         if start.elapsed() >= COMMIT_WAIT_TIMEOUT {
@@ -802,6 +841,29 @@ fn find_deploy_by_commit(client: &FlooClient, app_id: &str, sha_prefix: &str) ->
         }
 
         thread::sleep(COMMIT_POLL_INTERVAL);
+    }
+}
+
+fn emit_commit_coalesced(lineage: &CoalescedCommit, deploy: &Deploy) {
+    let effective_commit = deploy.commit_sha.as_deref().unwrap_or("unknown");
+    if output::is_json_mode() {
+        output::print_json(&serde_json::json!({
+            "event": "commit_coalesced",
+            "lineage_status": "superseded",
+            "requested_commit": lineage.requested_commit_sha,
+            "effective_commit": effective_commit,
+            "effective_deploy_id": deploy.id,
+        }));
+    } else {
+        output::info(
+            &format!(
+                "Commit {} was coalesced into descendant {} — following deploy {}.",
+                super::short_sha(&lineage.requested_commit_sha),
+                super::short_sha(effective_commit),
+                deploy.id,
+            ),
+            None,
+        );
     }
 }
 

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -4351,6 +4351,234 @@ fn test_deploy_list_from_config() {
         .stdout(predicate::str::contains("deploy-123"));
 }
 
+#[test]
+fn test_deploy_watch_follows_coalesced_descendant_and_emits_structured_lineage() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let requested = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let effective = "cccccccccccccccccccccccccccccccccccccccc";
+    let _deploys = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{
+                "deploys":[{{
+                    "id":"deploy-effective",
+                    "status":"live",
+                    "commit_sha":"{effective}",
+                    "coalesced_commits":[{{
+                        "requested_commit_sha":"{requested}",
+                        "source_repo_full_name":"myorg/myrepo",
+                        "github_ref":"refs/heads/main",
+                        "created_at":"2026-07-30T12:00:00Z",
+                        "resolved_at":"2026-07-30T12:01:00Z"
+                    }}]
+                }}],
+                "has_more":false
+            }}"#
+        ))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploys",
+            "watch",
+            "--app",
+            TEST_APP_NAME,
+            "--commit",
+            "bbbbbbbb",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""event":"commit_coalesced""#))
+        .stdout(predicate::str::contains(r#""lineage_status":"superseded""#))
+        .stdout(predicate::str::contains(format!(
+            r#""requested_commit":"{requested}""#
+        )))
+        .stdout(predicate::str::contains(format!(
+            r#""effective_commit":"{effective}""#
+        )))
+        .stdout(predicate::str::contains(
+            r#""effective_deploy_id":"deploy-effective""#,
+        ))
+        .stdout(predicate::str::contains(r#""event":"done""#))
+        .stdout(predicate::str::contains(r#""status":"live""#));
+}
+
+#[test]
+fn test_deploy_watch_prefers_exact_commit_on_later_page_over_coalesced_match() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let requested = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let _first_page = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{
+                "deploys":[{{
+                    "id":"deploy-coalesced",
+                    "status":"live",
+                    "commit_sha":"cccccccccccccccccccccccccccccccccccccccc",
+                    "coalesced_commits":[{{
+                        "requested_commit_sha":"{requested}",
+                        "source_repo_full_name":"myorg/myrepo",
+                        "github_ref":"refs/heads/main",
+                        "created_at":"2026-07-30T12:00:00Z"
+                    }}]
+                }}],
+                "has_more":true,
+                "next_cursor":"cursor-2"
+            }}"#
+        ))
+        .create();
+    let _second_page = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+            Matcher::UrlEncoded("cursor".into(), "cursor-2".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{
+                "deploys":[{{
+                    "id":"deploy-exact",
+                    "status":"live",
+                    "commit_sha":"{requested}"
+                }}],
+                "has_more":false
+            }}"#
+        ))
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploys",
+            "watch",
+            "--app",
+            TEST_APP_NAME,
+            "--commit",
+            "bbbbbbbb",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""deploy_id":"deploy-exact""#))
+        .stdout(predicate::str::contains("commit_coalesced").not());
+}
+
+#[test]
+fn test_deploy_watch_coalesced_failed_descendant_keeps_failure_exit() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _deploys = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+                "deploys":[{
+                    "id":"deploy-failed",
+                    "status":"failed",
+                    "commit_sha":"cccccccccccccccccccccccccccccccccccccccc",
+                    "coalesced_commits":[{
+                        "requested_commit_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "source_repo_full_name":"myorg/myrepo",
+                        "github_ref":"refs/heads/main",
+                        "created_at":"2026-07-30T12:00:00Z"
+                    }]
+                }],
+                "has_more":false
+            }"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploys",
+            "watch",
+            "--app",
+            TEST_APP_NAME,
+            "--commit",
+            "bbbbbbbb",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""event":"commit_coalesced""#))
+        .stdout(predicate::str::contains(r#""status":"failed""#));
+}
+
+#[test]
+fn test_deploy_watch_coalesced_superseded_descendant_is_non_failure_terminal() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _deploys = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("include_build_logs".into(), "false".into()),
+            Matcher::UrlEncoded("limit".into(), "100".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+                "deploys":[{
+                    "id":"deploy-superseded",
+                    "status":"superseded",
+                    "commit_sha":"cccccccccccccccccccccccccccccccccccccccc",
+                    "coalesced_commits":[{
+                        "requested_commit_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "source_repo_full_name":"myorg/myrepo",
+                        "github_ref":"refs/heads/main",
+                        "created_at":"2026-07-30T12:00:00Z"
+                    }]
+                }],
+                "has_more":false
+            }"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "deploys",
+            "watch",
+            "--app",
+            TEST_APP_NAME,
+            "--commit",
+            "bbbbbbbb",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""event":"commit_coalesced""#))
+        .stdout(predicate::str::contains(r#""status":"superseded""#));
+}
+
 // ───────────────────────── Deploy ─────────────────────────
 
 #[test]


### PR DESCRIPTION
Companion CLI change for getfloo/floo#1772.

## Summary

- deserialize durable `coalesced_commits` from deploy reads
- make `deploys watch --commit` traverse cursor pages and prefer any exact deploy
- follow a recorded effective deploy when the requested push was coalesced
- emit a structured `commit_coalesced` event and preserve terminal exit semantics
- document exact and coalesced commit watch behavior in the offline deploy guide

## Test plan

- `scripts/test` (501 unit, 147 CLI, 161 mock API, 1 doc-link test)
- focused coalesced watch cases for abbreviated SHA, paginated exact precedence, LIVE, FAILED, and SUPERSEDED outcomes