### PR TITLE
feat: expose runtime scaling plans

### DIFF
--- a/docs/offline/config.md
+++ b/docs/offline/config.md
@@ -125,7 +125,13 @@ floo Config Files
   [resources]
   cpu = "1"             # CPU cores (0.25 to 8)
   memory = "512Mi"      # Memory (128Mi to 32Gi)
-  max_instances = 10    # Max autoscale instances
+  min_instances = 0     # HTTP baseline; 0 = on-demand, 1+ = warm
+  max_instances = 3     # Max HTTP autoscale instances (platform default: 3)
+
+  Global min_instances applies only to web/api services. Workers use the
+  per-service `instances` field and never inherit this HTTP autoscaling floor.
+  See `floo docs scaling` for exact on-demand, warm, running-worker, and
+  paused-worker recipes.
 
 ## Environment Overrides (in floo.app.toml)
 

--- a/docs/offline/scaling.md
+++ b/docs/offline/scaling.md
@@ -1,0 +1,60 @@
+floo Scaling and Availability
+
+Use `floo.app.toml` for every runtime scaling choice. There is no separate
+dashboard or CLI write path and CPU allocation is not customer-configurable.
+
+## Deterministic selection rules
+
+Choose on-demand for an HTTP service when the first request after an idle
+period may cold-start and the lowest idle cost matters most:
+
+  [services.web]
+  type = "web"
+  path = "."
+  port = 3000
+  min_instances = 0
+  max_instances = 3
+
+Choose warm only when a user-facing latency requirement justifies a continuous
+idle cost floor:
+
+  [services.web]
+  type = "web"
+  path = "."
+  port = 3000
+  min_instances = 1
+  max_instances = 3
+
+A warm HTTP service keeps one baseline instance ready and can still autoscale
+up to `max_instances`. The baseline avoids its cold start; new burst capacity
+may still cold-start. Warm does not mean CPU always on: web and api services use
+request-based CPU, including when attached to floo-managed Postgres.
+
+Use a worker for work that must run without an HTTP request. Workers have a
+fixed count and always-allocated CPU:
+
+  [services.worker]
+  type = "worker"
+  path = "."
+  port = 3000
+  command = "bundle exec sidekiq"
+  instances = 1
+
+Pause a worker explicitly with `instances = 0`. Workers never use
+`min_instances`; global `[resources] min_instances` applies only to web/api.
+
+## Defaults, limits, and verification
+
+- HTTP `min_instances` defaults to 0 in dev and in the locally resolved plan.
+- HTTP `max_instances` defaults to 3.
+- Worker `instances` defaults to 1.
+- Per-service values override delegated `floo.service.toml` values, which
+  override global `[resources]` values.
+- The server applies plan and platform ceilings. Local preflight marks those
+  values as requiring server resolution instead of pretending a clamp is known.
+
+Run `floo preflight --json` before pushing. Read `data.runtime_plan` for the
+configured values, locally resolved defaults, field sources, availability
+posture, and CPU mode. After deployment, use
+`floo services show <name> --app <app> --json` to verify the server-effective
+runtime plan.

--- a/docs/offline/services.md
+++ b/docs/offline/services.md
@@ -18,6 +18,9 @@ with confirmation for the exact app, environment, type, and name.
   api     - HTTP server for backend APIs
   worker  - background process (no incoming HTTP traffic)
 
+  Availability and cost/latency choices are declared with `min_instances` for
+  web/api and `instances` for workers. See: floo docs scaling
+
   Declare inline in floo.app.toml with type, port, and path. A deploy applies
   the declared service shape. It does not infer destructive intent for a
   production service merely because a declaration disappeared.

--- a/plugin/skills/floo-services/SKILL.md
+++ b/plugin/skills/floo-services/SKILL.md
@@ -8,9 +8,10 @@ description: floo service, database, cache, storage, cron, and service-routing s
 Use the installed CLI as the version-matched authority:
 
 1. Read `floo docs services --json`.
-2. Read `floo docs config --json` for the current declaration schema.
-3. Inspect exact command syntax with `floo services --help` and the selected subcommand's help.
-4. Run `floo preflight --json` before pushing config or completing an operational change.
+2. Read `floo docs scaling --json` before choosing HTTP availability or worker count.
+3. Read `floo docs config --json` for the current declaration schema.
+4. Inspect exact command syntax with `floo services --help` and the selected subcommand's help.
+5. Run `floo preflight --json` before pushing config or completing an operational change.
 
 Do not copy service syntax from memory or search the web until these offline surfaces are exhausted.
 

--- a/plugin/skills/floo/SKILL.md
+++ b/plugin/skills/floo/SKILL.md
@@ -65,6 +65,7 @@ Never place credentials in source, committed `.env` files, floo TOML, logs, erro
 - Decision flow: `floo docs golden-path`
 - Config and secret behavior: `floo docs config`
 - Services and data: `floo docs services`
+- Availability, scaling, and CPU behavior: `floo docs scaling`
 - Managed-service health and accounts drift: `floo docs doctor`
 - Git-driven deployment: `floo docs deploy`
 - Routes and access controls: `floo docs edge`

--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -65,6 +65,7 @@ Never place credentials in source, committed `.env` files, floo TOML, logs, erro
 - Decision flow: `floo docs golden-path`
 - Config and secret behavior: `floo docs config`
 - Services and data: `floo docs services`
+- Availability, scaling, and CPU behavior: `floo docs scaling`
 - Managed-service health and accounts drift: `floo docs doctor`
 - Git-driven deployment: `floo docs deploy`
 - Routes and access controls: `floo docs edge`

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -337,6 +337,38 @@ pub struct SetEnvVarResponse {
 // --- Service ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiRuntimeValues {
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    pub min_instances: Option<u64>,
+    pub max_instances: Option<u64>,
+    pub instances: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiRuntimeSources {
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    pub min_instances: Option<String>,
+    pub max_instances: Option<String>,
+    pub instances: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiRuntimePlan {
+    pub environment: Option<String>,
+    pub service_type: String,
+    pub availability: String,
+    pub declared: ApiRuntimeValues,
+    pub effective: ApiRuntimeValues,
+    pub sources: ApiRuntimeSources,
+    pub cpu_allocation: String,
+    pub cpu_allocation_reason: String,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiService {
     pub id: String,
     pub name: String,
@@ -355,7 +387,11 @@ pub struct ApiService {
     #[serde(default)]
     pub min_instances: Option<u64>,
     #[serde(default)]
+    pub instances: Option<u64>,
+    #[serde(default)]
     pub max_request_body_mb: Option<u64>,
+    #[serde(default)]
+    pub runtime_plan: Option<ApiRuntimePlan>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1064,6 +1064,10 @@ pub enum ServicesCommands {
             conflicts_with = "service_name"
         )]
         service: Option<String>,
+
+        /// Environment to inspect: dev or prod.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod"])]
+        env: String,
     },
 
     /// Provision a managed service (postgres, redis, or storage).
@@ -2346,6 +2350,7 @@ pub fn run() {
                 service_name,
                 app,
                 service,
+                env,
             } => {
                 let resolved = service_name.or(service).unwrap_or_else(|| {
                     output::error(
@@ -2355,7 +2360,7 @@ pub fn run() {
                     );
                     std::process::exit(1);
                 });
-                commands::services::info(&resolved, app.as_deref())
+                commands::services::info(&resolved, app.as_deref(), &env)
             }
             ServicesCommands::Add {
                 service_type,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -43,6 +43,127 @@ struct ManagedEnvInjection {
     keys: Vec<String>,
 }
 
+const LOCAL_DEFAULT_MAX_INSTANCES: u32 = 3;
+
+/// Stable, agent-readable scaling plan derived from local configuration.
+///
+/// Values under `configured` preserve the merged declaration (including a global
+/// resource value). `locally_resolved` fills platform defaults needed to describe
+/// intent. The server remains authoritative for plan clamps, which is why every
+/// entry carries `server_resolution_required=true`; post-deploy `services show`
+/// reports the effective result.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct RuntimePlan {
+    service: String,
+    service_type: String,
+    availability: String,
+    configured: RuntimePlanValues,
+    locally_resolved: RuntimePlanValues,
+    sources: RuntimePlanSources,
+    cpu_allocation: String,
+    cpu_allocation_reason: String,
+    server_resolution_required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct RuntimePlanValues {
+    min_instances: Option<u32>,
+    max_instances: Option<u32>,
+    instances: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct RuntimePlanSources {
+    min_instances: Option<String>,
+    max_instances: Option<String>,
+    instances: Option<String>,
+}
+
+fn build_runtime_plan(services: &[ServiceConfig]) -> Vec<RuntimePlan> {
+    services
+        .iter()
+        .map(|service| {
+            let is_worker = service.service_type == ServiceType::Worker;
+            let configured = RuntimePlanValues {
+                min_instances: service.min_instances,
+                max_instances: service.max_instances,
+                instances: service.instances,
+            };
+
+            if is_worker {
+                let instances = service.instances.unwrap_or(1);
+                RuntimePlan {
+                    service: service.name.clone(),
+                    service_type: service.service_type.to_string(),
+                    availability: if instances == 0 { "paused" } else { "fixed" }.to_string(),
+                    configured,
+                    locally_resolved: RuntimePlanValues {
+                        min_instances: None,
+                        max_instances: None,
+                        instances: Some(instances),
+                    },
+                    sources: RuntimePlanSources {
+                        min_instances: None,
+                        max_instances: None,
+                        instances: Some(
+                            if service.instances.is_some() {
+                                "configured"
+                            } else {
+                                "platform_default"
+                            }
+                            .to_string(),
+                        ),
+                    },
+                    cpu_allocation: "always_allocated".to_string(),
+                    cpu_allocation_reason: "worker_background_process".to_string(),
+                    server_resolution_required: true,
+                }
+            } else {
+                let min_instances = service.min_instances.unwrap_or(0);
+                let max_instances = service.max_instances.unwrap_or(LOCAL_DEFAULT_MAX_INSTANCES);
+                RuntimePlan {
+                    service: service.name.clone(),
+                    service_type: service.service_type.to_string(),
+                    availability: if min_instances == 0 {
+                        "on_demand"
+                    } else {
+                        "warm"
+                    }
+                    .to_string(),
+                    configured,
+                    locally_resolved: RuntimePlanValues {
+                        min_instances: Some(min_instances),
+                        max_instances: Some(max_instances),
+                        instances: None,
+                    },
+                    sources: RuntimePlanSources {
+                        min_instances: Some(
+                            if service.min_instances.is_some() {
+                                "configured"
+                            } else {
+                                "platform_default"
+                            }
+                            .to_string(),
+                        ),
+                        max_instances: Some(
+                            if service.max_instances.is_some() {
+                                "configured"
+                            } else {
+                                "platform_default"
+                            }
+                            .to_string(),
+                        ),
+                        instances: None,
+                    },
+                    cpu_allocation: "request_based".to_string(),
+                    cpu_allocation_reason: "http_request_scoped".to_string(),
+                    server_resolution_required: true,
+                }
+            }
+        })
+        .collect()
+}
+
 /// Severity of a preflight finding.
 ///
 /// - `Error` blocks the deploy (preflight exits 1). Reserved for configs that
@@ -424,6 +545,7 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
         &env_injection_plan,
     );
     let security_findings = generate_security_findings(&services, &resolved, &env_injection_plan);
+    let runtime_plan = build_runtime_plan(&services);
 
     let valid = !has_errors(&validation_findings);
     let contains_secrets = security_findings
@@ -472,6 +594,7 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
         let data = serde_json::json!({
             "app": app_name,
             "services": svc_json,
+            "runtime_plan": runtime_plan,
             "managed_services": managed_json,
             "env_injection_plan": env_injection_plan,
             "cron": cron_json,
@@ -520,6 +643,7 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
         &resolved,
         &services,
         &per_service_detection,
+        &runtime_plan,
         &env_injection_plan,
         &validation_findings,
     );
@@ -749,6 +873,7 @@ pub fn deploy(
         &env_injection_plan,
     );
     let valid = !has_errors(&validation_findings);
+    let runtime_plan = build_runtime_plan(&services);
 
     // 6. Display preflight info
     if !output::is_json_mode() {
@@ -757,6 +882,7 @@ pub fn deploy(
             &resolved,
             &services,
             &per_service_detection,
+            &runtime_plan,
             &env_injection_plan,
             &validation_findings,
         );
@@ -819,6 +945,7 @@ pub fn deploy(
                 "app": app_name,
                 "services": svc_json,
                 "managed_services": managed_json,
+                "runtime_plan": runtime_plan,
                 "env_injection_plan": env_injection_plan,
                 "cron": cron_json(&resolved),
                 "findings": validation_findings,
@@ -2372,6 +2499,7 @@ fn display_preflight_human(
     resolved: &project_config::ResolvedApp,
     services: &[ServiceConfig],
     per_service_detection: &[(String, DetectionResult)],
+    runtime_plan: &[RuntimePlan],
     env_injection_plan: &EnvInjectionPlan,
     findings: &[PreflightFinding],
 ) {
@@ -2406,7 +2534,11 @@ fn display_preflight_human(
     }
     eprintln!();
 
-    for (svc, (_, det)) in services.iter().zip(per_service_detection.iter()) {
+    for ((svc, (_, det)), runtime) in services
+        .iter()
+        .zip(per_service_detection.iter())
+        .zip(runtime_plan.iter())
+    {
         let path_label = if svc.path == "." {
             String::new()
         } else {
@@ -2427,6 +2559,26 @@ fn display_preflight_human(
             "    runtime: {}{framework_label} \u{2014} {} confidence",
             det.runtime, det.confidence
         );
+        if runtime.availability == "paused" {
+            eprintln!("    availability: paused, 0 running instances");
+        } else if runtime.availability == "fixed" {
+            eprintln!(
+                "    availability: {}, fixed {}, always-allocated CPU",
+                runtime.availability,
+                runtime.locally_resolved.instances.unwrap_or(0),
+            );
+        } else {
+            eprintln!(
+                "    availability: {}, scales {}\u{2013}{}, request-based CPU",
+                runtime.availability.replace('_', "-"),
+                runtime.locally_resolved.min_instances.unwrap_or(0),
+                runtime
+                    .locally_resolved
+                    .max_instances
+                    .unwrap_or(LOCAL_DEFAULT_MAX_INSTANCES),
+            );
+        }
+        eprintln!("    note: plan limits are resolved by the server; verify with `floo services show --json`");
         eprintln!();
     }
 
@@ -2435,7 +2587,10 @@ fn display_preflight_human(
     // Show global [resources] if present
     if let Some(ref app_cfg) = resolved.app_config {
         if let Some(ref res) = app_cfg.resources {
-            let has_any = res.cpu.is_some() || res.memory.is_some() || res.max_instances.is_some();
+            let has_any = res.cpu.is_some()
+                || res.memory.is_some()
+                || res.max_instances.is_some()
+                || res.min_instances.is_some();
             if has_any {
                 eprintln!("  [resources] (global defaults)");
                 let mut parts = Vec::new();
@@ -2447,6 +2602,9 @@ fn display_preflight_human(
                 }
                 if let Some(max) = res.max_instances {
                     parts.push(format!("max_instances: {max}"));
+                }
+                if let Some(min) = res.min_instances {
+                    parts.push(format!("min_instances: {min} (HTTP services only)"));
                 }
                 eprintln!("    {}", parts.join(", "));
                 eprintln!();
@@ -3036,6 +3194,63 @@ mod tests {
             r#"{{"id":"dep-1","status":"{status}","created_at":"2024-01-01T00:00:00Z"}}"#
         ))
         .unwrap()
+    }
+
+    fn runtime_service(
+        name: &str,
+        service_type: ServiceType,
+        min_instances: Option<u32>,
+        max_instances: Option<u32>,
+        instances: Option<u32>,
+    ) -> ServiceConfig {
+        ServiceConfig {
+            name: name.to_string(),
+            service_type,
+            path: ".".to_string(),
+            port: 8080,
+            ingress: ServiceIngress::Public,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances,
+            min_instances,
+            instances,
+            migrate_command: None,
+        }
+    }
+
+    #[test]
+    fn runtime_plan_names_all_four_scaling_postures() {
+        let services = vec![
+            runtime_service("on-demand", ServiceType::Web, None, None, None),
+            runtime_service("warm", ServiceType::Api, Some(1), Some(5), None),
+            runtime_service("worker", ServiceType::Worker, None, None, None),
+            runtime_service("paused", ServiceType::Worker, None, None, Some(0)),
+        ];
+
+        let plan = build_runtime_plan(&services);
+
+        assert_eq!(plan[0].availability, "on_demand");
+        assert_eq!(plan[0].locally_resolved.min_instances, Some(0));
+        assert_eq!(plan[0].locally_resolved.max_instances, Some(3));
+        assert_eq!(
+            plan[0].sources.min_instances.as_deref(),
+            Some("platform_default")
+        );
+        assert_eq!(plan[0].cpu_allocation, "request_based");
+
+        assert_eq!(plan[1].availability, "warm");
+        assert_eq!(plan[1].configured.min_instances, Some(1));
+        assert_eq!(plan[1].locally_resolved.max_instances, Some(5));
+        assert_eq!(plan[1].sources.max_instances.as_deref(), Some("configured"));
+
+        assert_eq!(plan[2].availability, "fixed");
+        assert_eq!(plan[2].locally_resolved.instances, Some(1));
+        assert_eq!(plan[2].cpu_allocation, "always_allocated");
+
+        assert_eq!(plan[3].availability, "paused");
+        assert_eq!(plan[3].configured.instances, Some(0));
+        assert_eq!(plan[3].locally_resolved.instances, Some(0));
     }
 
     // floo-cli#208: the SSE stream closes when the executor job exits, which

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -20,6 +20,8 @@ const PREVIEWS: &str = include_str!("../../docs/offline/previews.md");
 
 const CONFIG: &str = include_str!("../../docs/offline/config.md");
 
+const SCALING: &str = include_str!("../../docs/offline/scaling.md");
+
 const DEPLOY: &str = include_str!("../../docs/offline/deploy.md");
 
 const AUTH: &str = include_str!("../../docs/offline/auth.md");
@@ -150,6 +152,12 @@ pub(crate) const TOPICS: &[Topic] = &[
         summary: "Configuration file formats and examples",
         aliases: CONFIG_ALIASES,
         content: CONFIG,
+    },
+    Topic {
+        name: "scaling",
+        summary: "Availability, scaling, and CPU behavior",
+        aliases: NO_ALIASES,
+        content: SCALING,
     },
     Topic {
         name: "cron",
@@ -291,6 +299,7 @@ mod tests {
         assert!(!DOCTOR.is_empty());
         assert!(!PREVIEWS.is_empty());
         assert!(!CONFIG.is_empty());
+        assert!(!SCALING.is_empty());
         assert!(!CRON.is_empty());
         assert!(!DEPLOY.is_empty());
         assert!(!AUTH.is_empty());
@@ -370,6 +379,26 @@ mod tests {
     #[test]
     fn test_services_no_coming_soon() {
         assert!(!SERVICES.contains("coming soon"));
+    }
+
+    #[test]
+    fn test_scaling_topic_has_all_runtime_postures() {
+        assert!(render_overview().contains("floo docs scaling"));
+        for phrase in [
+            "min_instances = 0",
+            "min_instances = 1",
+            "instances = 1",
+            "instances = 0",
+            "request-based CPU",
+            "always-allocated CPU",
+            "floo preflight --json",
+            "floo services show",
+        ] {
+            assert!(
+                SCALING.contains(phrase),
+                "scaling topic is missing {phrase}"
+            );
+        }
     }
 
     #[test]

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -105,7 +105,7 @@ pub fn list(app: Option<&str>, env: &str) {
     output::table(&["Name", "Type", "Status", "Ingress", "URL"], &rows, None);
 }
 
-pub fn info(service_name: &str, app: Option<&str>) {
+pub fn info(service_name: &str, app: Option<&str>, env: &str) {
     super::require_auth();
     let client = super::init_client(None);
 
@@ -113,7 +113,7 @@ pub fn info(service_name: &str, app: Option<&str>) {
     let app_id = app_id.as_str();
     let app_name = app_name.as_str();
 
-    let app_services = match client.list_services(app_id, None) {
+    let app_services = match client.list_services(app_id, Some(env)) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
@@ -210,6 +210,10 @@ fn render_app_service(svc: &crate::api_types::ApiService, service_name: &str, ap
         .max_instances
         .map(|count| count.to_string())
         .unwrap_or_else(|| "-".to_string());
+    let instances = svc
+        .instances
+        .map(|count| count.to_string())
+        .unwrap_or_else(|| "-".to_string());
     let max_request_body = svc
         .max_request_body_mb
         .map(|size| format!("{size} MiB"))
@@ -226,7 +230,50 @@ fn render_app_service(svc: &crate::api_types::ApiService, service_name: &str, ap
     output::info(&format!("    Memory:           {memory}"), None);
     output::info(&format!("    Min instances:    {min_instances}"), None);
     output::info(&format!("    Max instances:    {max_instances}"), None);
+    output::info(&format!("    Worker instances: {instances}"), None);
     output::info(&format!("    Max request body: {max_request_body}"), None);
+
+    if let Some(runtime) = &svc.runtime_plan {
+        let environment = runtime
+            .environment
+            .as_deref()
+            .unwrap_or("selected environment");
+        let effective = &runtime.effective;
+        let scaling = if runtime.service_type == "worker" {
+            format!(
+                "{} fixed instance(s)",
+                effective.instances.unwrap_or_default()
+            )
+        } else {
+            format!(
+                "{}–{} instances",
+                effective.min_instances.unwrap_or_default(),
+                effective.max_instances.unwrap_or_default()
+            )
+        };
+        let cpu = effective.cpu.as_deref().unwrap_or("-");
+        let memory = effective.memory.as_deref().unwrap_or("-");
+        let cpu_reason = runtime.cpu_allocation_reason.replace('_', " ");
+        output::info(&format!("  Effective runtime ({environment}):"), None);
+        output::info(
+            &format!(
+                "    Availability: {} ({scaling})",
+                runtime.availability.replace('_', " ")
+            ),
+            None,
+        );
+        output::info(&format!("    CPU / memory: {cpu} / {memory}"), None);
+        output::info(
+            &format!(
+                "    CPU allocation: {} ({cpu_reason})",
+                runtime.cpu_allocation.replace('_', " ")
+            ),
+            None,
+        );
+        for warning in &runtime.warnings {
+            output::warn(&format!("Runtime adjustment: {warning}"));
+        }
+    }
 }
 
 fn render_managed_service(

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -79,9 +79,11 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
             let max_instances = entry
                 .max_instances
                 .or_else(|| global_resources.and_then(|r| r.max_instances));
-            let min_instances = entry
-                .min_instances
-                .or_else(|| global_resources.and_then(|r| r.min_instances));
+            let min_instances = entry.min_instances.or_else(|| {
+                (service_type != ServiceType::Worker)
+                    .then(|| global_resources.and_then(|r| r.min_instances))
+                    .flatten()
+            });
 
             let svc = ServiceConfig {
                 name: name.clone(),
@@ -94,6 +96,7 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
                 memory,
                 max_instances,
                 min_instances,
+                instances: entry.instances,
                 migrate_command: entry.migrate_command.clone(),
             };
 
@@ -164,7 +167,14 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
 
                 let mut svc = svc_file.service.to_api_service_config(normalized_path);
 
-                // Let floo.app.toml override floo.service.toml values
+                // Apply resources from floo.service.toml [resources]
+                let global_resources = resolved
+                    .app_config
+                    .as_ref()
+                    .and_then(|c| c.resources.as_ref());
+                apply_service_file_resources(&mut svc, &svc_file.resources, global_resources);
+
+                // Let floo.app.toml override floo.service.toml/global values last.
                 if let Some(ref app_cfg) = resolved.app_config {
                     if let Some(entry) = app_cfg.services.get(name) {
                         if let Some(override_ingress) = entry.ingress {
@@ -173,15 +183,9 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
                         if entry.domain.is_some() {
                             svc.domain = entry.domain.clone();
                         }
+                        apply_app_service_overrides(&mut svc, entry);
                     }
                 }
-
-                // Apply resources from floo.service.toml [resources]
-                let global_resources = resolved
-                    .app_config
-                    .as_ref()
-                    .and_then(|c| c.resources.as_ref());
-                apply_service_file_resources(&mut svc, &svc_file.resources, global_resources);
 
                 if !seen_names.insert(svc.name.clone()) {
                     return Err(FlooError::new(
@@ -233,11 +237,12 @@ fn apply_service_file_resources(
     svc_resources: &Option<ResourceConfig>,
     global_resources: Option<&ResourceConfig>,
 ) {
+    let is_worker = svc.service_type == ServiceType::Worker;
     if let Some(res) = svc_resources {
         svc.cpu = res.cpu.clone();
         svc.memory = res.memory.clone();
         svc.max_instances = res.max_instances;
-        svc.min_instances = res.min_instances;
+        svc.min_instances = (!is_worker).then_some(res.min_instances).flatten();
     }
     // Fall back to global for any fields still None
     if let Some(global) = global_resources {
@@ -250,9 +255,29 @@ fn apply_service_file_resources(
         if svc.max_instances.is_none() {
             svc.max_instances = global.max_instances;
         }
-        if svc.min_instances.is_none() {
+        if !is_worker && svc.min_instances.is_none() {
             svc.min_instances = global.min_instances;
         }
+    }
+}
+
+/// Apply the app-level declaration last: delegated precedence is
+/// floo.app.toml service override > floo.service.toml > global [resources].
+fn apply_app_service_overrides(svc: &mut ServiceConfig, entry: &AppServiceEntry) {
+    if entry.cpu.is_some() {
+        svc.cpu = entry.cpu.clone();
+    }
+    if entry.memory.is_some() {
+        svc.memory = entry.memory.clone();
+    }
+    if entry.max_instances.is_some() {
+        svc.max_instances = entry.max_instances;
+    }
+    if svc.service_type != ServiceType::Worker && entry.min_instances.is_some() {
+        svc.min_instances = entry.min_instances;
+    }
+    if svc.service_type == ServiceType::Worker && entry.instances.is_some() {
+        svc.instances = entry.instances;
     }
 }
 
@@ -437,6 +462,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -590,6 +616,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -690,6 +717,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -889,6 +917,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -1085,6 +1114,7 @@ ingress = "public"
                 memory: None,
                 max_instances: None,
                 min_instances: None,
+                instances: None,
                 migrate_command: None,
             },
             ServiceConfig {
@@ -1098,6 +1128,7 @@ ingress = "public"
                 memory: None,
                 max_instances: None,
                 min_instances: None,
+                instances: None,
                 migrate_command: None,
             },
         ];
@@ -1120,6 +1151,7 @@ ingress = "public"
                 memory: None,
                 max_instances: None,
                 min_instances: None,
+                instances: None,
                 migrate_command: None,
             },
             ServiceConfig {
@@ -1133,6 +1165,7 @@ ingress = "public"
                 memory: None,
                 max_instances: None,
                 min_instances: None,
+                instances: None,
                 migrate_command: None,
             },
         ];
@@ -1156,6 +1189,7 @@ ingress = "public"
                 memory: None,
                 max_instances: None,
                 min_instances: None,
+                instances: None,
                 migrate_command: None,
             },
             ServiceConfig {
@@ -1169,6 +1203,7 @@ ingress = "public"
                 memory: None,
                 max_instances: None,
                 min_instances: None,
+                instances: None,
                 migrate_command: None,
             },
         ];
@@ -1208,6 +1243,7 @@ ingress = "public"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -1728,6 +1764,135 @@ domain = "svc.example.com"
     }
 
     #[test]
+    fn worker_never_inherits_global_http_minimum() {
+        let mut worker = ServiceConfig {
+            name: "jobs".to_string(),
+            service_type: ServiceType::Worker,
+            path: ".".to_string(),
+            port: 8080,
+            ingress: ServiceIngress::Internal,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+            min_instances: None,
+            instances: None,
+            migrate_command: None,
+        };
+        let global = ResourceConfig {
+            cpu: Some("1".to_string()),
+            memory: Some("512Mi".to_string()),
+            max_instances: Some(3),
+            min_instances: Some(1),
+        };
+
+        apply_service_file_resources(&mut worker, &None, Some(&global));
+
+        assert_eq!(worker.min_instances, None);
+        assert_eq!(worker.instances, None);
+    }
+
+    #[test]
+    fn delegated_app_override_wins_service_file_and_global_resources() {
+        let mut service = ServiceConfig {
+            name: "api".to_string(),
+            service_type: ServiceType::Api,
+            path: "backend".to_string(),
+            port: 8080,
+            ingress: ServiceIngress::Public,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+            min_instances: None,
+            instances: None,
+            migrate_command: None,
+        };
+        let global = ResourceConfig {
+            cpu: Some("1".to_string()),
+            memory: Some("512Mi".to_string()),
+            max_instances: Some(2),
+            min_instances: Some(0),
+        };
+        let service_file = Some(ResourceConfig {
+            cpu: Some("2".to_string()),
+            memory: None,
+            max_instances: Some(4),
+            min_instances: Some(1),
+        });
+        let app_override = AppServiceEntry {
+            service_type: AppServiceType::Api,
+            path: Some("backend".to_string()),
+            repo: None,
+            version: None,
+            plan: None,
+            port: None,
+            ingress: None,
+            env_file: None,
+            domain: None,
+            cpu: Some("4".to_string()),
+            memory: Some("2Gi".to_string()),
+            max_instances: Some(8),
+            min_instances: Some(2),
+            instances: None,
+            dev_command: None,
+            migrate_command: None,
+            command: None,
+            env: None,
+        };
+
+        apply_service_file_resources(&mut service, &service_file, Some(&global));
+        apply_app_service_overrides(&mut service, &app_override);
+
+        assert_eq!(service.cpu.as_deref(), Some("4"));
+        assert_eq!(service.memory.as_deref(), Some("2Gi"));
+        assert_eq!(service.max_instances, Some(8));
+        assert_eq!(service.min_instances, Some(2));
+    }
+
+    #[test]
+    fn delegated_worker_app_instances_override_wins_service_file() {
+        let mut worker = ServiceConfig {
+            name: "jobs".to_string(),
+            service_type: ServiceType::Worker,
+            path: "jobs".to_string(),
+            port: 8080,
+            ingress: ServiceIngress::Internal,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+            min_instances: None,
+            instances: Some(2),
+            migrate_command: None,
+        };
+        let app_override = AppServiceEntry {
+            service_type: AppServiceType::Worker,
+            path: Some("jobs".to_string()),
+            repo: None,
+            version: None,
+            plan: None,
+            port: None,
+            ingress: None,
+            env_file: None,
+            domain: None,
+            cpu: None,
+            memory: None,
+            max_instances: None,
+            min_instances: None,
+            instances: Some(0),
+            dev_command: None,
+            migrate_command: None,
+            command: None,
+            env: None,
+        };
+
+        apply_app_service_overrides(&mut worker, &app_override);
+
+        assert_eq!(worker.instances, Some(0));
+    }
+
+    #[test]
     fn test_discover_inline_errors_when_service_toml_exists() {
         let dir = TempDir::new().unwrap();
 
@@ -1910,6 +2075,7 @@ domain = "svc.example.com"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -215,6 +215,8 @@ pub struct ServiceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_instances: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub instances: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_command: Option<String>,
 }
 
@@ -296,6 +298,10 @@ pub struct ServiceSection {
     pub domain: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_instances: Option<u32>,
+    /// Exact fixed count for a worker. Omitted workers default to one instance;
+    /// zero is the explicit paused state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instances: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dev_command: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -324,6 +330,7 @@ impl ServiceSection {
             memory: None,
             max_instances: None,
             min_instances: self.min_instances,
+            instances: self.instances,
             migrate_command: self.migrate_command.clone(),
         }
     }
@@ -352,6 +359,36 @@ pub fn load_service_config(dir: &Path) -> Result<Option<ServiceFileConfig>, Floo
     validate_domain_blocks(&config.domains)?;
     if let Some(ref edge) = config.edge {
         edge.validate("[edge]")?;
+    }
+    let is_worker = config.service.service_type == ServiceType::Worker;
+    if config.service.instances.is_some() && !is_worker {
+        return Err(FlooError::with_suggestion(
+            ErrorCode::InvalidProjectConfig,
+            format!(
+                "Service '{}' in {} sets 'instances', which is only valid for type = \"worker\".",
+                config.service.name,
+                super::SERVICE_CONFIG_FILE,
+            ),
+            "Remove instances, or use min_instances/max_instances for an HTTP service.".to_string(),
+        ));
+    }
+    if is_worker
+        && (config.service.min_instances.is_some()
+            || config
+                .resources
+                .as_ref()
+                .is_some_and(|resources| resources.min_instances.is_some()))
+    {
+        return Err(FlooError::with_suggestion(
+            ErrorCode::InvalidProjectConfig,
+            format!(
+                "Service '{}' in {} is a worker and sets min_instances, which does not control a worker's fixed count.",
+                config.service.name,
+                super::SERVICE_CONFIG_FILE,
+            ),
+            "Replace min_instances with instances = <n> in [service] (0 turns the worker off)."
+                .to_string(),
+        ));
     }
 
     Ok(Some(config))
@@ -432,6 +469,81 @@ env_file = ".env"
     }
 
     #[test]
+    fn test_worker_instances_parse_and_pause() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "jobs"
+type = "worker"
+port = 8080
+instances = 0
+"#,
+        )
+        .unwrap();
+
+        let config = load_service_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.service.instances, Some(0));
+        assert_eq!(config.service.to_api_service_config(".").instances, Some(0));
+    }
+
+    #[test]
+    fn test_http_service_rejects_worker_instances() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(super::super::SERVICE_CONFIG_FILE),
+            r#"
+[app]
+name = "my-app"
+
+[service]
+name = "web"
+type = "web"
+port = 8080
+instances = 1
+"#,
+        )
+        .unwrap();
+
+        let error = load_service_config(dir.path()).unwrap_err();
+        assert_eq!(error.code, ErrorCode::InvalidProjectConfig);
+        assert!(error.message.contains("only valid for type = \"worker\""));
+    }
+
+    #[test]
+    fn test_worker_rejects_http_min_instances_in_either_section() {
+        for scaling in ["min_instances = 1", "[resources]\nmin_instances = 1"] {
+            let dir = TempDir::new().unwrap();
+            fs::write(
+                dir.path().join(super::super::SERVICE_CONFIG_FILE),
+                format!(
+                    r#"
+[app]
+name = "my-app"
+
+[service]
+name = "jobs"
+type = "worker"
+port = 8080
+{scaling}
+"#
+                ),
+            )
+            .unwrap();
+
+            let error = load_service_config(dir.path()).unwrap_err();
+            assert_eq!(error.code, ErrorCode::InvalidProjectConfig);
+            assert!(error
+                .message
+                .contains("does not control a worker's fixed count"));
+        }
+    }
+
+    #[test]
     fn test_load_service_config_missing_returns_none() {
         let dir = TempDir::new().unwrap();
         let result = load_service_config(dir.path()).unwrap();
@@ -501,6 +613,7 @@ ingress = "internal"
                 env_file: None,
                 domain: None,
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -525,6 +638,7 @@ ingress = "internal"
             env_file: None,
             domain: None,
             min_instances: None,
+            instances: None,
             dev_command: None,
             migrate_command: None,
         };
@@ -550,6 +664,7 @@ ingress = "internal"
             memory: None,
             max_instances: None,
             min_instances: None,
+            instances: None,
             migrate_command: None,
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -730,6 +845,7 @@ port = 8000
             env_file: None,
             domain: Some("getfloo.com".to_string()),
             min_instances: None,
+            instances: None,
             dev_command: None,
             migrate_command: None,
         };
@@ -751,6 +867,7 @@ port = 8000
             memory: None,
             max_instances: None,
             min_instances: None,
+            instances: None,
             migrate_command: None,
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -770,6 +887,7 @@ port = 8000
             memory: None,
             max_instances: None,
             min_instances: None,
+            instances: None,
             migrate_command: None,
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -794,6 +912,7 @@ port = 8000
                 env_file: None,
                 domain: Some("getfloo.com".to_string()),
                 min_instances: None,
+                instances: None,
                 dev_command: None,
                 migrate_command: None,
             },
@@ -869,6 +988,7 @@ port = 8000
             memory: None,
             max_instances: None,
             min_instances: None,
+            instances: None,
             migrate_command: None,
         };
         let json = serde_json::to_value(&config).unwrap();
@@ -890,6 +1010,7 @@ port = 8000
             memory: Some("4Gi".to_string()),
             max_instances: Some(5),
             min_instances: None,
+            instances: None,
             migrate_command: None,
         };
         let json = serde_json::to_value(&config).unwrap();

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -115,18 +115,33 @@ fn mock_resolve_app(server: &mut Server) -> Vec<Mock> {
 
 /// Mock a single user-managed service (web).
 fn mock_services_single(server: &mut Server) -> Mock {
+    mock_services_single_for_env(server, None)
+}
+
+fn mock_services_single_env(server: &mut Server, environment: &str) -> Mock {
+    mock_services_single_for_env(server, Some(environment))
+}
+
+fn mock_services_single_for_env(server: &mut Server, environment: Option<&str>) -> Mock {
+    let mut query = vec![
+        Matcher::UrlEncoded("page".into(), "1".into()),
+        Matcher::UrlEncoded("per_page".into(), "100".into()),
+    ];
+    if let Some(environment) = environment {
+        query.push(Matcher::UrlEncoded(
+            "environment".into(),
+            environment.into(),
+        ));
+    }
     server
         .mock(
             "GET",
             format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
         )
-        .match_query(Matcher::AllOf(vec![
-            Matcher::UrlEncoded("page".into(), "1".into()),
-            Matcher::UrlEncoded("per_page".into(), "100".into()),
-        ]))
+        .match_query(Matcher::AllOf(query))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"services":[{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000,"cpu":"2","memory":"1Gi","max_instances":10,"min_instances":1,"max_request_body_mb":32}]}"#)
+        .with_body(r#"{"services":[{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000,"cpu":"2","memory":"1Gi","max_instances":10,"min_instances":1,"instances":null,"max_request_body_mb":32,"runtime_plan":{"environment":"dev","service_type":"web","availability":"warm","declared":{"cpu":"2","memory":"1Gi","min_instances":1,"max_instances":10,"instances":null},"effective":{"cpu":"2","memory":"1Gi","min_instances":1,"max_instances":10,"instances":null},"sources":{"cpu":"configured","memory":"configured","min_instances":"configured","max_instances":"configured","instances":null},"cpu_allocation":"request_based","cpu_allocation_reason":"http_request_scoped","warnings":[]}}]}"#)
         .create()
 }
 
@@ -3038,7 +3053,7 @@ fn test_services_list_json_returns_both_app_and_managed_services() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
-    let _services = mock_services_single(&mut server);
+    let _services = mock_services_single_env(&mut server, "dev");
 
     let _m_managed = server
         .mock(
@@ -3069,6 +3084,9 @@ fn test_services_list_json_returns_both_app_and_managed_services() {
     assert_eq!(service["max_instances"], 10);
     assert_eq!(service["min_instances"], 1);
     assert_eq!(service["max_request_body_mb"], 32);
+    assert_eq!(service["runtime_plan"]["environment"], "dev");
+    assert_eq!(service["runtime_plan"]["availability"], "warm");
+    assert_eq!(service["runtime_plan"]["cpu_allocation"], "request_based");
 }
 
 #[test]
@@ -3646,7 +3664,7 @@ fn test_services_list_partial_view_when_managed_services_fetch_fails() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
-    let _services = mock_services_single(&mut server);
+    let _services = mock_services_single_env(&mut server, "dev");
 
     // Managed services endpoint is broken. `list` must degrade gracefully:
     // app services render, managed_services is empty, a warning fires.
@@ -3783,7 +3801,7 @@ fn test_services_show_user_managed() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
-    let _services = mock_services_single(&mut server);
+    let _services = mock_services_single_env(&mut server, "dev");
 
     let output = floo()
         .args(["--json", "services", "show", "web", "--app", TEST_APP_NAME])
@@ -3817,6 +3835,7 @@ fn test_services_show_json_preserves_null_resource_fields() {
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "dev".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -3852,7 +3871,7 @@ fn test_services_show_human_renders_configured_resources() {
     let mut server = Server::new();
     let home = setup_config(&server);
     let _resolve = mock_resolve_app(&mut server);
-    let _services = mock_services_single(&mut server);
+    let _services = mock_services_single_env(&mut server, "dev");
 
     floo()
         .args(["services", "show", "web", "--app", TEST_APP_NAME])
@@ -3864,7 +3883,54 @@ fn test_services_show_human_renders_configured_resources() {
         .stderr(predicate::str::contains("Memory:           1Gi"))
         .stderr(predicate::str::contains("Min instances:    1"))
         .stderr(predicate::str::contains("Max instances:    10"))
-        .stderr(predicate::str::contains("Max request body: 32 MiB"));
+        .stderr(predicate::str::contains("Max request body: 32 MiB"))
+        .stderr(predicate::str::contains("Effective runtime (dev):"))
+        .stderr(predicate::str::contains(
+            "Availability: warm (1–10 instances)",
+        ))
+        .stderr(predicate::str::contains(
+            "CPU allocation: request based (http request scoped)",
+        ));
+}
+
+#[test]
+fn test_services_show_selects_prod_runtime_plan() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/services").as_str(),
+        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "prod".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"services":[{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000,"runtime_plan":{"environment":"prod","service_type":"web","availability":"on_demand","declared":{"cpu":null,"memory":null,"min_instances":null,"max_instances":null,"instances":null},"effective":{"cpu":"1","memory":"512Mi","min_instances":0,"max_instances":3,"instances":null},"sources":{"cpu":"platform_default","memory":"platform_default","min_instances":"platform_default","max_instances":"platform_default","instances":null},"cpu_allocation":"request_based","cpu_allocation_reason":"http_request_scoped","warnings":[]}}]}"#)
+        .create();
+
+    let output = floo()
+        .args([
+            "--json",
+            "services",
+            "show",
+            "web",
+            "--app",
+            TEST_APP_NAME,
+            "--env",
+            "prod",
+        ])
+        .env("HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    let json = parse_single_json_object(&output.stdout);
+    assert_eq!(json["data"]["runtime_plan"]["environment"], "prod");
 }
 
 #[test]
@@ -3878,6 +3944,7 @@ fn test_services_show_routes_to_managed_service_by_type() {
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "dev".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -3938,6 +4005,7 @@ fn test_services_show_nothing_matches_lists_available() {
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "dev".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -4265,6 +4333,7 @@ fn test_services_show_surfaces_api_errors() {
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("page".into(), "1".into()),
             Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "dev".into()),
         ]))
         .with_status(500)
         .with_header("content-type", "application/json")


### PR DESCRIPTION
## Summary

- add normalized runtime plans to human and JSON preflight output
- show server-resolved runtime plans with `floo services show --env dev|prod`
- close inline/delegated worker `instances` and `min_instances` parity gaps
- add version-matched `floo docs scaling` guidance and route bundled skills to it

## Scope

The 14-file CLI slice is intentionally atomic: parser parity, preflight, inspection, offline docs, bundled skills, and executable evidence must ship in one installed version or agents receive contradictory guidance.

## Test plan

- `cargo fmt --check`
- `./scripts/test` (824 tests pass)

Refs getfloo/floo#1996