### PR TITLE
feat: resolve production runtime defaults in preflight

### DIFF
--- a/docs/offline/config.md
+++ b/docs/offline/config.md
@@ -125,8 +125,13 @@ floo Config Files
   [resources]
   cpu = "1"             # CPU cores (0.25 to 8)
   memory = "512Mi"      # Memory (128Mi to 32Gi)
-  min_instances = 0     # HTTP baseline; 0 = on-demand, 1+ = warm
   max_instances = 3     # Max HTTP autoscale instances (platform default: 3)
+
+  Omitted HTTP min_instances is 1 for paid production and 0 for Free, dev,
+  and preview. Set min_instances = 0 explicitly to opt paid production into
+  scale-to-zero. The warm default is about $24.64/month for the default HTTP
+  shape before request traffic and credits, or about $36.96/month with the
+  floo-managed Postgres default shape.
 
   Global min_instances applies only to web/api services. Workers use the
   per-service `instances` field and never inherit this HTTP autoscaling floor.

--- a/docs/offline/deploy.md
+++ b/docs/offline/deploy.md
@@ -91,6 +91,7 @@ floo Deploy Flow
 
   floo preflight                   - validate config, detect runtimes, check readiness
   floo preflight --json            - structured output for agents
+  floo preflight --env prod --json - resolve tier-aware production runtime defaults
 
   Preflight FAILS (exit 1, valid=false) on configs that can't build or run:
   a service path that doesn't exist, a [cron.*] with an invalid schedule, a
@@ -110,6 +111,10 @@ floo Deploy Flow
                            required/optional keys, explicit vs implicit mode.
     data.cron[]          - declared [cron.*] entries (name, schedule, command,
                            service, timeout).
+    data.runtime_plan[]  - local configured/default scaling intent. A production
+                           omission remains unresolved without the app plan.
+    data.plan.runtime_services[] - authenticated server resolution for --env,
+                           including effective values, sources, and billing notes.
     contains_secrets     - top-level marker, true when a secret-shaped var is
                            found in a web service's env file (it may ship to
                            the browser). Harnesses can refuse the payload.

--- a/docs/offline/scaling.md
+++ b/docs/offline/scaling.md
@@ -30,6 +30,11 @@ up to `max_instances`. The baseline avoids its cold start; new burst capacity
 may still cold-start. Warm does not mean CPU always on: web and api services use
 request-based CPU, including when attached to floo-managed Postgres.
 
+At the current floo rate card, one warm default HTTP instance (1 vCPU / 512
+MiB) is about $24.64/month before request traffic and credits. A service
+attached to floo-managed Postgres uses the 1.5 vCPU / 768 MiB default shape,
+about $36.96/month while warm.
+
 Use a worker for work that must run without an HTTP request. Workers have a
 fixed count and always-allocated CPU:
 
@@ -45,7 +50,10 @@ Pause a worker explicitly with `instances = 0`. Workers never use
 
 ## Defaults, limits, and verification
 
-- HTTP `min_instances` defaults to 0 in dev and in the locally resolved plan.
+- Omitted HTTP `min_instances` defaults to 1 for paid production and 0 for
+  Free, dev, and preview.
+- Explicit `min_instances = 0` opts a paid production HTTP service into
+  scale-to-zero.
 - HTTP `max_instances` defaults to 3.
 - Worker `instances` defaults to 1.
 - Per-service values override delegated `floo.service.toml` values, which
@@ -55,6 +63,13 @@ Pause a worker explicitly with `instances = 0`. Workers never use
 
 Run `floo preflight --json` before pushing. Read `data.runtime_plan` for the
 configured values, locally resolved defaults, field sources, availability
-posture, and CPU mode. After deployment, use
-`floo services show <name> --app <app> --json` to verify the server-effective
-runtime plan.
+posture, and CPU mode. For an authenticated existing app, run
+`floo preflight --env prod --json` and read `data.plan.runtime_services` for the
+exact tier-aware production default and continuous-billing note. After
+deployment, use `floo services show <name> --app <app> --json` to verify the
+server-effective runtime plan.
+
+Existing paid production services with an omitted minimum adopt warm on their
+next production deploy, promote, restart, or rollback. floo does not create a
+revision only to migrate the default. Commit an explicit zero before that next
+runtime change to remain on-demand.

--- a/docs/offline/services.md
+++ b/docs/offline/services.md
@@ -21,6 +21,11 @@ with confirmation for the exact app, environment, type, and name.
   Availability and cost/latency choices are declared with `min_instances` for
   web/api and `instances` for workers. See: floo docs scaling
 
+  Paid production web/api services default to one warm instance when
+  min_instances is omitted. The default bills continuously. Set
+  min_instances = 0 to opt into scale-to-zero; Free, dev, and preview default
+  to zero.
+
   Declare inline in floo.app.toml with type, port, and path. A deploy applies
   the declared service shape. It does not infer destructive intent for a
   production service merely because a declaration disappeared.

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -644,9 +644,39 @@ pub struct DeclaredManagedService {
     pub tier: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
+pub struct DeclaredRuntimeService {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub service_type: String,
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
+    pub min_instances: Option<u32>,
+    pub max_instances: Option<u32>,
+    pub instances: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct DeclaredState {
     pub managed_services: Vec<DeclaredManagedService>,
+    pub environment: String,
+    pub services: Vec<DeclaredRuntimeService>,
+}
+
+impl Default for DeclaredState {
+    fn default() -> Self {
+        Self {
+            managed_services: Vec::new(),
+            environment: "dev".to_string(),
+            services: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PreflightRuntimeService {
+    pub name: String,
+    pub runtime_plan: ApiRuntimePlan,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -684,6 +714,8 @@ pub struct PlanSummary {
 pub struct PreflightPlan {
     #[serde(default)]
     pub managed_services: ManagedServicesPlan,
+    #[serde(default)]
+    pub runtime_services: Vec<PreflightRuntimeService>,
     #[serde(default)]
     pub summary: PlanSummary,
     #[serde(default)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,7 +144,8 @@ Examples:
     #[command(after_help = "\
 Examples:
   floo preflight                           Validate current directory
-  floo preflight ./app --json              Validate ./app with JSON output")]
+  floo preflight ./app --json              Validate ./app with JSON output
+  floo preflight --env prod                Resolve the production runtime plan")]
     Preflight {
         /// Project directory to validate.
         #[arg(default_value = ".")]
@@ -162,6 +163,10 @@ Examples:
             value_delimiter = ','
         )]
         services: Vec<String>,
+
+        /// Environment whose server-side runtime defaults should be resolved.
+        #[arg(long, default_value = "dev", value_parser = ["dev", "prod", "preview"])]
+        env: String,
     },
 
     /// Force a redeploy (after env var changes, config updates, or to rebuild).
@@ -2108,7 +2113,8 @@ pub fn run() {
             path,
             app,
             services,
-        } => commands::deploy::preflight(path, app, services),
+            env,
+        } => commands::deploy::preflight(path, app, services, env),
 
         Commands::Redeploy {
             path,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -56,6 +56,7 @@ const LOCAL_DEFAULT_MAX_INSTANCES: u32 = 3;
 struct RuntimePlan {
     service: String,
     service_type: String,
+    environment: String,
     availability: String,
     configured: RuntimePlanValues,
     locally_resolved: RuntimePlanValues,
@@ -63,6 +64,7 @@ struct RuntimePlan {
     cpu_allocation: String,
     cpu_allocation_reason: String,
     server_resolution_required: bool,
+    notes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -79,7 +81,7 @@ struct RuntimePlanSources {
     instances: Option<String>,
 }
 
-fn build_runtime_plan(services: &[ServiceConfig]) -> Vec<RuntimePlan> {
+fn build_runtime_plan(services: &[ServiceConfig], environment: &str) -> Vec<RuntimePlan> {
     services
         .iter()
         .map(|service| {
@@ -95,6 +97,7 @@ fn build_runtime_plan(services: &[ServiceConfig]) -> Vec<RuntimePlan> {
                 RuntimePlan {
                     service: service.name.clone(),
                     service_type: service.service_type.to_string(),
+                    environment: environment.to_string(),
                     availability: if instances == 0 { "paused" } else { "fixed" }.to_string(),
                     configured,
                     locally_resolved: RuntimePlanValues {
@@ -117,14 +120,21 @@ fn build_runtime_plan(services: &[ServiceConfig]) -> Vec<RuntimePlan> {
                     cpu_allocation: "always_allocated".to_string(),
                     cpu_allocation_reason: "worker_background_process".to_string(),
                     server_resolution_required: true,
+                    notes: Vec::new(),
                 }
             } else {
-                let min_instances = service.min_instances.unwrap_or(0);
+                let min_instances = service
+                    .min_instances
+                    .or_else(|| (environment != "prod").then_some(0));
                 let max_instances = service.max_instances.unwrap_or(LOCAL_DEFAULT_MAX_INSTANCES);
+                let server_resolved_prod_default = environment == "prod" && min_instances.is_none();
                 RuntimePlan {
                     service: service.name.clone(),
                     service_type: service.service_type.to_string(),
-                    availability: if min_instances == 0 {
+                    environment: environment.to_string(),
+                    availability: if server_resolved_prod_default {
+                        "server_resolved"
+                    } else if min_instances == Some(0) {
                         "on_demand"
                     } else {
                         "warm"
@@ -132,18 +142,13 @@ fn build_runtime_plan(services: &[ServiceConfig]) -> Vec<RuntimePlan> {
                     .to_string(),
                     configured,
                     locally_resolved: RuntimePlanValues {
-                        min_instances: Some(min_instances),
+                        min_instances,
                         max_instances: Some(max_instances),
                         instances: None,
                     },
                     sources: RuntimePlanSources {
-                        min_instances: Some(
-                            if service.min_instances.is_some() {
-                                "configured"
-                            } else {
-                                "platform_default"
-                            }
-                            .to_string(),
+                        min_instances: service.min_instances.map(|_| "configured".to_string()).or_else(
+                            || (environment != "prod").then(|| "platform_default".to_string()),
                         ),
                         max_instances: Some(
                             if service.max_instances.is_some() {
@@ -158,6 +163,11 @@ fn build_runtime_plan(services: &[ServiceConfig]) -> Vec<RuntimePlan> {
                     cpu_allocation: "request_based".to_string(),
                     cpu_allocation_reason: "http_request_scoped".to_string(),
                     server_resolution_required: true,
+                    notes: if server_resolved_prod_default {
+                        vec!["Paid production defaults to one warm instance and bills continuously; Free remains on-demand. Set min_instances = 0 to opt out.".to_string()]
+                    } else {
+                        Vec::new()
+                    },
                 }
             }
         })
@@ -464,7 +474,12 @@ fn status_label(status: &str) -> &str {
     }
 }
 
-pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String>) {
+pub fn preflight(
+    path: PathBuf,
+    app: Option<String>,
+    services_filter: Vec<String>,
+    environment: String,
+) {
     // 1. Canonicalize path
     let project_path = match path.canonicalize() {
         Ok(p) => p,
@@ -545,7 +560,7 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
         &env_injection_plan,
     );
     let security_findings = generate_security_findings(&services, &resolved, &env_injection_plan);
-    let runtime_plan = build_runtime_plan(&services);
+    let runtime_plan = build_runtime_plan(&services, &environment);
 
     let valid = !has_errors(&validation_findings);
     let contains_secrets = security_findings
@@ -558,7 +573,13 @@ pub fn preflight(path: PathBuf, app: Option<String>, services_filter: Vec<String
 
     // 7. Remote preflight audit (declared vs deployed). Best-effort — auth/resolution
     // failures degrade to a note; local validation still ships.
-    let remote_plan = fetch_remote_preflight(&app_name, &managed_services, &resolved.config_dir);
+    let remote_plan = fetch_remote_preflight(
+        &app_name,
+        &managed_services,
+        &services,
+        &environment,
+        &resolved.config_dir,
+    );
 
     // 8. Display
     if output::is_json_mode() {
@@ -873,7 +894,7 @@ pub fn deploy(
         &env_injection_plan,
     );
     let valid = !has_errors(&validation_findings);
-    let runtime_plan = build_runtime_plan(&services);
+    let runtime_plan = build_runtime_plan(&services, "dev");
 
     // 6. Display preflight info
     if !output::is_json_mode() {
@@ -2567,6 +2588,11 @@ fn display_preflight_human(
                 runtime.availability,
                 runtime.locally_resolved.instances.unwrap_or(0),
             );
+        } else if runtime.availability == "server_resolved" {
+            eprintln!(
+                "    availability: server-resolved for {}; authenticate to resolve the app plan",
+                runtime.environment,
+            );
         } else {
             eprintln!(
                 "    availability: {}, scales {}\u{2013}{}, request-based CPU",
@@ -2577,6 +2603,9 @@ fn display_preflight_human(
                     .max_instances
                     .unwrap_or(LOCAL_DEFAULT_MAX_INSTANCES),
             );
+        }
+        for note in &runtime.notes {
+            eprintln!("    note: {note}");
         }
         eprintln!("    note: plan limits are resolved by the server; verify with `floo services show --json`");
         eprintln!();
@@ -3075,9 +3104,11 @@ pub(crate) fn sync_env_vars_if_needed(
 fn fetch_remote_preflight(
     app_name: &str,
     managed: &[project_config::ManagedServiceDeclaration],
+    services: &[ServiceConfig],
+    environment: &str,
     project_root: &Path,
 ) -> Option<crate::api_types::PreflightPlan> {
-    use crate::api_types::DeclaredState;
+    use crate::api_types::{DeclaredRuntimeService, DeclaredState};
     use crate::config::load_config;
 
     load_config().api_key.as_ref()?;
@@ -3087,6 +3118,19 @@ fn fetch_remote_preflight(
 
     let declared = DeclaredState {
         managed_services: collect_declared_managed_services(managed, project_root),
+        environment: environment.to_string(),
+        services: services
+            .iter()
+            .map(|service| DeclaredRuntimeService {
+                name: service.name.clone(),
+                service_type: service.service_type.to_string(),
+                cpu: service.cpu.clone(),
+                memory: service.memory.clone(),
+                min_instances: service.min_instances,
+                max_instances: service.max_instances,
+                instances: service.instances,
+            })
+            .collect(),
     };
 
     client.preflight(&app.id, &declared).ok()
@@ -3140,6 +3184,47 @@ fn collect_declared_managed_services(
 }
 
 fn render_plan_human(plan: &crate::api_types::PreflightPlan) {
+    if !plan.runtime_services.is_empty() {
+        eprintln!("  Server-resolved runtime plan:");
+        for service in &plan.runtime_services {
+            let runtime = &service.runtime_plan;
+            let environment = runtime
+                .environment
+                .as_deref()
+                .unwrap_or("selected environment");
+            let scaling = if runtime.service_type == "worker" {
+                format!(
+                    "{} fixed instance(s)",
+                    runtime.effective.instances.unwrap_or_default()
+                )
+            } else {
+                format!(
+                    "{}-{} instances",
+                    runtime.effective.min_instances.unwrap_or_default(),
+                    runtime.effective.max_instances.unwrap_or_default()
+                )
+            };
+            let source = runtime
+                .sources
+                .min_instances
+                .as_deref()
+                .or(runtime.sources.instances.as_deref())
+                .unwrap_or("not applicable");
+            eprintln!(
+                "    {} ({}): {}, {} [{}]",
+                service.name,
+                environment,
+                runtime.availability.replace('_', " "),
+                scaling,
+                source.replace('_', " "),
+            );
+            for note in &runtime.warnings {
+                eprintln!("      note: {note}");
+            }
+        }
+        eprintln!();
+    }
+
     let ms = &plan.managed_services;
     if !ms.to_provision.is_empty() {
         eprintln!("  Will provision on next deploy:");
@@ -3228,7 +3313,7 @@ mod tests {
             runtime_service("paused", ServiceType::Worker, None, None, Some(0)),
         ];
 
-        let plan = build_runtime_plan(&services);
+        let plan = build_runtime_plan(&services, "dev");
 
         assert_eq!(plan[0].availability, "on_demand");
         assert_eq!(plan[0].locally_resolved.min_instances, Some(0));
@@ -3251,6 +3336,20 @@ mod tests {
         assert_eq!(plan[3].availability, "paused");
         assert_eq!(plan[3].configured.instances, Some(0));
         assert_eq!(plan[3].locally_resolved.instances, Some(0));
+    }
+
+    #[test]
+    fn prod_omission_waits_for_server_tier_resolution_and_explains_cost() {
+        let services = vec![runtime_service("web", ServiceType::Web, None, None, None)];
+
+        let plan = build_runtime_plan(&services, "prod");
+
+        assert_eq!(plan[0].environment, "prod");
+        assert_eq!(plan[0].availability, "server_resolved");
+        assert_eq!(plan[0].locally_resolved.min_instances, None);
+        assert_eq!(plan[0].sources.min_instances, None);
+        assert!(plan[0].notes[0].contains("bills continuously"));
+        assert!(plan[0].notes[0].contains("min_instances = 0"));
     }
 
     // floo-cli#208: the SSE stream closes when the executor job exits, which

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -392,7 +392,10 @@ mod tests {
             "request-based CPU",
             "always-allocated CPU",
             "floo preflight --json",
+            "floo preflight --env prod --json",
             "floo services show",
+            "paid production",
+            "$24.64/month",
         ] {
             assert!(
                 SCALING.contains(phrase),

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5524,6 +5524,14 @@ fn test_preflight_surfaces_orphaned_managed_service() {
             "POST",
             format!("/v1/apps/{TEST_APP_ID}/preflight").as_str(),
         )
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "environment": "prod",
+            "services": [{
+                "name": "web",
+                "type": "web",
+                "min_instances": null
+            }]
+        })))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
@@ -5534,6 +5542,20 @@ fn test_preflight_surfaces_orphaned_managed_service() {
                     "to_orphan":[{"type":"postgres","name":"default","tier":"basic","managed_service_id":"ms-1","data_impact":"Postgres schema app_xyz and role floo_app_xyz"}],
                     "in_flight_deprovisioning":[]
                 },
+                "runtime_services":[{
+                    "name":"web",
+                    "runtime_plan":{
+                        "environment":"prod",
+                        "service_type":"web",
+                        "availability":"warm",
+                        "declared":{"cpu":null,"memory":null,"min_instances":null,"max_instances":null,"instances":null},
+                        "effective":{"cpu":"1","memory":"512Mi","min_instances":1,"max_instances":3,"instances":null},
+                        "sources":{"cpu":"platform_default","memory":"platform_default","min_instances":"platform_default","max_instances":"platform_default","instances":null},
+                        "cpu_allocation":"request_based",
+                        "cpu_allocation_reason":"http_request_scoped",
+                        "warnings":["Warm production baseline bills continuously; set min_instances = 0 in floo.app.toml to opt out."]
+                    }
+                }],
                 "summary":{"action_count":1,"destructive_count":1,"estimated_duration_seconds":null},
                 "destructive":true,
                 "data_loss":false
@@ -5564,13 +5586,24 @@ ingress = "public"
     .unwrap();
 
     floo()
-        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .args([
+            "--json",
+            "preflight",
+            project.path().to_str().unwrap(),
+            "--env",
+            "prod",
+        ])
         .env("HOME", home.path())
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""valid":true"#))
         .stdout(predicate::str::contains(r#""to_orphan""#))
         .stdout(predicate::str::contains("app_xyz"))
+        .stdout(predicate::str::contains(r#""availability":"warm""#))
+        .stdout(predicate::str::contains(
+            r#""min_instances":"platform_default""#,
+        ))
+        .stdout(predicate::str::contains("bills continuously"))
         .stdout(predicate::str::contains(r#""destructive":true"#));
 }
 


### PR DESCRIPTION
## Summary

- add `floo preflight --env dev|prod|preview`
- send declared runtime services to the server and render its tier-aware runtime plan
- keep an omitted production HTTP minimum unresolved locally instead of guessing the app tier
- document the paid production warm baseline, cost, migration timing, and explicit `min_instances = 0` opt-out in the embedded offline corpus

## Testing

- `FLOO_TEST_CARGO=/Users/patrickdonohoe/.cargo/bin/cargo scripts/test`
- 512 unit tests, 147 CLI tests, 165 mock API tests, and the documentation link guard passed

Refs getfloo/floo#1998