### PR TITLE
fix: surface custom domain claimant proof

### DIFF
--- a/docs/offline/golden-path.md
+++ b/docs/offline/golden-path.md
@@ -68,14 +68,15 @@ floo - Golden Path
 
      floo domains add app.example.com --app my-app
 
-  2. The output shows a CNAME record to add at your DNS provider:
+  2. The output shows the traffic and claimant-control records to add:
 
      CNAME app.example.com -> my-app.on.getfloo.com
+     TXT _floo-verify.app.example.com -> <claim token from the command>
 
-  3. Add that CNAME record in your DNS provider (Cloudflare, Route 53, etc).
+  3. Add both records in your DNS provider (Cloudflare, Route 53, etc).
 
-  4. Verify the domain in the dashboard (click "Verify DNS") or wait for
-     the auto-poll to pick it up. Once verified, status changes to active
+  4. Run `floo domains verify app.example.com --app my-app` or click
+     "Verify DNS" in the dashboard. Once verified, status changes to active
      and you get a confirmation email.
 
   For multi-service apps, target a specific service:
@@ -111,7 +112,7 @@ floo - Golden Path
   See deploy history                    | floo deploys list --app my-app
   Roll back to a previous version       | floo deploys rollback my-app <id>
   Set an env var                        | floo env set KEY=val --app my-app
-  Add a custom domain                   | floo domains add example.com --app my-app (then add CNAME at DNS provider)
+  Add a custom domain                   | floo domains add example.com --app my-app (then add the shown DNS records)
   Verify a custom domain                | floo domains verify example.com --app my-app
   View logs                             | floo logs query --app my-app
   Run locally with prod credentials     | floo dev --app my-app (requires dev_command)

--- a/docs/offline/rails.md
+++ b/docs/offline/rails.md
@@ -125,7 +125,8 @@ identity headers in front of the local server, no conditional code.
 
   floo domains add app.example.com --app my-rails-app
 
-Add the CNAME shown in the output at your DNS provider.
+Add the traffic and `_floo-verify` TXT records shown in the output, then run
+`floo domains verify app.example.com --app my-rails-app`.
 
 ## Common gotchas
 

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -666,6 +666,8 @@ pub struct Domain {
     pub service_name: Option<String>,
     pub ssl_status: Option<String>,
     pub verified: Option<bool>,
+    #[serde(default)]
+    pub claim_verified_at: Option<String>,
     pub created_at: Option<String>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1198,7 +1198,7 @@ pub enum DomainsCommands {
         app: Option<String>,
     },
 
-    /// Verify DNS for a pending custom domain.
+    /// Confirm DNS control for a pending or grandfathered custom domain.
     Verify {
         /// Domain hostname to verify.
         hostname: String,

--- a/src/commands/domains.rs
+++ b/src/commands/domains.rs
@@ -6,6 +6,18 @@ use crate::api_client::FlooClient;
 use crate::errors::ErrorCode;
 use crate::output;
 
+fn claimant_proof_status(domain: &crate::api_types::Domain) -> &'static str {
+    if domain.claim_verified_at.is_some() {
+        "confirmed"
+    } else if domain.status.as_deref() == Some("active")
+        || domain.status.as_deref() == Some("ACTIVE")
+    {
+        "reproof required"
+    } else {
+        "pending"
+    }
+}
+
 fn check_services_flag(client: &FlooClient, app_id: &str, services: Option<&str>) {
     let result = match client.list_services(app_id, None) {
         Ok(r) => r,
@@ -123,6 +135,7 @@ pub fn list(app: Option<&str>) {
             vec![
                 d.hostname.clone(),
                 d.status.as_deref().unwrap_or("-").to_string(),
+                claimant_proof_status(d).to_string(),
                 d.dns_instructions
                     .as_deref()
                     .unwrap_or("\u{2014}")
@@ -132,7 +145,7 @@ pub fn list(app: Option<&str>) {
         .collect();
 
     output::table(
-        &["Domain", "Status", "DNS"],
+        &["Domain", "Status", "DNS control", "DNS"],
         &rows,
         Some(output::to_value(&result)),
     );
@@ -274,6 +287,10 @@ pub fn status(hostname: &str, app: Option<&str>) {
     output::info(&format!("Status:   {status}"), None);
     output::info(&format!("SSL:      {ssl}"), None);
     output::info(&format!("Verified: {verified}"), None);
+    output::info(
+        &format!("Control:  {}", claimant_proof_status(domain)),
+        None,
+    );
     output::info(&format!("Service:  {service}"), None);
     if let Some(dns) = domain.dns_instructions.as_deref() {
         output::info(&format!("DNS:      {dns}"), None);
@@ -329,7 +346,9 @@ pub fn watch(hostname: &str, app: Option<&str>, timeout_secs: u64) {
                 output::error(
                     &format!("Domain {hostname} verification failed."),
                     &ErrorCode::DomainVerificationFailed,
-                    Some("Check your DNS CNAME record and try again with 'floo domains verify'."),
+                    Some(
+                        "Check the traffic and _floo-verify TXT records, then try 'floo domains verify' again.",
+                    ),
                 );
                 process::exit(1);
             }

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -2207,6 +2207,33 @@ fn test_domains_list_json() {
 }
 
 #[test]
+fn test_domains_list_marks_legacy_active_domain_for_reproof() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/domains").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"domains":[{"hostname":"legacy.example.com","status":"active","claim_verified_at":null,"dns_instructions":"Add a TXT record: _floo-verify.legacy.example.com with value claim-token"}]}"#,
+        )
+        .create();
+
+    floo()
+        .args(["domains", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("reproof required"))
+        .stderr(predicate::str::contains("_floo-verify.legacy.example.com"));
+}
+
+#[test]
 fn test_domains_remove_refuses_without_yes_flag_in_json_mode() {
     let mut server = Server::new();
     let home = setup_config(&server);
@@ -2325,6 +2352,32 @@ fn test_domains_show_json() {
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains("app.example.com"));
+}
+
+#[test]
+fn test_domains_show_reports_confirmed_claimant_control() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let _m_list = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/domains").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"domains":[{"hostname":"app.example.com","status":"active","verified":true,"claim_verified_at":"2026-07-30T12:00:00Z"}]}"#,
+        )
+        .create();
+
+    floo()
+        .args(["domains", "show", "app.example.com", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Control:  confirmed"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- deserialize the new `claim_verified_at` domain proof marker without breaking older API responses
- show confirmed, pending, or reproof-required claimant-control state in human domain output
- update offline domain setup guidance to require the traffic and `_floo-verify` TXT records

## Test plan
- `FLOO_TEST_CARGO=/Users/patrickdonohoe/.cargo/bin/cargo ./scripts/test`

Closes getfloo/floo#1698