### PR TITLE
fix: validate feedback context length

### DIFF
--- a/docs/offline/feedback.md
+++ b/docs/offline/feedback.md
@@ -28,6 +28,7 @@ the CLI. Feedback is routed to the floo team in real-time.
 
 ## Context
 
-  Use --context to attach extra detail (error output, steps to reproduce):
+  Use --context to attach up to 10,000 characters of extra detail (error
+  output, steps to reproduce). The CLI validates the length before submitting:
 
   floo feedback --category bug "deploy fails" --context "error: no Dockerfile found"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -384,7 +384,7 @@ Examples:
         #[arg(short, long)]
         app: Option<String>,
 
-        /// Extra context (error output, steps to reproduce, etc.).
+        /// Extra context, up to 10,000 characters (error output, reproduction steps, etc.).
         #[arg(long)]
         context: Option<String>,
     },

--- a/src/commands/feedback.rs
+++ b/src/commands/feedback.rs
@@ -3,7 +3,28 @@ use std::process;
 use crate::errors::ErrorCode;
 use crate::output;
 
+pub const MAX_FEEDBACK_CONTEXT_LENGTH: usize = 10_000;
+
+fn validate_context_length(context: Option<&str>) -> Result<(), usize> {
+    let actual_length = context.map(str::chars).map(Iterator::count).unwrap_or(0);
+    if actual_length > MAX_FEEDBACK_CONTEXT_LENGTH {
+        return Err(actual_length);
+    }
+    Ok(())
+}
+
 pub fn feedback(message: &str, category: &str, app: Option<&str>, context: Option<&str>) {
+    if let Err(actual_length) = validate_context_length(context) {
+        output::error(
+            &format!(
+                "Feedback context is {actual_length} characters; the maximum is {MAX_FEEDBACK_CONTEXT_LENGTH}."
+            ),
+            &ErrorCode::Other("FEEDBACK_CONTEXT_TOO_LONG".to_string()),
+            None,
+        );
+        process::exit(1);
+    }
+
     super::require_auth();
     let client = super::init_client(None);
 
@@ -19,5 +40,22 @@ pub fn feedback(message: &str, category: &str, app: Option<&str>, context: Optio
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
             process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_length_validation_counts_unicode_characters() {
+        let at_limit = "é".repeat(MAX_FEEDBACK_CONTEXT_LENGTH);
+        let over_limit = format!("{at_limit}é");
+
+        assert_eq!(validate_context_length(Some(&at_limit)), Ok(()));
+        assert_eq!(
+            validate_context_length(Some(&over_limit)),
+            Err(MAX_FEEDBACK_CONTEXT_LENGTH + 1)
+        );
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -96,6 +96,40 @@ fn test_no_args_shows_help() {
         .stderr(predicate::str::contains("Usage: floo"));
 }
 
+#[test]
+fn test_feedback_help_documents_context_limit() {
+    floo()
+        .args(["feedback", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to 10,000 characters"));
+}
+
+#[test]
+fn test_feedback_rejects_oversized_context_before_auth_or_request() {
+    let context = "x".repeat(10_001);
+
+    floo()
+        .env("FLOO_NO_UPDATE_CHECK", "1")
+        .args([
+            "--json",
+            "feedback",
+            "Detailed report",
+            "--context",
+            &context,
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"FEEDBACK_CONTEXT_TOO_LONG""#,
+        ))
+        .stdout(predicate::str::contains(
+            "Feedback context is 10001 characters; the maximum is 10000.",
+        ))
+        .stdout(predicate::str::contains(context.clone()).not())
+        .stderr(predicate::str::is_empty());
+}
+
 // --- Offline documentation ---
 
 fn offline_docs() -> Command {


### PR DESCRIPTION
## Summary
- document the 10,000-character context limit in command help and offline guidance
- reject oversized context before authentication or network work
- report the actual and maximum character counts without echoing the context

## Tests
- ./scripts/test

Coordinated API boundary: getfloo/floo#2192

Closes getfloo/floo#2190