### PR TITLE
fix: keep floo lowercase in CLI output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Repo Is
 
-This is the **open-source Rust CLI** for [Floo](https://getfloo.com) — deploy, manage, and observe web apps from the terminal. The CLI is a thin HTTP client that calls the Floo API. Licensed under MIT.
+This is the **open-source Rust CLI** for [floo](https://getfloo.com). It deploys, manages, and observes web apps from the terminal. The CLI is a thin HTTP client that calls the floo API. Licensed under MIT.
 
 ## Development Commands
 
@@ -83,6 +83,7 @@ Packs source into `.tar.gz`, respects `.flooignore`. 500MB size limit.
 ## Key Conventions
 
 - Rust 2021 edition, **cargo** for build/deps, **clap** derive for CLI
+- Always write the product name as `floo` in user-visible text.
 - Lint: **clippy** (`-D warnings`). Format: **cargo fmt**. Test: **`./scripts/test`** (canonical entry point; wraps fmt + clippy + `cargo test` and self-heals the #204 corrupt-harness artifact class)
 - No `println!` — use `output` module functions
 - No `unwrap()` in production paths — use `?` operator

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Floo Contributors
+Copyright (c) 2026 floo contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Floo CLI installer
+# floo CLI installer
 # Usage: curl -fsSL https://getfloo.com/install.sh | bash
 
 set -euo pipefail

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "floo",
   "version": "0.1.0",
-  "description": "Floo deployment platform — CLI usage, managed services, and security patterns for AI agents",
+  "description": "CLI guidance for the floo deployment platform, including managed services and security patterns for agents",
   "author": {
-    "name": "Floo",
+    "name": "floo",
     "url": "https://github.com/getfloo"
   },
   "repository": "https://github.com/getfloo/floo-cli",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,7 @@ pub enum Commands {
         period: String,
     },
 
-    /// Initialize a new Floo project (creates config files).
+    /// Initialize a new floo project (creates config files).
     #[command(after_help = "\
 Examples:
   floo init my-app                         Scaffold config in current directory
@@ -535,7 +535,7 @@ pub enum LogsSubcommands {
 
 #[derive(Subcommand)]
 pub enum AuthCommands {
-    /// Authenticate with the Floo API (opens browser).
+    /// Authenticate with the floo API (opens browser).
     Login {
         /// Use an existing API key instead of browser auth.
         #[arg(long)]
@@ -551,7 +551,7 @@ pub enum AuthCommands {
     Whoami,
     /// Print the current API key to stdout.
     Token,
-    /// Create a new Floo account.
+    /// Create a new floo account.
     Register {
         /// Account email address.
         email: String,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -2667,7 +2667,7 @@ fn render_security_findings_human(findings: &[PreflightFinding]) {
 /// Print the auto-deploy contract and the final "ready" line. Only called when
 /// the config has no errors; the warning count keeps a clean green honest.
 fn print_preflight_ready(findings: &[PreflightFinding]) {
-    // Closes feedback c9b70eb5: "no obvious signal anywhere in the Floo
+    // Closes feedback c9b70eb5: "no obvious signal anywhere in the floo
     // workflow that dev auto-deploys on GitHub push." The CLI is the surface
     // the user is in front of right before pushing — surfacing the auto-deploy
     // contract here means they don't have to leave for the docs.

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -125,7 +125,7 @@ pub fn connect(
             if no_browser {
                 let setup_url = manual_setup_url(&client, install_url);
                 output::error(
-                    &format!("Floo GitHub App not installed on \"{owner}\"."),
+                    &format!("floo GitHub App not installed on \"{owner}\"."),
                     &ErrorCode::from_api("GITHUB_APP_NOT_INSTALLED"),
                     Some(&format!(
                         "Open the GitHub App setup URL and grant access to \"{repo}\": {setup_url}\n\
@@ -136,7 +136,7 @@ pub fn connect(
             }
 
             if !output::is_json_mode() {
-                output::warn(&format!("Floo GitHub App not installed on \"{owner}\""));
+                output::warn(&format!("floo GitHub App not installed on \"{owner}\""));
             }
 
             run_installation_flow(&client, install_url, &rerun_command);
@@ -170,7 +170,7 @@ pub fn connect(
             if no_browser {
                 let setup_url = manual_setup_url(&client, install_url);
                 output::error(
-                    &format!("Floo GitHub App does not have access to \"{repo}\"."),
+                    &format!("floo GitHub App does not have access to \"{repo}\"."),
                     &ErrorCode::from_api("GITHUB_REPO_NOT_IN_INSTALLATION"),
                     Some(&repo_access_manual_suggestion(
                         repo,
@@ -184,7 +184,7 @@ pub fn connect(
 
             if !output::is_json_mode() {
                 output::warn(&format!(
-                    "Floo GitHub App does not have access to \"{repo}\"."
+                    "floo GitHub App does not have access to \"{repo}\"."
                 ));
                 output::info("Opening GitHub App setup to grant repo access...", None);
             }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -178,7 +178,7 @@ fn init_dry_run(project_path: &std::path::Path, name: Option<String>, detection:
 /// The content mirrors the public app-auth checklist on getfloo.com so
 /// the same advice is available to a coding agent reading local files
 /// AND to a human reading the docs site. Closes feedback 9494ea44
-/// (floo-artifact, 2026-04-30): "Floo should publish an agent-safe
+/// (floo-artifact, 2026-04-30): "floo should publish an agent-safe
 /// checklist/template for apps using accounts mode... could live in
 /// docs and/or be generated into AGENTS.md by floo init."
 const AGENTS_MD_TEMPLATE: &str = r#"# Agent operating notes

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -188,14 +188,14 @@ pub fn update(version: Option<&str>) {
 
     if !output::is_json_mode() {
         let label = version.unwrap_or("latest");
-        output::info(&format!("Checking for Floo updates ({label})..."), None);
+        output::info(&format!("Checking for floo updates ({label})..."), None);
     }
 
     match updater::run_update(version) {
         Ok(result) => {
             let refreshed = refresh_and_announce_skills();
             output::success(
-                &format!("Updated Floo to {}.", result.version),
+                &format!("Updated floo to {}.", result.version),
                 Some(serde_json::json!({
                     "version": result.version,
                     "path": result.install_path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,7 +107,7 @@ pub fn config_dir_name() -> &'static str {
     }
 }
 
-/// Returns the Floo config directory. Checks `FLOO_CONFIG_DIR` first,
+/// Returns the floo config directory. Checks `FLOO_CONFIG_DIR` first,
 /// falls back to `$HOME/.floo-local` or `$HOME/.floo` based on binary name.
 pub(crate) fn config_dir() -> PathBuf {
     if let Ok(dir) = env::var("FLOO_CONFIG_DIR") {

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -211,7 +211,7 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
             return Err(FlooError::with_suggestion(
                 ErrorCode::NoDeployableServices,
                 format!(
-                    "{} has no deployable services (only Floo-managed services like postgres/redis).",
+                    "{} has no deployable services (only floo-managed services like postgres/redis).",
                     super::APP_CONFIG_FILE,
                 ),
                 "Add a [services.<name>] block with type, port, and path. Run 'floo docs config' for the schema.".to_string(),

--- a/tests/brand_case_test.rs
+++ b/tests/brand_case_test.rs
@@ -1,0 +1,60 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CAPITALIZED_PRODUCT_NAME: &str = concat!("Fl", "oo");
+
+fn collect_files(directory: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).expect("read repository directory") {
+        let entry = entry.expect("read repository entry");
+        let path = entry.path();
+        let file_name = entry.file_name();
+
+        if path.is_dir() {
+            if file_name != ".git" && file_name != "target" {
+                collect_files(&path, files);
+            }
+        } else if path.is_file() {
+            files.push(path);
+        }
+    }
+}
+
+fn has_non_protocol_product_name(line: &str) -> bool {
+    line.match_indices(CAPITALIZED_PRODUCT_NAME)
+        .any(|(index, product_name)| {
+            let bytes = line.as_bytes();
+            let previous = bytes[..index].last().copied();
+            let next = bytes[index + product_name.len()..].first().copied();
+            let is_word_byte = |byte: u8| byte.is_ascii_alphanumeric() || byte == b'_';
+            let is_standalone = previous.is_none_or(|byte| !is_word_byte(byte))
+                && next.is_none_or(|byte| !is_word_byte(byte));
+
+            is_standalone && !line[..index].ends_with("X-")
+        })
+}
+
+#[test]
+fn product_name_is_lowercase_across_the_cli_repository() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    collect_files(root, &mut files);
+
+    let mut violations = Vec::new();
+    for path in files {
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for (line_index, line) in contents.lines().enumerate() {
+            if has_non_protocol_product_name(line) {
+                let relative = path.strip_prefix(root).unwrap_or(&path);
+                violations.push(format!("{}:{}: {line}", relative.display(), line_index + 1));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "the floo product name must be lowercase; protocol header names are the only exception:\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -241,7 +241,7 @@ fn test_auth_login_help() {
         .args(["auth", "login", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Authenticate with the Floo API"));
+        .stdout(predicate::str::contains("Authenticate with the floo API"));
 }
 
 /// Regression: the dev stack has no WorkOS, so `floo-dev auth login`
@@ -271,7 +271,7 @@ fn test_auth_register_help() {
         .args(["auth", "register", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Create a new Floo account"));
+        .stdout(predicate::str::contains("Create a new floo account"));
 }
 
 #[test]
@@ -958,7 +958,7 @@ fn test_init_help() {
         .args(["init", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Initialize a new Floo project"));
+        .stdout(predicate::str::contains("Initialize a new floo project"));
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5441,7 +5441,7 @@ fn test_update_json_release_lookup_failure() {
 }
 
 #[test]
-fn test_update_json_success() {
+fn test_update_human_and_json_success() {
     let Some(asset_name) = update_asset_name() else {
         return;
     };
@@ -5506,6 +5506,18 @@ fn test_update_json_success() {
         .success()
         .stdout(predicate::str::contains(r#""success":true"#))
         .stdout(predicate::str::contains(r#""version":"v0.2.0""#));
+
+    floo()
+        .args(["update"])
+        .env("FLOO_UPDATE_API_BASE", format!("{}/releases", server.url()))
+        .env("FLOO_UPDATE_TARGET_PATH", install_path.as_os_str())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Checking for floo updates (latest)...",
+        ))
+        .stderr(predicate::str::contains("Updated floo to v0.2.0."))
+        .stderr(predicate::str::contains(concat!("Fl", "oo")).not());
 
     assert_eq!(
         std::fs::read(install_path).unwrap(),


### PR DESCRIPTION
## Summary

- lowercase every floo product-name occurrence across CLI output, help, errors, plugin metadata, and repository guidance
- preserve the case-sensitive X-Floo-* HTTP header contract
- add a repository-wide brand-case guard and direct update-output coverage

## Validation

- FLOO_TEST_CARGO=/Users/patrickdonohoe/.cargo/bin/cargo ./scripts/test
- 827 tests passed; formatting and Clippy passed