### PR TITLE
feat: align CLI with Paygo and Team catalog

### DIFF
--- a/docs/offline/auth.md
+++ b/docs/offline/auth.md
@@ -89,8 +89,8 @@ the old role; removing a member revokes their app sessions and keys.
 ## Access Modes
 
   public    - no auth, anyone can access (default)
-  password  - shared password for simple protection (Pro+)
-  accounts  - per-user auth, gateway-managed (Pro+)
+  password  - shared password for simple protection (Pay as you go+)
+  accounts  - per-user auth, gateway-managed (Pay as you go+)
 
 Enterprise SSO (SAML/OIDC) is a sales-assisted setup, not a self-serve
 access_mode value - email sales@getfloo.com if your team needs it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -567,8 +567,8 @@ pub enum BillingCommands {
 
     /// Upgrade your plan via Stripe Checkout or Billing Portal.
     Upgrade {
-        /// Plan to upgrade to: hobby, pro, or team. Omit to open billing portal.
-        #[arg(long, value_parser = ["hobby", "pro", "team"])]
+        /// Plan to upgrade to: paygo or team. Omit to open billing portal.
+        #[arg(long, value_parser = ["paygo", "team"])]
         plan: Option<String>,
     },
 
@@ -3083,6 +3083,23 @@ mod tests {
 
         let err = parse_err(&["floo", "orgs", "invite", "a@x.com", "--role", "owner"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn billing_upgrade_accepts_only_canonical_self_serve_plans() {
+        for plan in ["paygo", "team"] {
+            let cli = Cli::try_parse_from(["floo", "billing", "upgrade", "--plan", plan])
+                .unwrap_or_else(|e| panic!("clap rejected canonical plan {plan}: {e}"));
+            let Commands::Billing(BillingCommands::Upgrade { plan: parsed }) = cli.command else {
+                panic!("expected Billing::Upgrade");
+            };
+            assert_eq!(parsed.as_deref(), Some(plan));
+        }
+
+        for legacy in ["hobby", "pro"] {
+            let err = parse_err(&["floo", "billing", "upgrade", "--plan", legacy]);
+            assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+        }
     }
 
     // --- `--json` arg-error contract (#1156) ---

--- a/src/commands/billing.rs
+++ b/src/commands/billing.rs
@@ -3,6 +3,22 @@ use std::process;
 use crate::errors::ErrorCode;
 use crate::output;
 
+fn canonical_plan(plan: &str) -> &str {
+    match plan {
+        "hobby" | "pro" => "paygo",
+        current => current,
+    }
+}
+
+fn plan_display(plan: &str) -> (&'static str, &'static str) {
+    match canonical_plan(plan) {
+        "paygo" => ("Pay as you go", "$0 commitment"),
+        "team" => ("Team", "$250/mo"),
+        "enterprise" => ("Enterprise", "Custom"),
+        _ => ("Free", "$0"),
+    }
+}
+
 pub fn upgrade(plan: Option<String>) {
     super::require_auth();
     let client = super::init_client(None);
@@ -107,7 +123,7 @@ pub fn spend_cap_get() {
         output::warn("Spend cap exceeded \u{2014} deploys are blocked.");
     }
     if org.plan.as_deref() == Some("free") {
-        eprintln!("  Upgrade: floo billing upgrade --plan pro");
+        eprintln!("  Upgrade: floo billing upgrade --plan paygo");
     }
 }
 
@@ -186,16 +202,10 @@ pub fn usage(period: &str) {
     let period_spend_cents = (breakdown.total_cost_usd * 100.0).round() as u64;
     let exceeded = matches!(spend_cap, Some(cap) if cap > 0 && period_spend_cents >= cap);
 
-    let plan_price = match plan {
-        "hobby" => "$5/mo",
-        "pro" => "$20/mo",
-        "team" => "$200/mo",
-        "enterprise" => "Custom",
-        _ => "$0",
-    };
+    let (plan_label, plan_price) = plan_display(plan);
 
     let data = serde_json::json!({
-        "plan": plan,
+        "plan": canonical_plan(plan),
         "spend_cap_cents": spend_cap,
         "max_spend_cap_cents": max_cap,
         "period_spend_cents": period_spend_cents,
@@ -215,10 +225,9 @@ pub fn usage(period: &str) {
         return;
     }
 
-    let plan_label = plan[..1].to_uppercase() + &plan[1..];
     eprintln!("  Plan: {} ({})", plan_label, plan_price);
     eprintln!(
-        "  Compute credit: ${:.2}/month",
+        "  floo credits included: {:.2}/month",
         breakdown.included_cost_usd
     );
     eprintln!(
@@ -266,5 +275,21 @@ pub fn usage(period: &str) {
         } else {
             output::warn("Spend cap exceeded \u{2014} deploys are blocked.");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_plan, plan_display};
+
+    #[test]
+    fn plan_display_projects_legacy_offers_into_the_canonical_catalog() {
+        for plan in ["hobby", "pro", "paygo"] {
+            assert_eq!(canonical_plan(plan), "paygo");
+            assert_eq!(plan_display(plan), ("Pay as you go", "$0 commitment"));
+        }
+        assert_eq!(plan_display("team"), ("Team", "$250/mo"));
+        assert_eq!(plan_display("enterprise"), ("Enterprise", "Custom"));
+        assert_eq!(plan_display("free"), ("Free", "$0"));
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -30,7 +30,7 @@ const APP_TOML_HEADER: &str = r#"# floo.app.toml — see https://getfloo.com/doc
 # https://getfloo.com/docs/guides/golden-path.md.
 #
 # Common knobs to add when you need them (under [app], applies to every env):
-#   access_mode = "accounts"   # require sign-in (Pro+) — public, password,
+#   access_mode = "accounts"   # require sign-in (Pay as you go+) — public, password,
 #                              #   accounts, or sso. The [app] level is the
 #                              #   one that actually applies on push deploys
 #                              #   today; per-env overrides via

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -315,7 +315,7 @@ fn test_billing_usage_period_scopes_derived_fields() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(format!(
-            r#"{{"id":"{TEST_ORG_ID}","name":"Test Org","slug":"test-org","plan":"pro","spend_cap":10000,"current_period_spend_cents":9000,"spend_cap_exceeded":false}}"#
+            r#"{{"id":"{TEST_ORG_ID}","name":"Test Org","slug":"test-org","plan":"paygo","spend_cap":10000,"current_period_spend_cents":9000,"spend_cap_exceeded":false}}"#
         ))
         .create();
 
@@ -323,7 +323,7 @@ fn test_billing_usage_period_scopes_derived_fields() {
         .mock("GET", "/v1/billing/limits")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"plan":"pro","max_spend_cap_cents":20000}"#)
+        .with_body(r#"{"plan":"paygo","max_spend_cap_cents":20000}"#)
         .create();
 
     let _breakdown = server
@@ -332,7 +332,7 @@ fn test_billing_usage_period_scopes_derived_fields() {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
-            r#"{"period":{"start":"2026-05-01T00:00:00Z","end":"2026-06-01T00:00:00Z","label":"Last month"},"total_cost_usd":120.0,"included_cost_usd":5.0,"apps":[]}"#,
+            r#"{"period":{"start":"2026-05-01T00:00:00Z","end":"2026-06-01T00:00:00Z","label":"Last month"},"total_cost_usd":120.0,"included_cost_usd":0.0,"apps":[]}"#,
         )
         .create();
 


### PR DESCRIPTION
Closes getfloo/floo#1924

Companion to getfloo/floo#2122.

- accepts only paygo and team as writable upgrade targets
- projects readable legacy Hobby and Pro values to Pay as you go
- displays Team at $250/month and uses floo-credit wording
- updates bundled offline guidance and mock API evidence

Validation: PATH=/Users/patrickdonohoe/.cargo/bin:$PATH ./scripts/test (all Rust, CLI, mock API, and doc-link tests passed)