### PR TITLE
fix: add floo apps github setup to re-mint the install handshake

### DIFF
--- a/docs/offline/quickstart.md
+++ b/docs/offline/quickstart.md
@@ -4,16 +4,25 @@ floo Quickstart - End-to-End Walkthrough
 
   - Your code must be in a **GitHub repository** (public or private).
     floo pulls source from GitHub - it does not upload local files.
-  - The floo GitHub App must be installed on your GitHub org/account.
-    The CLI opens GitHub to grant access during `floo apps github connect`.
+  - The floo GitHub App must be installed on your GitHub org/account, and
+    installed through a link floo minted. The CLI opens GitHub to grant access
+    during `floo apps github connect`, and that redirect is what binds the
+    installation to your floo org.
+
+    Installing from github.com directly skips the redirect, so floo ends up
+    with no binding: GitHub shows the App installed while every connect fails
+    with GITHUB_INSTALLATION_NOT_AUTHORIZED. Run `floo apps github setup` to
+    mint a fresh link and recover — no need to uninstall anything.
 
 ## Agents & CI (headless environments)
 
   Agents and CI pipelines can deploy without a browser:
 
-  1. A human installs the floo GitHub App on the org (one-time):
-     https://github.com/apps/getfloo/installations/new
-  2. The agent authenticates: floo auth login --api-key <key>
+  1. The agent authenticates: floo auth login --api-key <key>
+  2. The agent mints an install link: floo apps github setup --no-browser
+     A human opens that link once and grants access to the repo. Use this link
+     rather than github.com/apps/getfloo — only the minted link carries the
+     handshake that binds the installation to your floo org.
   3. The agent runs floo init, edits floo.app.toml, and runs floo preflight
   4. The agent commits and pushes the generated config to GitHub
   5. The agent connects: floo apps github connect owner/repo --no-browser

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -823,6 +823,18 @@ pub enum GitHubCommands {
         #[arg(short, long)]
         app: Option<String>,
     },
+
+    /// Link the floo GitHub App to this org, whether or not it is installed.
+    ///
+    /// `connect` only mints a setup link when the App is NOT installed, so an
+    /// App installed straight from GitHub's UI — or installed more than 15
+    /// minutes before the connect — left the org with no way to link it
+    /// (getfloo/floo#2189). This always mints a fresh link.
+    Setup {
+        /// Never open a browser (for agents/CI). Prints the link instead.
+        #[arg(long)]
+        no_browser: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2299,6 +2311,7 @@ pub fn run() {
                 ),
                 GitHubCommands::Disconnect { app } => commands::github::disconnect(app.as_deref()),
                 GitHubCommands::Status { app } => commands::github::status(app.as_deref()),
+                GitHubCommands::Setup { no_browser } => commands::github::setup(no_browser),
             },
             AppsCommands::Password { app_name } => commands::apps::show_password(&app_name),
             AppsCommands::Invite { email, app, role } => {

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -13,6 +13,7 @@ const GITHUB_WAIT_TIMEOUT: Duration = Duration::from_secs(900);
 const INSTALLATION_POLL_INTERVAL: Duration = Duration::from_secs(3);
 const REPO_ACCESS_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const APPROVAL_HINT_AFTER: Duration = Duration::from_secs(60);
+const DEFAULT_INSTALL_URL: &str = "https://github.com/apps/getfloo/installations/new";
 
 pub fn connect(
     repo: &str,
@@ -118,7 +119,7 @@ pub fn connect(
                 .as_ref()
                 .and_then(|v| v.get("install_url"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("https://github.com/apps/getfloo/installations/new");
+                .unwrap_or(DEFAULT_INSTALL_URL);
 
             let owner = repo.split('/').next().unwrap_or(repo);
 
@@ -155,7 +156,7 @@ pub fn connect(
                 .as_ref()
                 .and_then(|v| v.get("install_url"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("https://github.com/apps/getfloo/installations/new");
+                .unwrap_or(DEFAULT_INSTALL_URL);
             let settings_url = e
                 .extra
                 .as_ref()
@@ -209,6 +210,13 @@ pub fn connect(
                 "GITHUB_REPO_NOT_ACCESSIBLE" => {
                     Some("Ensure the GitHub App is installed on the repo's organization.")
                 }
+                // Installed on GitHub, unlinked in floo. Without this the error
+                // named no command at all and the only exit anyone found was
+                // uninstalling the App (getfloo/floo#2189).
+                "GITHUB_INSTALLATION_NOT_AUTHORIZED" => Some(
+                    "The App is installed on GitHub but not linked to this floo org. \
+                     Link it: floo apps github setup",
+                ),
                 _ => None,
             };
             output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
@@ -315,6 +323,50 @@ pub fn disconnect(app: Option<&str>) {
     output::success(
         &format!("Disconnected {name} from GitHub."),
         Some(serde_json::json!({"app": name})),
+    );
+}
+
+/// Mint a fresh GitHub App setup link regardless of install state.
+///
+/// `connect` mints one only on the `GITHUB_APP_NOT_INSTALLED` and
+/// `GITHUB_REPO_NOT_IN_INSTALLATION` branches. Once the App IS installed but
+/// floo holds no binding for the org, every connect returns
+/// `GITHUB_INSTALLATION_NOT_AUTHORIZED` and nothing re-mints the handshake —
+/// the dead end in getfloo/floo#2189, whose only exit was uninstalling the App
+/// from the GitHub org. This command is that exit.
+pub fn setup(no_browser: bool) {
+    super::require_auth();
+    let client = super::init_client(None);
+
+    // In JSON mode, never open a browser — agents can't use one.
+    let no_browser = no_browser || output::is_json_mode();
+    let setup_url = begin_setup_or_exit(&client, DEFAULT_INSTALL_URL);
+
+    if no_browser {
+        // The URL goes in the message, not only the JSON payload: human mode
+        // prints the message and drops the data, so a payload-only link is an
+        // instruction to open nothing.
+        output::success(
+            &format!(
+                "Open this link to link the floo GitHub App to your org:\n  {setup_url}\n\n\
+                 Then run: floo apps github connect <owner>/<repo>"
+            ),
+            Some(serde_json::json!({
+                "setup_url": setup_url,
+                "next": "floo apps github connect <owner>/<repo>",
+            })),
+        );
+        return;
+    }
+
+    run_installation_flow(&client, DEFAULT_INSTALL_URL, "floo apps github setup");
+
+    output::success(
+        "Linked the floo GitHub App to your org.",
+        Some(serde_json::json!({
+            "linked": true,
+            "next": "floo apps github connect <owner>/<repo>",
+        })),
     );
 }
 

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -340,9 +340,12 @@ pub fn setup(no_browser: bool) {
 
     // In JSON mode, never open a browser — agents can't use one.
     let no_browser = no_browser || output::is_json_mode();
-    let setup_url = begin_setup_or_exit(&client, DEFAULT_INSTALL_URL);
 
     if no_browser {
+        // Minted here only on this branch: run_installation_flow begins its own
+        // session, so hoisting this above the `if` would burn two setup tokens
+        // per interactive run and leave the first orphaned in Redis.
+        let setup_url = begin_setup_or_exit(&client, DEFAULT_INSTALL_URL);
         // The URL goes in the message, not only the JSON payload: human mode
         // prints the message and drops the data, so a payload-only link is an
         // instruction to open nothing.

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -6928,3 +6928,108 @@ fn test_org_analytics_renders_rejection_breakdown() {
         .stderr(predicate::str::contains("Gateway Rejections"))
         .stderr(predicate::str::contains("edge_policy"));
 }
+
+// ─────────────── GitHub setup re-mint (getfloo/floo#2189) ───────────────
+//
+// `connect` mints a setup link only when the App is NOT installed. Once it IS
+// installed but floo holds no binding for the org, every connect returned
+// GITHUB_INSTALLATION_NOT_AUTHORIZED and no surface re-minted the handshake.
+// The only exit anyone found was uninstalling the App from the GitHub org.
+
+#[test]
+fn test_github_setup_mints_a_link_regardless_of_install_state() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let begin = server
+        .mock("POST", "/v1/github/setup/begin")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"install_url":"https://api.floo.dev/v1/github/setup/install?setup_token=tok-123"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "apps", "github", "setup"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("setup_token=tok-123"))
+        .stdout(predicate::str::contains(
+            r#""next":"floo apps github connect <owner>/<repo>""#,
+        ));
+
+    begin.assert();
+}
+
+#[test]
+fn test_github_setup_no_browser_prints_link_without_polling() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+
+    let begin = server
+        .mock("POST", "/v1/github/setup/begin")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"install_url":"https://api.floo.dev/v1/github/setup/install?setup_token=tok-456"}"#,
+        )
+        .create();
+    // No /setup/poll mock: --no-browser must return the link and stop. If it
+    // polled, mockito would 501 the unmatched request and this would fail.
+    let poll = server
+        .mock("GET", "/v1/github/setup/poll")
+        .expect(0)
+        .create();
+
+    floo()
+        .args(["apps", "github", "setup", "--no-browser"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("setup_token=tok-456"));
+
+    begin.assert();
+    poll.assert();
+}
+
+#[test]
+fn test_connect_unauthorized_installation_names_the_setup_command() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+
+    let connect = server
+        .mock(
+            "POST",
+            format!("/v1/apps/{TEST_APP_ID}/github/connection").as_str(),
+        )
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"GITHUB_INSTALLATION_NOT_AUTHORIZED","message":"The floo GitHub App is installed on \"myorg\" but is not linked to floo org \"acme-1234\"."}}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "apps",
+            "github",
+            "connect",
+            "myorg/myrepo",
+            "--app",
+            TEST_APP_NAME,
+            "--no-browser",
+        ])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"GITHUB_INSTALLATION_NOT_AUTHORIZED""#,
+        ))
+        .stdout(predicate::str::contains("floo apps github setup"));
+
+    connect.assert();
+}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -6968,8 +6968,11 @@ fn test_github_setup_no_browser_prints_link_without_polling() {
     let mut server = Server::new();
     let home = setup_config(&server);
 
+    // expect(1): exactly one setup token per run. Minting a second and
+    // discarding it orphans the first in Redis.
     let begin = server
         .mock("POST", "/v1/github/setup/begin")
+        .expect(1)
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(


### PR DESCRIPTION
## What changed

`floo apps github setup` mints a fresh GitHub App install link regardless of
whether the App is already installed, and `GITHUB_INSTALLATION_NOT_AUTHORIZED`
now points at it. The CLI half of getfloo/floo#2189; the durable server-side
binding is getfloo/floo#2193.

## Why

Feedback `01c60dc6` (CLI, 2026-08-21): the App installed on the org and scoped to
the repo, floo holding no binding, and every connect returning
`GITHUB_INSTALLATION_NOT_AUTHORIZED` — "Start the setup flow from the floo CLI
first", remediation naming a command that did not exist.

A setup link was minted only inside the `GITHUB_APP_NOT_INSTALLED` and
`GITHUB_REPO_NOT_IN_INSTALLATION` arms of `connect`. Once the App *is* installed,
neither arm is reachable, the error fell to the generic arm with no suggestion,
and `GitHubCommands` had only Connect/Disconnect/Status. The reporter's words:
"the remediation the error names has no command behind it." The only exit either
report found was uninstalling the App from the GitHub org.

## Files reviewers should scrutinize

- `src/commands/github.rs` — `setup()`, and the new arm in `connect`'s error match.
- `docs/offline/quickstart.md` — see below; this is the part I'd most like a second opinion on.

## The docs were a reproduction

Worth calling out separately, because it is the highest-leverage part of this
diff. The quickstart's "Agents & CI" recipe opened with:

> 1. A human installs the floo GitHub App on the org (one-time):
>    https://github.com/apps/getfloo/installations/new

That raw GitHub URL carries no `state`, so the post-install redirect never
returns the handshake and floo never records a binding. **The documented headless
path produced the exact dead end the bug reports describe.** The recipe now mints
the link through `floo apps github setup --no-browser` after auth, and the
prerequisites name both the failure mode and its recovery.

## Tests run

`scripts/test` — green. 516 unit + 168 mock-API + doc-link tests, `cargo fmt
--check` and `cargo clippy --all-targets -D warnings` clean.

Three new mock-API tests: the link is minted with no install-state precondition;
`--no-browser` returns the link without polling (asserted by a `.expect(0)` poll
mock, so a regression that polls fails loudly); and connect's 403 names the setup
command.

## Deliberate deviations from the issue text

- **No `--app` flag.** The issue sketched `floo apps github setup [--app]`.
  `/v1/github/setup/begin` does accept an `app_id`, but it is only stored in the
  session and read by nothing — the flag would have been decorative, so I left it
  off rather than ship an option that does nothing.
- **Does not continue into `connect`.** Report suggestion 2 asked for setup to
  flow into connect and a first deploy. With no repo argument there is nothing to
  connect, and adding one would duplicate `connect`'s resolution logic. The
  command prints `floo apps github connect <owner>/<repo>` as the next step
  instead, in both human and JSON output.

## Ordering note

getfloo/floo#2193's 403 message names `floo apps github setup`, so this is the
better one to land first. Users on older CLI builds will get "unknown command"
until they update either way — still a better dead end than a remediation that
named nothing, but it is a real gap and worth knowing about rather than
discovering.

## Known non-goals

Adoption-by-admin-proof (report suggestion 3) needs a GitHub OAuth user identity
the platform does not have. Named and deferred in getfloo/floo#2193.

## Issue Closure (Required)
Closes getfloo/floo#2189
