### PR TITLE
docs: align CLI guidance with shipped behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ floo update --version v0.1.0
 # Authenticate
 floo auth login
 
-# Connect and deploy your project
+# Initialize, validate, and push the config GitHub will deploy
 cd my-project
+floo init my-app
+floo preflight
+git add floo.app.toml Dockerfile AGENTS.md
+git commit -m "chore: configure floo"
+git push origin main
+
+# Create the floo app, connect GitHub, and deploy the pushed commit
 floo apps github connect owner/repo
 
 # Manage apps
@@ -61,7 +68,7 @@ floo apps show my-app
 floo apps delete my-app
 
 # Environment variables
-floo env set DATABASE_URL=postgres://... --app my-app
+floo env set DATABASE_URL --stdin --secret --app my-app
 floo env list --app my-app
 
 # Custom domains

--- a/docs/offline/config.md
+++ b/docs/offline/config.md
@@ -98,9 +98,8 @@ floo Config Files
 
 ## Managed Services (in floo.app.toml)
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   [managed.cache]
   type = "redis"
@@ -109,9 +108,11 @@ floo Config Files
   type = "storage"
 
   Missing declared resources are provisioned by a git-triggered deploy.
-  Credentials are injected as env vars. Removing a declaration never
-  destroys stored data; use the explicit services lifecycle only after
-  resolving and confirming the exact resource.
+  Credentials are injected as env vars. Removing a deployed declaration is
+  a tier-3 change that requires human approval and schedules a rescindable
+  teardown; it does not delete provider data. Terminal deletion still uses
+  the explicit services lifecycle after resolving and confirming the exact
+  resource.
 
   Legacy [postgres], [redis], and [storage] sections remain readable for
   existing apps. Use `floo docs services` and the installed migration help
@@ -140,11 +141,10 @@ floo Config Files
 
 ## Environment Overrides (in floo.app.toml)
 
-  [environments.dev]
-  access_mode = "public"
-
-  [environments.prod]
-  access_mode = "accounts"
+  Per-environment access_mode values are accepted by the parser but are not
+  applied by push deploys today. Set one access_mode under [app] for both
+  environments. Per-environment edge policy is supported under
+  [environments.dev.edge] and [environments.prod.edge].
 
 ## Cron Jobs ([cron.<name>])
 
@@ -185,7 +185,7 @@ floo Config Files
   declaratively by handle:
 
     [services.api.env]
-    managed = ["postgres:primary", "redis:cache"]
+    managed = ["postgres", "redis:cache"]
 
     [services.worker.env]
     managed = ["redis:cache"]
@@ -207,7 +207,7 @@ floo Config Files
   Recommended pattern for multi-service apps:
 
     # Backend secrets - api/worker only
-    floo env set LINEAR_API_KEY=lin_... --service api
+    floo env set LINEAR_API_KEY --stdin --secret --service api
 
     # Frontend config - web only (public, not secret)
     floo env set VITE_API_URL=https://my-app.getfloo.com/api --service web

--- a/docs/offline/deploy.md
+++ b/docs/offline/deploy.md
@@ -36,7 +36,7 @@ floo Deploy Flow
   without a new commit, such as updated environment values. It resolves
   source from the connected GitHub repository and never uploads local files:
 
-    floo env set API_KEY=new-value --app myapp --service api
+    floo env set API_KEY --stdin --secret --app myapp --service api
     floo redeploy --app myapp
 
   A no-rebuild redeploy replays only the immutable contract captured by the
@@ -54,9 +54,10 @@ floo Deploy Flow
 
 ## First Deploy
 
-  Use `floo apps github connect owner/repo`. This connects GitHub and
-  triggers the first deploy in one step. The app is auto-created if
-  it doesn't exist.
+  Run `floo init`, edit and preflight the generated config, then commit and
+  push it to GitHub. Use `floo apps github connect owner/repo` only after the
+  push. Connect creates the app, connects GitHub, and triggers the first
+  deploy from that pushed source.
 
 ## Do I Need a Dockerfile?
 

--- a/docs/offline/django.md
+++ b/docs/offline/django.md
@@ -41,18 +41,19 @@ Use whitenoise for static files, gunicorn for the WSGI server.
   dev_command = "python manage.py runserver 0.0.0.0:8000"
   migrate_command = "python manage.py migrate --noinput"
 
+  floo preflight
+  git add . && git commit -m "chore: configure floo"
   git push origin main
   floo apps github connect owner/my-django-app
 
   # Set the secret key after first deploy
-  floo env set DJANGO_SECRET_KEY="$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')" --app my-django-app
+  python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())' | floo env set DJANGO_SECRET_KEY --stdin --secret --app my-django-app
   floo redeploy --app my-django-app
 
 ## 4. Postgres
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   # dj-database-url parses DATABASE_URL automatically
 

--- a/docs/offline/express.md
+++ b/docs/offline/express.md
@@ -29,14 +29,15 @@ won't get set behind floo's edge.
   ingress = "public"
   dev_command = "node --watch server.js"
 
+  floo preflight
+  git add . && git commit -m "chore: configure floo"
   git push origin main
   floo apps github connect owner/my-express-app
 
 ## 4. Postgres
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   import pg from "pg";
   export const pool = new pg.Pool({

--- a/docs/offline/fastapi.md
+++ b/docs/offline/fastapi.md
@@ -24,14 +24,15 @@ Bind to 0.0.0.0 - 127.0.0.1 won't accept Cloud Run traffic.
   dev_command = "uvicorn app.main:app --reload --port 8000"
   migrate_command = "alembic upgrade head"   # if you use Alembic
 
+  floo preflight
+  git add . && git commit -m "chore: configure floo"
   git push origin main
   floo apps github connect owner/my-fastapi-app
 
 ## 3. Postgres
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   # Async SQLAlchemy - convert to asyncpg URL:
   DATABASE_URL = os.environ["DATABASE_URL"].replace(

--- a/docs/offline/golden-path.md
+++ b/docs/offline/golden-path.md
@@ -13,16 +13,20 @@ floo - Golden Path
   (floo.service.toml or floo.app.toml). Use it when running commands from
   outside your project directory.
 
-## First-Time Setup (4 commands)
+## First-Time Setup
 
   1. floo auth login                         # sign up or log in (opens browser)
   2. floo init my-app
   3. floo preflight                          # validate config (local only, no auth)
-  4. floo apps github connect owner/repo     # creates app + triggers first deploy
+  4. git add floo.app.toml Dockerfile AGENTS.md
+  5. git commit -m "chore: configure floo"
+  6. git push origin main
+  7. floo apps github connect owner/repo     # creates app + deploys pushed source
 
   The `floo auth login` command opens a browser. New users create an account automatically.
   In headless/CI environments, use: floo auth login --api-key <key>
 
+  Connect reads from GitHub, so push the generated config before running it.
   floo installs a GitHub webhook when you connect. After that, every
   git push triggers a build and deploy automatically.
 
@@ -44,16 +48,15 @@ floo - Golden Path
 
 ## How to Add Env Vars
 
-  floo env set KEY=value --app my-app
+  floo env set API_KEY --stdin --secret --app my-app
   floo redeploy --app my-app                # pick up new vars
 
 ## How to Add a Database
 
   Declare it in floo.app.toml:
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   Commit the declaration and push to GitHub:
   git add floo.app.toml && git commit -m "feat: add postgres"
@@ -110,7 +113,7 @@ floo - Golden Path
   Watch a deploy in progress            | floo deploys watch --app my-app
   See deploy history                    | floo deploys list --app my-app
   Roll back to a previous version       | floo deploys rollback my-app <id>
-  Set an env var                        | floo env set KEY=val --app my-app
+  Set a secret env var                 | floo env set API_KEY --stdin --secret --app my-app
   Add a custom domain                   | floo domains add example.com --app my-app (then add CNAME at DNS provider)
   Verify a custom domain                | floo domains verify example.com --app my-app
   View logs                             | floo logs query --app my-app

--- a/docs/offline/nextjs.md
+++ b/docs/offline/nextjs.md
@@ -32,14 +32,15 @@ Skipping this is the most common Next.js footgun on floo.
   dev_command = "npm run dev"
   migrate_command = "npx prisma migrate deploy"   # if you use Prisma
 
+  floo preflight
+  git add . && git commit -m "chore: configure floo"
   git push origin main
   floo apps github connect owner/my-nextjs-app
 
 ## 4. Postgres
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   # Prisma reads DATABASE_URL automatically
 

--- a/docs/offline/overview.md
+++ b/docs/offline/overview.md
@@ -14,13 +14,16 @@ observation. All source comes from GitHub - the CLI never uploads code.
 
   1. `floo auth login` - authenticate
   2. `floo init <name>` - scaffold config files (local only)
-  3. `floo apps github connect owner/repo` - connect to GitHub (triggers first deploy)
-  4. `floo apps show <name>` - see your app's URL and status
+  3. `floo preflight` - validate the config locally
+  4. Commit the generated files and run `git push origin main`
+  5. `floo apps github connect owner/repo` - create the app and deploy the pushed commit
+  6. `floo apps show <name>` - see your app's URL and status
 
+  Connect pulls from GitHub, so the generated config must be pushed first.
   After the first deploy, push to GitHub to deploy: `git push origin main`.
   Watch progress with `floo deploys watch --app <name>`.
   Use `floo redeploy` only to force a redeploy (e.g., after updating env vars).
-  Use `floo preflight` to validate config before pushing.
+  Keep using `floo preflight` to validate config before pushing.
 
   floo --help          - all available commands
   floo <command> --help - details for a specific command

--- a/docs/offline/quickstart.md
+++ b/docs/offline/quickstart.md
@@ -14,10 +14,12 @@ floo Quickstart - End-to-End Walkthrough
   1. A human installs the floo GitHub App on the org (one-time):
      https://github.com/apps/getfloo/installations/new
   2. The agent authenticates: floo auth login --api-key <key>
-  3. The agent connects: floo apps github connect owner/repo --no-browser
+  3. The agent runs floo init, edits floo.app.toml, and runs floo preflight
+  4. The agent commits and pushes the generated config to GitHub
+  5. The agent connects: floo apps github connect owner/repo --no-browser
      (--no-browser errors cleanly if the app is not installed, instead of
      trying to open a browser)
-  4. Subsequent deploys: git push triggers automatic deploys via webhook
+  6. Subsequent deploys: git push triggers automatic deploys via webhook
 
 ## 1. Install and Sign Up
 
@@ -39,9 +41,8 @@ floo Quickstart - End-to-End Walkthrough
 
   Declare auditable intent in floo.app.toml:
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   [managed.cache]
   type = "redis"
@@ -49,11 +50,12 @@ floo Quickstart - End-to-End Walkthrough
   [managed.uploads]
   type = "storage"
 
-  The first git-triggered deploy provisions missing declarations.
-  Credentials arrive as runtime env vars (Postgres: DATABASE_URL + PG*,
-  Redis: REDIS_URL, Storage: STORAGE_BUCKET). Removing a declaration does
-  not destroy stored data. Use the explicit services lifecycle only after
-  confirming the exact resource.
+  The first git-triggered deploy provisions missing declarations. The optional
+  tier field is retained for compatibility but does not change capacity.
+  Credentials arrive as runtime env vars. The default Postgres block owns
+  DATABASE_URL + PG*. Named resources own suffixed keys: REDIS_URL_CACHE,
+  STORAGE_BUCKET_UPLOADS, and STORAGE_URL_UPLOADS. Removing a declaration
+  does not perform terminal data deletion.
 
 ## 4. Validate Config
 
@@ -62,7 +64,15 @@ floo Quickstart - End-to-End Walkthrough
   Checks config files, service graph, ports, and Dockerfiles locally - no
   auth or GitHub connection required. Fix any warnings before deploying.
 
-## 5. Connect to GitHub and Deploy
+## 5. Push, Connect to GitHub, and Deploy
+
+  Commit and push the files that floo init created:
+
+  git add floo.app.toml Dockerfile AGENTS.md
+  git commit -m "chore: configure floo"
+  git push origin main
+
+  Then connect the repository:
 
   floo apps github connect owner/my-project
 
@@ -71,7 +81,8 @@ floo Quickstart - End-to-End Walkthrough
   2. Connects your GitHub repo as the source
   3. Triggers the first deploy (source pulled from GitHub, built, deployed)
 
-  Use --no-deploy to skip the automatic deploy.
+  Connect pulls source from GitHub. If the generated config is only local, the
+  first deploy cannot see it. Use --no-deploy to skip the automatic deploy.
 
 ## 6. Check Status
 

--- a/docs/offline/rails.md
+++ b/docs/offline/rails.md
@@ -35,6 +35,7 @@ promote (against prod). Rails migrations stay in sync with deploys.
 
 ## 3. Connect repo and deploy
 
+  floo preflight
   git add . && git commit -m "feat: floo config"
   git push origin main
   floo apps github connect owner/my-rails-app
@@ -77,9 +78,8 @@ path.
 
 ## 5. Add Postgres
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   git add floo.app.toml && git commit -m "feat: add postgres"
   git push origin main

--- a/docs/offline/services.md
+++ b/docs/offline/services.md
@@ -8,9 +8,10 @@ deployable. floo distinguishes two kinds by lifecycle:
                       with explicit CLI lifecycle actions for stored data
 
 The split matters: git owns auditable intent, but a deploy never infers
-permission to destroy stored data. Removing a managed-service declaration
-does not delete the resource. Destruction is always an explicit CLI action
-with confirmation for the exact app, environment, type, and name.
+permission to destroy stored data. Removing a managed-service declaration is
+a tier-3 proposed change that requires human approval and schedules a
+rescindable teardown. It does not delete provider data. Terminal deletion is
+still an explicit CLI action with confirmation for the exact resource.
 
 ## App Services (your code)
 
@@ -36,9 +37,8 @@ with confirmation for the exact app, environment, type, and name.
 
   Managed services are stateful. Declare auditable intent in floo.app.toml:
 
-    [managed.primary]
+    [managed.default]
     type = "postgres"
-    tier = "basic"
 
     [managed.cache]
     type = "redis"
@@ -46,13 +46,14 @@ with confirmation for the exact app, environment, type, and name.
     [managed.uploads]
     type = "storage"
 
-  A git-triggered deploy provisions a declared service that is missing and
-  applies supported declared settings such as tier. Omission is orphan-safe:
-  it never destroys an existing database, cache, or bucket.
+  A git-triggered deploy provisions a declared service that is missing.
+  Removing a previously deployed declaration appears in preflight as a tier-3
+  deprovision proposal. The approval gate schedules a rescindable teardown,
+  but no automated path destroys the database, cache, or bucket.
 
   Read and explicit lifecycle surfaces:
 
-    floo services show primary --app <name>       # inspect
+    floo services show default --app <name>       # inspect
     floo services list --app <name>               # see everything
     floo services add postgres --app <name>       # explicit provision
     floo services remove postgres --app <name>    # tier-3 destructive
@@ -64,9 +65,9 @@ with confirmation for the exact app, environment, type, and name.
 
   Connection credentials are injected at runtime, never stored in the
   lock file or in your repo:
-    postgres → DATABASE_URL + PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD
-    redis    → REDIS_URL
-    storage  → STORAGE_BUCKET (read/write via the GCS SDK over ADC)
+    default postgres → DATABASE_URL + PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD
+    named redis cache → REDIS_URL_CACHE
+    named storage uploads → STORAGE_BUCKET_UPLOADS + STORAGE_URL_UPLOADS
 
   Your app reaches storage with the native GCS SDK (Rails Active Storage
   `:google` in proxy mode). floo runs your container as a service account
@@ -101,7 +102,7 @@ with confirmation for the exact app, environment, type, and name.
 
   In multi-service apps, attach credentials by managed handle:
     [services.api.env]
-    managed = ["postgres:primary", "redis:cache"]
+    managed = ["postgres", "redis:cache"]
 
     [services.web.env]
     managed = []
@@ -109,22 +110,13 @@ with confirmation for the exact app, environment, type, and name.
   Single-service apps can use top-level [env] managed = [] in
   floo.service.toml to opt out of managed credentials entirely.
 
-## Managed Service Tiers
+## Managed Service Capacity
 
-  All tiers are available on every plan. Only Postgres tiers have
-  functional differences today:
-
-                Basic (default)   Standard        Performance
-  Connections   5                 15              50
-  Query timeout 30s               60s             120s
-  Idle timeout  60s               120s            300s
-  work_mem      64 MB             128 MB          256 MB
-
-  Start with basic. Upgrade to standard for multi-service apps or
-  reporting queries. Use performance for high-concurrency workloads.
-
-  Set `tier = "standard"` in the matching [managed.<name>] declaration.
-  For an explicit operational provision, inspect `floo services add --help`.
+  Managed Postgres uses one capacity profile: 25 connections and a 60-second
+  statement timeout. The optional `tier` field and `floo services add --tier`
+  remain compatible, but their value is recorded and ignored. Redis and
+  Storage also have one profile. For sustained higher Postgres concurrency,
+  contact team@getfloo.com about dedicated infrastructure.
 
 ## Legacy [postgres] / [redis] / [storage] in floo.app.toml
 
@@ -203,4 +195,4 @@ default behind an explicit development-only guard.
   floo services show <service> --app <name>  - details (no credentials in output)
   floo services add <type> --app <name>      - provision a managed service
   floo services remove <type> --app <name>   - permanently destroy (tier-3)
-  floo services migrate --app <name>         - move legacy TOML → CLI state
+  floo services migrate --app <name>         - preserve legacy resource identity in lock state

--- a/docs/offline/templates.md
+++ b/docs/offline/templates.md
@@ -22,9 +22,8 @@ floo Templates - Copy-Paste App Structures
   [app]
   name = "my-app"
 
-  [managed.primary]
+  [managed.default]
   type = "postgres"
-  tier = "basic"
 
   [services.web]
   path = "./web"
@@ -42,7 +41,7 @@ floo Templates - Copy-Paste App Structures
   migrate_command = "alembic upgrade head"
 
   [services.api.env]
-  managed = ["postgres:primary"]
+  managed = ["postgres"]
 
   [services.web.env]
   managed = []
@@ -78,14 +77,14 @@ floo Templates - Copy-Paste App Structures
 ### Deploy
 
   PREREQUISITE: Your code must be in a GitHub repo. floo pulls source
-  from GitHub - it does not upload local files. Push your code first.
+  from GitHub - it does not upload local files.
 
   1. floo auth login
   2. floo init my-app                          # from root directory
   3. floo preflight                            # validate both services
-  4. git push origin main                      # push to GitHub first
-  5. floo apps github connect owner/my-app     # triggers first deploy
-  6. floo env set DATABASE_URL=<url> --service api  # managed postgres auto-sets this
+  4. git add . && git commit -m "chore: configure floo"
+  5. git push origin main                      # push config before connecting
+  6. floo apps github connect owner/my-app     # creates app and deploys pushed source
   7. floo apps show my-app                     # get your URL
 
 ### Local Development (two terminals)
@@ -103,9 +102,9 @@ floo Templates - Copy-Paste App Structures
 ### Env Vars
 
   Backend secrets (api service only):
-    floo env set SECRET_KEY=... --service api
+    floo env set SECRET_KEY --stdin --secret --service api
 
-  DATABASE_URL is injected from the `postgres:primary` attachment.
+  DATABASE_URL is injected from the default `postgres` attachment.
 
   Frontend config (web service only, public - baked into JS bundle):
     floo env set VITE_API_URL=/api --service web
@@ -156,4 +155,7 @@ floo Templates - Copy-Paste App Structures
   Deploy:
     floo auth login
     floo init my-app
+    floo preflight
+    git add . && git commit -m "chore: configure floo"
+    git push origin main
     floo apps github connect owner/my-app

--- a/plugin/skills/floo-services/SKILL.md
+++ b/plugin/skills/floo-services/SKILL.md
@@ -27,7 +27,10 @@ Do not copy service syntax from memory or search the web until these offline sur
 
 ## Application code
 
-Consume the platform-provided connection value as-is:
+Consume the platform-provided connection value as-is. A resource named
+`default` receives the conventional unsuffixed key. Named resources receive
+suffixes, so inspect `floo services show` or `floo docs services` instead of
+guessing:
 
 - Postgres: `DATABASE_URL`
 - Redis: `REDIS_URL`

--- a/plugin/skills/floo/SKILL.md
+++ b/plugin/skills/floo/SKILL.md
@@ -28,6 +28,8 @@ Deploys are git-driven:
 - A push or merge to the connected branch deploys dev.
 - A GitHub release promotes prod.
 - The CLI never uploads source and `floo init` only writes local config.
+- `floo apps github connect` creates the app and triggers its first deploy
+  from GitHub. Run preflight, commit, and push generated config before connect.
 - `floo redeploy` is for a no-code rebuild from connected GitHub source, such as applying changed environment values.
 
 There is no normal deploy command. Validate with `floo preflight`, push through git, then observe with the current `deploys` and `logs` help surfaces.

--- a/scripts/check-external-guidance
+++ b/scripts/check-external-guidance
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: scripts/check-external-guidance <documentation-directory>" >&2
+    exit 2
+fi
+
+guidance_dir="$1"
+if [[ ! -d "$guidance_dir" ]]; then
+    echo "error: documentation directory does not exist: $guidance_dir" >&2
+    exit 2
+fi
+guidance_dir="$(cd "$guidance_dir" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cli_root="$(cd "$script_dir/.." && pwd)"
+
+FLOO_EXTERNAL_GUIDANCE_DIR="$guidance_dir" \
+    cargo test --manifest-path "$cli_root/Cargo.toml" first_party_guidance_matches_clap

--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -28,6 +28,8 @@ Deploys are git-driven:
 - A push or merge to the connected branch deploys dev.
 - A GitHub release promotes prod.
 - The CLI never uploads source and `floo init` only writes local config.
+- `floo apps github connect` creates the app and triggers its first deploy
+  from GitHub. Run preflight, commit, and push generated config before connect.
 - `floo redeploy` is for a no-code rebuild from connected GitHub source, such as applying changed environment values.
 
 There is no normal deploy command. Validate with `floo preflight`, push through git, then observe with the current `deploys` and `logs` help surfaces.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -887,10 +887,10 @@ pub enum EnvCommands {
 
     /// Get an environment variable's plaintext value.
     ///
-    /// Secret-shaped values (by key name or value content) are refused unless
-    /// you pass `--reveal-secrets`, in both human and `--json` output, so a
-    /// secret is never echoed to a terminal or transcript by accident. Plain,
-    /// non-secret values print without the flag.
+    /// Human output refuses secret-shaped values unless you pass
+    /// `--reveal-secrets`. JSON output redacts them by default and stamps the
+    /// envelope with `contains_secrets: true`; reveal only when you control the
+    /// destination. Plain, non-secret values print without the flag.
     Get {
         /// Environment variable key.
         key: String,

--- a/src/cli/guidance_tests.rs
+++ b/src/cli/guidance_tests.rs
@@ -26,6 +26,12 @@ fn collect_files(dir: &Path, extension: &str, files: &mut Vec<PathBuf>) {
     }
 }
 
+fn collect_markdown_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for extension in ["md", "mdx", "txt"] {
+        collect_files(dir, extension, files);
+    }
+}
+
 fn source_name(path: &Path) -> String {
     path.strip_prefix(env!("CARGO_MANIFEST_DIR"))
         .unwrap_or(path)
@@ -80,10 +86,33 @@ fn push_occurrences(
             remainder = &remainder[start + "floo ".len()..];
             continue;
         }
-        let delimiter = remainder[..start]
+        let prefix = &remainder[..start];
+        let delimiter = prefix
             .chars()
             .last()
             .filter(|character| matches!(character, '`' | '\''));
+        // Preserve the separating whitespace: the suffixes below deliberately
+        // include it so words such as "rerun" do not match "run ".
+        let normalized_prefix = prefix.to_ascii_lowercase();
+        let prose_guidance = [
+            "run ",
+            "use ",
+            "try ",
+            "with ",
+            "then ",
+            "command ",
+            "invocation ",
+            "rerun ",
+            "execute ",
+        ]
+        .iter()
+        .any(|suffix| normalized_prefix.ends_with(suffix));
+        let line_command = text.trim_start().starts_with("floo ");
+        let path_command = prefix.ends_with('/');
+        if delimiter.is_none() && !prose_guidance && !line_command && !path_command {
+            remainder = &remainder[start + "floo ".len()..];
+            continue;
+        }
         let occurrence = &remainder[start..];
         let mut end = occurrence[5..]
             .find("floo ")
@@ -233,6 +262,7 @@ fn command_column(invocation: &str) -> &str {
                 || remainder.starts_with("- ")
                 || remainder.starts_with('|')
                 || remainder.starts_with("&&")
+                || remainder.starts_with('>')
             {
                 return &invocation[..spaces_start];
             }
@@ -274,7 +304,10 @@ fn normalized_argv(invocation: &str) -> Result<Vec<String>, String> {
                 '`' | '\'' | '"' | '(' | ')' | '[' | ']' | ',' | '.' | ';' | '*'
             )
         });
-        if token.is_empty() || matches!(token, "|" | "||" | "&&" | "#") || token.starts_with("2>") {
+        if token.is_empty()
+            || matches!(token, "|" | "||" | "&&" | "#" | ">" | ">>")
+            || token.starts_with("2>")
+        {
             break;
         }
         argv.push(replace_placeholders(token, argv.last().map(String::as_str)));
@@ -379,7 +412,16 @@ fn first_party_guidance_matches_clap() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut markdown = vec![root.join("README.md")];
     for directory in ["docs/offline", "skills", "plugin/skills"] {
-        collect_files(&root.join(directory), "md", &mut markdown);
+        collect_markdown_files(&root.join(directory), &mut markdown);
+    }
+    if let Some(external_root) = std::env::var_os("FLOO_EXTERNAL_GUIDANCE_DIR") {
+        let external_root = PathBuf::from(external_root);
+        assert!(
+            external_root.is_dir(),
+            "FLOO_EXTERNAL_GUIDANCE_DIR is not a directory: {}",
+            external_root.display()
+        );
+        collect_markdown_files(&external_root, &mut markdown);
     }
     markdown.sort();
     markdown.dedup();

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -374,6 +374,38 @@ mod tests {
         assert!(QUICKSTART.contains("init"));
         assert!(QUICKSTART.contains("github connect"));
         assert!(QUICKSTART.contains("apps show"));
+        let preflight = QUICKSTART
+            .find("floo preflight --json")
+            .expect("quickstart must validate before the first deploy");
+        let push = QUICKSTART
+            .find("git push origin main")
+            .expect("quickstart must push generated config");
+        let connect = QUICKSTART
+            .find("floo apps github connect owner/my-project")
+            .expect("quickstart must connect GitHub");
+        assert!(preflight < push && push < connect);
+    }
+
+    #[test]
+    fn test_first_deploy_guidance_pushes_generated_config_before_connect() {
+        for (name, content) in [
+            ("overview", OVERVIEW),
+            ("golden-path", HOWTO),
+            ("templates", TEMPLATES),
+            ("rails", RAILS),
+            ("nextjs", NEXTJS),
+            ("fastapi", FASTAPI),
+            ("django", DJANGO),
+            ("express", EXPRESS),
+        ] {
+            let push = content
+                .find("git push origin main")
+                .unwrap_or_else(|| panic!("{name} must push the generated config"));
+            let connect = content
+                .find("floo apps github connect")
+                .unwrap_or_else(|| panic!("{name} must connect GitHub"));
+            assert!(push < connect, "{name} must push before GitHub connect");
+        }
     }
 
     #[test]
@@ -454,12 +486,15 @@ mod tests {
             ("templates", TEMPLATES),
         ] {
             assert!(
-                content.contains("[managed.primary]"),
-                "{name} must use the current named managed-service declaration"
+                content.contains("[managed.default]"),
+                "{name} must use the default managed-service declaration when promising conventional env names"
             );
         }
-        assert!(SERVICES.contains("does not delete the resource"));
-        assert!(CONFIG.contains("Removing a declaration never"));
+        assert!(SERVICES.contains("does not delete provider data"));
+        assert!(CONFIG.contains("Removing a deployed declaration"));
+        assert!(SERVICES.contains("value is recorded and ignored"));
+        assert!(QUICKSTART.contains("REDIS_URL_CACHE"));
+        assert!(QUICKSTART.contains("STORAGE_BUCKET_UPLOADS"));
         assert!(!QUICKSTART.contains("authored via the CLI, not floo.app.toml"));
     }
 
@@ -500,7 +535,7 @@ mod tests {
     fn test_rails_topic_covers_full_journey() {
         // Stack-journey shape: deploy → local dev → DB → auth → domain
         assert!(RAILS.contains("floo init"));
-        assert!(RAILS.contains("[managed.primary]"));
+        assert!(RAILS.contains("[managed.default]"));
         assert!(RAILS.contains("access_mode = \"accounts\""));
         assert!(RAILS.contains("domains add"));
         assert!(RAILS.contains("floo dev"));
@@ -537,7 +572,7 @@ mod tests {
                 "{stack}: missing 'floo init'"
             );
             assert!(
-                content.contains("[managed.primary]"),
+                content.contains("[managed.default]"),
                 "{stack}: missing the managed Postgres declaration"
             );
             assert!(

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -1003,7 +1003,7 @@ pub fn get(key: &str, app_flag: Option<&str>, service_flag: Option<&str>, env: &
             // recovery paths instead of leaving a bare API error.
             let suggestion = if e.code == "ENV_VAR_WRITE_ONLY" {
                 Some(format!(
-                    "Set a new value with `floo env set {key}=<value>` or remove it with `floo env unset {key}`."
+                    "Set a new value with `floo env set {key} --stdin --secret` or remove it with `floo env unset {key}`."
                 ))
             } else {
                 None

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -23,10 +23,11 @@ use crate::project_config::{self, AppFileAppSection, AppFileConfig, AppServiceEn
 /// becomes noise. Anchor to canonical doc URLs for depth.
 const APP_TOML_HEADER: &str = r#"# floo.app.toml — see https://getfloo.com/docs/reference/config-spec.md
 #
-# Deploys happen on `git push`. After `floo apps github connect`, every
-# push to your default branch builds and deploys to the dev environment
-# automatically (no manual deploy command needed). Cutting a GitHub release
-# promotes that build to production. See
+# Commit and push this file before `floo apps github connect`. Connect creates
+# the floo app and triggers the first deploy from the pushed GitHub source.
+# After that, every push to your default branch builds and deploys to the dev
+# environment automatically (no manual deploy command needed). Cutting a
+# GitHub release promotes that build to production. See
 # https://getfloo.com/docs/guides/golden-path.md.
 #
 # Common knobs to add when you need them (under [app], applies to every env):
@@ -190,9 +191,15 @@ captures the floo-specific gotchas that aren't obvious from the code.
 - **Run `floo preflight` before every deploy.** Catches config drift,
   missing managed-service env vars, runtime detection issues, and
   destructive plan changes — most deploy failures are preventable here.
-- **Read the latest docs at `https://getfloo.com/docs/*.md`.** The
-  Markdown URLs are agent-friendly. `floo docs <topic>` also prints
-  cheatsheets locally.
+- **Discover the installed CLI locally first.** Run `floo commands
+  --json`, `floo <command> --help`, then `floo docs <topic> --json`.
+  These surfaces match the installed version. Use the hosted docs for
+  longer explanations after checking them.
+- **Commit before connecting GitHub.** `floo apps github connect`
+  creates the floo app and triggers its first deploy from GitHub. Run
+  preflight, commit, and push before connecting. For a fresh app,
+  declare managed services with `[managed.<name>]` in `floo.app.toml`;
+  `floo services add` requires an existing app.
 - **Deploy by pushing to GitHub.** `git push` to your default branch
   triggers a dev deploy; cutting a GitHub release promotes to prod.
   Don't shell out to `gcloud run deploy` — it bypasses the floo
@@ -403,7 +410,7 @@ fn init_non_interactive(
         "dockerfile_generated": dockerfile_generated,
         "agents_md_written": agents_md_written,
         "hint": "Edit floo.app.toml to configure your services — run 'floo docs config' for the schema",
-        "next_step": "Connect GitHub with 'floo apps github connect <owner/repo>'. Every git push to your default branch then deploys to dev automatically.",
+        "next_step": "Run 'floo preflight --json', commit and push the generated files, then connect GitHub with 'floo apps github connect <owner/repo>'.",
     });
 
     // Add suggestion when Dockerfile was not generated due to low confidence
@@ -414,9 +421,10 @@ fn init_non_interactive(
     }
 
     if !output::is_json_mode() {
-        eprintln!("  Next: 'floo apps github connect <owner/repo>' wires the repo so");
-        eprintln!("        every 'git push' to your default branch deploys to dev.");
-        eprintln!("  Edit floo.app.toml to configure services; run 'floo preflight' to validate.");
+        eprintln!("  Next: edit floo.app.toml, then run 'floo preflight'.");
+        eprintln!("        Commit and push these files before running");
+        eprintln!("        'floo apps github connect <owner/repo>'.");
+        eprintln!("        Connect deploys the pushed commit; later pushes deploy automatically.");
     }
     output::success(&format!("Initialized app '{app_name}'."), Some(json_data));
 }
@@ -562,8 +570,9 @@ fn init_interactive(
         output::info("Wrote AGENTS.md (agent operating notes)", None);
     }
 
-    eprintln!("  Next: 'floo apps github connect <owner/repo>' wires the repo so");
-    eprintln!("        every 'git push' to your default branch deploys to dev.");
-    eprintln!("  Edit floo.app.toml to configure services; run 'floo preflight' to validate.");
+    eprintln!("  Next: edit floo.app.toml, then run 'floo preflight'.");
+    eprintln!("        Commit and push these files before running");
+    eprintln!("        'floo apps github connect <owner/repo>'.");
+    eprintln!("        Connect deploys the pushed commit; later pushes deploy automatically.");
     output::success(&format!("Initialized app '{app_name}'."), None);
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -437,8 +437,10 @@ fn test_update_help() {
 
 #[test]
 fn test_deploy_not_authenticated() {
+    let project = tempfile::TempDir::new().unwrap();
     floo()
         .arg("redeploy")
+        .current_dir(project.path())
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -449,8 +451,10 @@ fn test_deploy_not_authenticated() {
 
 #[test]
 fn test_deploy_json_not_authenticated() {
+    let project = tempfile::TempDir::new().unwrap();
     floo()
         .args(["--json", "redeploy"])
+        .current_dir(project.path())
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .failure()
@@ -977,11 +981,20 @@ fn test_init_creates_config_json() {
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""app_name":"myapp"#))
+        .stdout(predicate::str::contains("floo preflight --json"))
+        .stdout(predicate::str::contains("commit and push"))
+        .stdout(predicate::str::contains("floo apps github connect"))
         .stdout(predicate::str::contains(r#""success":true"#));
 
     // Service is now inline in floo.app.toml — no separate floo.service.toml
     assert!(project.path().join("floo.app.toml").exists());
     assert!(!project.path().join("floo.service.toml").exists());
+
+    let agents = std::fs::read_to_string(project.path().join("AGENTS.md")).unwrap();
+    assert!(agents.contains("floo commands\n  --json"));
+    assert!(agents.contains("floo docs <topic> --json"));
+    assert!(agents.contains("commit, and push before connecting"));
+    assert!(!agents.contains("Read the latest docs"));
 }
 
 #[test]
@@ -1014,10 +1027,14 @@ fn test_init_writes_header_with_access_mode_and_autodeploy_signal() {
         toml.starts_with("# floo.app.toml"),
         "header should lead the file"
     );
-    // git push auto-deploy contract is mentioned by name.
+    // The push auto-deploy contract is explicit.
     assert!(
-        toml.contains("git push"),
-        "git push contract must be in header"
+        toml.contains("Commit and push"),
+        "push contract must be in header"
+    );
+    assert!(
+        toml.contains("Commit and push this file before `floo apps github connect`"),
+        "header must put the pushed source before the first connect"
     );
     // access_mode is shown under [app] — the placement that actually applies
     // on push today. Per-env overrides via [environments.<name>] are parsed


### PR DESCRIPTION
## Summary
- correct first-deploy guidance to preflight, commit, and push before GitHub connect
- align offline docs and bundled agent skills with declarative managed services, current capacity, env-key mapping, and safe secret handling
- validate public and bundled Markdown command examples against the shipped clap tree
- clarify env secret output behavior and make no-config integration tests independent of parent directories

## Verification
- `./scripts/test`
- cross-repository public-doc validation against getfloo/floo-docs (66 pages)
- internal knowledge-base command validation