### PR TITLE
fix: surface dormant rebuild recovery

### DIFF
--- a/docs/offline/deploy.md
+++ b/docs/offline/deploy.md
@@ -29,6 +29,19 @@ floo Deploy Flow
     floo env set API_KEY=new-value --app myapp --service api
     floo redeploy --app myapp
 
+  A no-rebuild redeploy replays only the immutable contract captured by the
+  current LIVE deploy. If that historical contract is unavailable or invalid,
+  floo fails closed and returns one exact recovery command:
+
+    floo redeploy --app myapp --rebuild
+
+  `--rebuild` resolves the connected primary repository's current default-
+  branch HEAD, downloads that exact commit from GitHub, reparses
+  `floo.app.toml`, and persists fresh immutable topology, environment,
+  resource, and cron contracts. It does not upload local files or require an
+  artificial source commit. JSON errors preserve `recovery_action`,
+  `recovery_command`, `recovery_app_id`, and `recovery_source`.
+
 ## First Deploy
 
   Use `floo apps github connect owner/repo`. This connects GitHub and
@@ -94,7 +107,7 @@ floo Deploy Flow
 ## Redeploy Options
 
   floo redeploy --app <name>       - redeploy with fresh env vars (no rebuild)
-  floo redeploy --app <name> --rebuild  - force a full rebuild from latest commit
+  floo redeploy --app <name> --rebuild  - rebuild exact current GitHub default-branch HEAD
   floo redeploy [path]             - resolve app/config from this directory; source stays on GitHub
   floo redeploy --service <name>  - redeploy specific services only
   floo redeploy --sync-env         - re-sync env vars from env_file before redeploying

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -168,12 +168,14 @@ Examples:
     #[command(after_help = "\
 Examples:
   floo redeploy --app my-app               Redeploy with fresh env vars (no rebuild)
-  floo redeploy --app my-app --rebuild     Force a full rebuild from latest commit
+  floo redeploy --app my-app --rebuild     Rebuild current GitHub default-branch HEAD
   floo redeploy                            Redeploy from current project directory
   floo redeploy --service api              Redeploy specific services only
 
 Note: The primary way to deploy is `git push`. Use `floo redeploy` when you
-need to apply env var changes or force a rebuild without a code change.")]
+need to apply env var changes or rebuild the unchanged GitHub commit. If a
+no-rebuild restart reports an unavailable immutable contract, run the exact
+`--rebuild` command it returns.")]
     Redeploy {
         /// Project directory (only needed when --app is not provided).
         #[arg(default_value = ".")]
@@ -192,7 +194,7 @@ need to apply env var changes or force a rebuild without a code change.")]
         )]
         services: Vec<String>,
 
-        /// Force a full rebuild from the latest commit (re-download source and run Cloud Build).
+        /// Rebuild the exact current GitHub default-branch commit (reparse immutable contracts and run Cloud Build).
         #[arg(long)]
         rebuild: bool,
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1146,7 +1146,17 @@ fn deploy_restart(
         }
         Err(e) => {
             spinner.finish();
-            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            let recovery_command = e
+                .extra
+                .as_ref()
+                .and_then(|extra| extra.get("recovery_command"))
+                .and_then(|command| command.as_str());
+            output::error_with_details(
+                &e.message,
+                &ErrorCode::from_api(&e.code),
+                recovery_command,
+                e.extra.as_ref(),
+            );
             process::exit(1);
         }
     };

--- a/src/output.rs
+++ b/src/output.rs
@@ -130,6 +130,33 @@ pub fn error(message: &str, code: &ErrorCode, suggestion: Option<&str>) {
     }
 }
 
+/// Render an API error while preserving its typed detail fields in JSON mode.
+///
+/// The API owns recovery metadata such as an exact command and authoritative
+/// source. Keeping those fields on the error object lets agents act without
+/// parsing prose; human mode uses the same command as the suggestion.
+pub fn error_with_details(
+    message: &str,
+    code: &ErrorCode,
+    suggestion: Option<&str>,
+    details: Option<&Value>,
+) {
+    if is_json_mode() {
+        let mut err = build_error_json(code, message, suggestion);
+        if let (Some(err_obj), Some(Value::Object(detail_obj))) = (err.as_object_mut(), details) {
+            for (key, value) in detail_obj {
+                err_obj.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
+        print_json(&serde_json::json!({"success": false, "error": err}));
+    } else {
+        eprintln!("{} {message}", "Error:".red());
+        if let Some(sug) = suggestion {
+            eprintln!("  \u{2192} {sug}");
+        }
+    }
+}
+
 pub fn error_with_data(
     message: &str,
     code: &ErrorCode,

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -4470,6 +4470,121 @@ fn test_deploy_existing_app_by_name_json() {
         .stdout(predicate::str::contains(r#""deploy""#));
 }
 
+#[test]
+fn test_redeploy_rebuild_requests_server_resolved_github_head() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let rebuild = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/deploys").as_str())
+        .match_body(Matcher::Json(serde_json::json!({"runtime": "nodejs"})))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"deploy-rebuilt","status":"live","commit_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","url":"https://my-app.floo.app"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "redeploy", "--app", TEST_APP_NAME, "--rebuild"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""id":"deploy-rebuilt""#))
+        .stdout(predicate::str::contains(
+            r#""commit_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""#,
+        ));
+
+    rebuild.assert();
+}
+
+#[test]
+fn test_redeploy_restart_json_preserves_typed_contract_recovery() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let command = format!("floo redeploy --app {TEST_APP_NAME} --rebuild");
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "detail": {
+                    "code": "DEPLOY_CRON_CONTRACT_UNAVAILABLE",
+                    "message": format!(
+                        "Source deploy predates immutable cron snapshots. Run `{command}`."
+                    ),
+                    "recovery_action": "rebuild_current_github_head",
+                    "recovery_command": command,
+                    "recovery_app_id": TEST_APP_ID,
+                    "recovery_source": "github_default_branch_head",
+                    "blocked_source_deploy_id": "deploy-legacy",
+                    "blocked_source_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            })
+            .to_string(),
+        )
+        .create();
+
+    floo()
+        .args(["--json", "redeploy", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"DEPLOY_CRON_CONTRACT_UNAVAILABLE""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""recovery_action":"rebuild_current_github_head""#,
+        ))
+        .stdout(predicate::str::contains(format!(
+            r#""recovery_command":"{command}""#
+        )))
+        .stdout(predicate::str::contains(format!(
+            r#""suggestion":"{command}""#
+        )))
+        .stdout(predicate::str::contains(
+            r#""recovery_source":"github_default_branch_head""#,
+        ));
+}
+
+#[test]
+fn test_redeploy_restart_human_prints_invalid_contract_rebuild_command() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let command = format!("floo redeploy --app {TEST_APP_NAME} --rebuild");
+    let _restart = server
+        .mock("POST", format!("/v1/apps/{TEST_APP_ID}/restart").as_str())
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "detail": {
+                    "code": "DEPLOY_CRON_CONTRACT_INVALID",
+                    "message": "The source deploy has an invalid immutable cron snapshot.",
+                    "recovery_action": "rebuild_current_github_head",
+                    "recovery_command": command,
+                    "recovery_app_id": TEST_APP_ID,
+                    "recovery_source": "github_default_branch_head"
+                }
+            })
+            .to_string(),
+        )
+        .create();
+
+    floo()
+        .args(["redeploy", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "The source deploy has an invalid immutable cron snapshot.",
+        ))
+        .stderr(predicate::str::contains(command));
+}
+
 // ───────── Deploy not-found keyed on HTTP 404 status (#152 follow-up) ─────────
 //
 // #157 hardened resolve_app_or_exit / logs / releases / github / the deploy()


### PR DESCRIPTION
Companion to getfloo/floo#1967 and getfloo/floo#1954.

## Summary

- keep `redeploy --rebuild` server-resolved: the CLI sends no local source or artificial commit
- preserve typed immutable-contract recovery fields in JSON output
- print the API-provided exact `floo redeploy --app <name> --rebuild` command in human output
- clarify help and embedded offline docs that rebuild targets the current GitHub default-branch HEAD

## Evidence

- canonical `scripts/test`: 501 unit, 147 CLI integration, 160 mock-API, and 1 documentation-link test
- focused mock-API coverage for rebuild request shape and unavailable/invalid contract recovery