### PR TITLE
feat: add enterprise SSO commands

### DIFF
--- a/docs/offline/auth.md
+++ b/docs/offline/auth.md
@@ -92,8 +92,32 @@ the old role; removing a member revokes their app sessions and keys.
   password  - shared password for simple protection (Pay as you go+)
   accounts  - per-user auth, gateway-managed (Pay as you go+)
 
-Enterprise SSO (SAML/OIDC) is a sales-assisted setup, not a self-serve
-access_mode value - email sales@getfloo.com if your team needs it.
+## Enterprise organization SSO
+
+Enterprise admins configure one SAML or OIDC connection for their
+organization. The connection and enforcement policy are organization state;
+they never belong in floo.app.toml or the local CLI config.
+
+  floo orgs sso status [--org SLUG]
+  floo orgs sso portal [--org SLUG]
+  floo orgs sso doctor [--org SLUG]
+  floo orgs sso enforce [--org SLUG]
+  floo orgs sso enforcement disable [--org SLUG]
+
+`portal` creates a short-lived provider setup URL. `enforce` and
+`enforcement disable` open a purpose-bound dashboard handoff because those
+policy changes require a fresh browser ceremony through the organization's
+exact SSO connection. In `--json` mode, browser-opening commands return the
+URL without opening it so an agent can hand the action to a human.
+
+Before enforcement, create and securely store the show-once recovery token in
+the dashboard. It can only make SSO optional; it cannot grant access or reveal
+organization data. `doctor` reports stable provider, credential, access, and
+next-action codes without exposing provider IDs, metadata, certificates, or
+customer identity.
+`doctor` exits non-zero when setup, reauthentication, recovery, or provider
+repair is required; its JSON envelope still uses `success: true` when the
+diagnosis itself completed.
 
 Per-environment overrides work too:
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -357,6 +357,33 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    pub fn get_organization_sso_status(
+        &self,
+        org_id: &str,
+    ) -> Result<OrganizationSsoStatusResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/organizations/{org_id}/sso"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn get_organization_sso_doctor(
+        &self,
+        org_id: &str,
+    ) -> Result<OrganizationSsoDoctorResponse, FlooApiError> {
+        let resp = self.get(&format!("/v1/organizations/{org_id}/sso/doctor"))?;
+        self.handle_response(resp)
+    }
+
+    pub fn create_organization_sso_portal(
+        &self,
+        org_id: &str,
+    ) -> Result<OrganizationSsoPortalSessionResponse, FlooApiError> {
+        let resp = self.post_json(
+            &format!("/v1/organizations/{org_id}/sso/portal-session"),
+            &serde_json::json!({}),
+        )?;
+        self.handle_response(resp)
+    }
+
     // --- Access ---
 
     pub fn create_app_invite(

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -125,6 +125,125 @@ pub struct CreateInviteResponse {
     pub expires_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationSsoDomain {
+    pub domain: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoLifecycle {
+    Enabled,
+    Disabled,
+    Removed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoProviderState {
+    Pending,
+    Active,
+    Inactive,
+    Deleted,
+    Invalid,
+    ProviderUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoProviderType {
+    Saml,
+    Oidc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoEnforcementPolicy {
+    Optional,
+    Enforced,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoCredentialStatus {
+    ExactCurrentSso,
+    NotExactCurrentSso,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrganizationSsoCredentialReason {
+    NoBinding,
+    SessionCredential,
+    ExactCurrentBinding,
+    PolicyEnforcedCredentialIncompatible,
+    CredentialNotExactCurrentSso,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoEnforcementAccess {
+    NotRequired,
+    Allowed,
+    StepUpRequired,
+    BindingUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationSsoProviderReachability {
+    Reachable,
+    Unavailable,
+    NotConfigured,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrganizationSsoNextAction {
+    OpenSsoSetup,
+    UseOrganizationSsoRecovery,
+    CliReauthenticateWithOrgSso,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationSsoStatusResponse {
+    pub id: String,
+    pub lifecycle: OrganizationSsoLifecycle,
+    pub status: OrganizationSsoProviderState,
+    pub provider_type: Option<OrganizationSsoProviderType>,
+    pub domains: Vec<OrganizationSsoDomain>,
+    pub enforcement_ready: bool,
+    pub enforcement_policy: OrganizationSsoEnforcementPolicy,
+    pub recovery_ready: bool,
+    pub observed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationSsoDoctorResponse {
+    pub credential_status: OrganizationSsoCredentialStatus,
+    pub credential_reason: OrganizationSsoCredentialReason,
+    pub enforcement_access: OrganizationSsoEnforcementAccess,
+    pub provider_reachability: OrganizationSsoProviderReachability,
+    pub next_action: Option<OrganizationSsoNextAction>,
+    pub status: Option<OrganizationSsoStatusResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationSsoPortalSessionResponse {
+    pub id: String,
+    pub url: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationSsoBrowserHandoff {
+    pub organization_id: String,
+    pub action: String,
+    pub url: String,
+}
+
 // --- App ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -641,6 +641,67 @@ pub enum OrgsCommands {
         /// Org slug or ID.
         org_slug: String,
     },
+
+    /// Inspect and manage Enterprise SSO for an organization.
+    #[command(subcommand)]
+    Sso(OrganizationSsoCommands),
+}
+
+#[derive(Subcommand)]
+pub enum OrganizationSsoCommands {
+    /// Show the live SSO connection and enforcement state.
+    Status {
+        /// Organization slug or ID. Uses the current organization when omitted.
+        #[arg(long)]
+        org: Option<String>,
+    },
+
+    /// Open a short-lived provider setup portal.
+    Portal {
+        /// Organization slug or ID. Uses the current organization when omitted.
+        #[arg(long)]
+        org: Option<String>,
+
+        /// Print the portal URL without opening a browser.
+        #[arg(long)]
+        no_browser: bool,
+    },
+
+    /// Verify with SSO in the dashboard and enable enforcement.
+    Enforce {
+        /// Organization slug or ID. Uses the current organization when omitted.
+        #[arg(long)]
+        org: Option<String>,
+
+        /// Print the dashboard handoff URL without opening a browser.
+        #[arg(long)]
+        no_browser: bool,
+    },
+
+    /// Manage the SSO enforcement policy.
+    #[command(subcommand)]
+    Enforcement(OrganizationSsoEnforcementCommands),
+
+    /// Diagnose provider reachability and current credential compatibility.
+    Doctor {
+        /// Organization slug or ID. Uses the current organization when omitted.
+        #[arg(long)]
+        org: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum OrganizationSsoEnforcementCommands {
+    /// Verify with SSO in the dashboard and make SSO optional.
+    Disable {
+        /// Organization slug or ID. Uses the current organization when omitted.
+        #[arg(long)]
+        org: Option<String>,
+
+        /// Print the dashboard handoff URL without opening a browser.
+        #[arg(long)]
+        no_browser: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2281,6 +2342,25 @@ pub fn run() {
             },
             OrgsCommands::Invite { email, role } => commands::orgs::invite(&email, &role),
             OrgsCommands::Switch { org_slug } => commands::orgs::switch(&org_slug),
+            OrgsCommands::Sso(sso_sub) => match sso_sub {
+                OrganizationSsoCommands::Status { org } => {
+                    commands::organization_sso::status(org.as_deref())
+                }
+                OrganizationSsoCommands::Portal { org, no_browser } => {
+                    commands::organization_sso::portal(org.as_deref(), no_browser)
+                }
+                OrganizationSsoCommands::Enforce { org, no_browser } => {
+                    commands::organization_sso::enforce(org.as_deref(), no_browser)
+                }
+                OrganizationSsoCommands::Enforcement(enforcement_sub) => match enforcement_sub {
+                    OrganizationSsoEnforcementCommands::Disable { org, no_browser } => {
+                        commands::organization_sso::disable_enforcement(org.as_deref(), no_browser)
+                    }
+                },
+                OrganizationSsoCommands::Doctor { org } => {
+                    commands::organization_sso::doctor(org.as_deref())
+                }
+            },
         },
 
         Commands::Apps(sub) => match sub {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod github;
 pub mod init;
 pub mod logs;
 pub mod notifications;
+pub mod organization_sso;
 pub mod orgs;
 pub mod previews;
 pub mod releases;

--- a/src/commands/organization_sso.rs
+++ b/src/commands/organization_sso.rs
@@ -1,0 +1,451 @@
+use std::process;
+
+use crate::api_client::FlooClient;
+use crate::api_types::{
+    OrgResponse, OrganizationSsoBrowserHandoff, OrganizationSsoCredentialStatus,
+    OrganizationSsoDoctorResponse, OrganizationSsoEnforcementAccess,
+    OrganizationSsoEnforcementPolicy, OrganizationSsoLifecycle, OrganizationSsoNextAction,
+    OrganizationSsoProviderReachability, OrganizationSsoProviderState, OrganizationSsoProviderType,
+    OrganizationSsoStatusResponse,
+};
+use crate::config::{load_config, FlooConfig};
+use crate::errors::{ErrorCode, FlooApiError};
+use crate::output;
+
+struct OrganizationContext {
+    client: FlooClient,
+    org: OrgResponse,
+    config: FlooConfig,
+}
+
+pub fn status(org_selector: Option<&str>) {
+    let context = resolve_organization(org_selector);
+    match context.client.get_organization_sso_status(&context.org.id) {
+        Ok(status) => render_status(&context.org, &status),
+        Err(error) => exit_api_error(error, Some(&context.org)),
+    }
+}
+
+pub fn doctor(org_selector: Option<&str>) {
+    let context = resolve_organization(org_selector);
+    match context.client.get_organization_sso_doctor(&context.org.id) {
+        Ok(doctor) => {
+            let healthy = doctor.provider_reachability
+                == OrganizationSsoProviderReachability::Reachable
+                && matches!(
+                    doctor.enforcement_access,
+                    OrganizationSsoEnforcementAccess::NotRequired
+                        | OrganizationSsoEnforcementAccess::Allowed
+                )
+                && doctor.next_action.is_none();
+            render_doctor(&context.org, &doctor);
+            if !healthy {
+                process::exit(1);
+            }
+        }
+        Err(error) => exit_api_error(error, Some(&context.org)),
+    }
+}
+
+pub fn portal(org_selector: Option<&str>, no_browser: bool) {
+    let context = resolve_organization(org_selector);
+    match context
+        .client
+        .create_organization_sso_portal(&context.org.id)
+    {
+        Ok(portal) => {
+            if output::is_json_mode() {
+                output::success("", Some(output::to_value(&portal)));
+                return;
+            }
+            output::success("Created a short-lived SSO setup session.", None);
+            output::info(&format!("  {}", portal.url), None);
+            if !no_browser {
+                open_browser(&portal.url);
+            }
+        }
+        Err(error) => exit_api_error(error, Some(&context.org)),
+    }
+}
+
+pub fn enforce(org_selector: Option<&str>, no_browser: bool) {
+    browser_handoff(org_selector, "enable", no_browser);
+}
+
+pub fn disable_enforcement(org_selector: Option<&str>, no_browser: bool) {
+    browser_handoff(org_selector, "disable", no_browser);
+}
+
+fn browser_handoff(org_selector: Option<&str>, action: &str, no_browser: bool) {
+    let context = resolve_organization(org_selector);
+    if let Err(error) = context.client.get_organization_sso_doctor(&context.org.id) {
+        exit_api_error(error, Some(&context.org));
+    }
+    let app_url = dashboard_url(&context.config.api_url).unwrap_or_else(|| {
+        output::error(
+            "The dashboard URL for this API environment is not configured.",
+            &ErrorCode::Other("SSO_DASHBOARD_URL_UNAVAILABLE".to_string()),
+            Some("Set FLOO_APP_URL to the matching floo dashboard origin and try again."),
+        );
+        process::exit(1);
+    });
+    let url = format!(
+        "{app_url}/sso/manage?org={}&action={action}",
+        context.org.id
+    );
+    let handoff = OrganizationSsoBrowserHandoff {
+        organization_id: context.org.id.clone(),
+        action: action.to_string(),
+        url: url.clone(),
+    };
+    if output::is_json_mode() {
+        output::success("", Some(output::to_value(&handoff)));
+        return;
+    }
+    let verb = if action == "enable" {
+        "enable SSO enforcement"
+    } else {
+        "disable SSO enforcement"
+    };
+    output::success(&format!("Created a browser handoff to {verb}."), None);
+    output::info(&format!("  {url}"), None);
+    if !no_browser {
+        open_browser(&url);
+    }
+}
+
+fn resolve_organization(selector: Option<&str>) -> OrganizationContext {
+    super::require_auth();
+    let mut config = load_config();
+    let mut discovery_config = config.clone();
+    if selector.is_some() {
+        discovery_config.default_org = None;
+    }
+    let discovery_client = super::init_client(Some(discovery_config));
+    let org = match selector {
+        Some(value) => {
+            let orgs = discovery_client.list_orgs().unwrap_or_else(|error| {
+                exit_api_error(error, None);
+            });
+            orgs.orgs
+                .into_iter()
+                .find(|org| org.id == value || org.slug.as_deref() == Some(value))
+                .unwrap_or_else(|| {
+                    output::error(
+                        &format!("Organization '{value}' not found."),
+                        &ErrorCode::from_api("ORG_NOT_FOUND"),
+                        Some("Run 'floo orgs switch <slug-or-id>' or choose an organization you belong to."),
+                    );
+                    process::exit(1);
+                })
+        }
+        None => discovery_client.get_org_me().unwrap_or_else(|error| {
+            exit_api_error(error, None);
+        }),
+    };
+    config.default_org = Some(org.id.clone());
+    let client = super::init_client(Some(config.clone()));
+    OrganizationContext {
+        client,
+        org,
+        config,
+    }
+}
+
+fn dashboard_url(api_url: &str) -> Option<String> {
+    if let Ok(value) = std::env::var("FLOO_APP_URL") {
+        let value = value.trim_end_matches('/');
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    match api_url.trim_end_matches('/') {
+        "https://api.getfloo.com" => Some("https://app.getfloo.com".to_string()),
+        "https://api.dev.getfloo.com" => Some("https://app.dev.getfloo.com".to_string()),
+        "http://localhost:8000" | "http://127.0.0.1:8000" => {
+            Some("http://localhost:5173".to_string())
+        }
+        _ => None,
+    }
+}
+
+fn render_status(org: &OrgResponse, status: &OrganizationSsoStatusResponse) {
+    if output::is_json_mode() {
+        output::success("", Some(output::to_value(status)));
+        return;
+    }
+    output::info(
+        &format!(
+            "Organization: {}",
+            org.display_name().unwrap_or(org.id.as_str())
+        ),
+        None,
+    );
+    output::info(
+        &format!("Connection:   {}", provider_state_label(status.status)),
+        None,
+    );
+    output::info(
+        &format!("Lifecycle:    {}", lifecycle_label(status.lifecycle)),
+        None,
+    );
+    output::info(
+        &format!(
+            "Provider:     {}",
+            status
+                .provider_type
+                .map(provider_type_label)
+                .unwrap_or("Not configured")
+        ),
+        None,
+    );
+    output::info(
+        &format!("Policy:       {}", policy_label(status.enforcement_policy)),
+        None,
+    );
+    output::info(
+        &format!(
+            "Ready:        {}",
+            if status.enforcement_ready {
+                "Yes"
+            } else {
+                "No"
+            }
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "Recovery:     {}",
+            if status.recovery_ready {
+                "Ready"
+            } else {
+                "Not ready"
+            }
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "Observed:     {}",
+            status.observed_at.as_deref().unwrap_or("Never")
+        ),
+        None,
+    );
+    if status.domains.is_empty() {
+        output::info("Domains:      None", None);
+    } else {
+        let domains = status
+            .domains
+            .iter()
+            .map(|domain| format!("{} ({})", domain.domain, string_label(&domain.state)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        output::info(&format!("Domains:      {domains}"), None);
+    }
+    let selector = org.display_name().unwrap_or(org.id.as_str());
+    if status.lifecycle != OrganizationSsoLifecycle::Enabled
+        || status.status != OrganizationSsoProviderState::Active
+    {
+        output::info(
+            &format!("Next action:  run 'floo orgs sso portal --org {selector}'"),
+            None,
+        );
+    } else if status.enforcement_policy == OrganizationSsoEnforcementPolicy::Optional {
+        output::info(
+            &format!("Next action:  run 'floo orgs sso enforce --org {selector}'"),
+            None,
+        );
+    }
+}
+
+fn render_doctor(org: &OrgResponse, doctor: &OrganizationSsoDoctorResponse) {
+    if output::is_json_mode() {
+        output::success("", Some(output::to_value(doctor)));
+        return;
+    }
+    output::info(
+        &format!(
+            "Organization: {}",
+            org.display_name().unwrap_or(org.id.as_str())
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "Provider:     {}",
+            reachability_label(doctor.provider_reachability)
+        ),
+        None,
+    );
+    output::info(
+        &format!(
+            "Credential:   {}",
+            credential_label(doctor.credential_status)
+        ),
+        None,
+    );
+    output::info(
+        &format!("Access:       {}", access_label(doctor.enforcement_access)),
+        None,
+    );
+    if let Some(action) = doctor.next_action {
+        output::info(&format!("Next action:  {}", next_action(action, org)), None);
+    }
+}
+
+fn next_action(action: OrganizationSsoNextAction, org: &OrgResponse) -> String {
+    let selector = org.display_name().unwrap_or(org.id.as_str());
+    match action {
+        OrganizationSsoNextAction::OpenSsoSetup => {
+            format!("run 'floo orgs sso portal --org {selector}'")
+        }
+        OrganizationSsoNextAction::UseOrganizationSsoRecovery => {
+            "open the dashboard recovery flow with your stored recovery token".to_string()
+        }
+        OrganizationSsoNextAction::CliReauthenticateWithOrgSso => format!(
+            "run 'floo orgs switch {selector}', then 'floo auth login --force' through organization SSO"
+        ),
+    }
+}
+
+fn exit_api_error(error: FlooApiError, org: Option<&OrgResponse>) -> ! {
+    let suggestion = match error.code.as_str() {
+        "SSO_BROWSER_STEP_UP_REQUIRED" | "SSO_STEP_UP_REQUIRED" => org.map(|org| {
+            format!(
+                "Run 'floo orgs switch {}', then 'floo auth login --force' through organization SSO.",
+                org.display_name().unwrap_or(org.id.as_str())
+            )
+        }),
+        "SSO_UNAVAILABLE" => Some(
+            "Run 'floo orgs sso doctor' and use the dashboard recovery flow if directed."
+                .to_string(),
+        ),
+        "ENTERPRISE_SSO_REQUIRED" => {
+            Some("Enterprise SSO setup requires an Enterprise organization plan.".to_string())
+        }
+        _ => None,
+    };
+    output::error_with_details(
+        &error.message,
+        &ErrorCode::from_api(&error.code),
+        suggestion.as_deref(),
+        error.extra.as_ref(),
+    );
+    process::exit(1);
+}
+
+fn open_browser(url: &str) {
+    if let Err(error) = open::that(url) {
+        output::warn(&format!("Could not open a browser: {error}"));
+    }
+}
+
+fn string_label(value: &str) -> &str {
+    match value {
+        "pending" => "Pending",
+        "verified" => "Verified",
+        other => other,
+    }
+}
+
+fn provider_state_label(value: OrganizationSsoProviderState) -> &'static str {
+    match value {
+        OrganizationSsoProviderState::Pending => "Pending",
+        OrganizationSsoProviderState::Active => "Active",
+        OrganizationSsoProviderState::Inactive => "Inactive",
+        OrganizationSsoProviderState::Deleted => "Deleted",
+        OrganizationSsoProviderState::Invalid => "Invalid",
+        OrganizationSsoProviderState::ProviderUnavailable => "Unavailable",
+    }
+}
+
+fn lifecycle_label(value: OrganizationSsoLifecycle) -> &'static str {
+    match value {
+        OrganizationSsoLifecycle::Enabled => "Enabled",
+        OrganizationSsoLifecycle::Disabled => "Disabled",
+        OrganizationSsoLifecycle::Removed => "Removed",
+    }
+}
+
+fn provider_type_label(value: OrganizationSsoProviderType) -> &'static str {
+    match value {
+        OrganizationSsoProviderType::Saml => "SAML",
+        OrganizationSsoProviderType::Oidc => "OIDC",
+    }
+}
+
+fn policy_label(value: OrganizationSsoEnforcementPolicy) -> &'static str {
+    match value {
+        OrganizationSsoEnforcementPolicy::Optional => "Optional",
+        OrganizationSsoEnforcementPolicy::Enforced => "Required",
+    }
+}
+
+fn reachability_label(value: OrganizationSsoProviderReachability) -> &'static str {
+    match value {
+        OrganizationSsoProviderReachability::Reachable => "Reachable",
+        OrganizationSsoProviderReachability::Unavailable => "Unavailable",
+        OrganizationSsoProviderReachability::NotConfigured => "Not configured",
+    }
+}
+
+fn credential_label(value: OrganizationSsoCredentialStatus) -> &'static str {
+    match value {
+        OrganizationSsoCredentialStatus::ExactCurrentSso => "Exact current SSO",
+        OrganizationSsoCredentialStatus::NotExactCurrentSso => "Not exact current SSO",
+        OrganizationSsoCredentialStatus::NotApplicable => "Not applicable",
+    }
+}
+
+fn access_label(value: OrganizationSsoEnforcementAccess) -> &'static str {
+    match value {
+        OrganizationSsoEnforcementAccess::NotRequired => "Not required",
+        OrganizationSsoEnforcementAccess::Allowed => "Allowed",
+        OrganizationSsoEnforcementAccess::StepUpRequired => "SSO sign-in required",
+        OrganizationSsoEnforcementAccess::BindingUnavailable => "Binding unavailable",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dashboard_url_tracks_known_api_environments() {
+        assert_eq!(
+            dashboard_url("https://api.getfloo.com"),
+            Some("https://app.getfloo.com".to_string())
+        );
+        assert_eq!(
+            dashboard_url("https://api.dev.getfloo.com"),
+            Some("https://app.dev.getfloo.com".to_string())
+        );
+        assert_eq!(
+            dashboard_url("http://localhost:8000"),
+            Some("http://localhost:5173".to_string())
+        );
+        assert_eq!(dashboard_url("https://api.custom.example"), None);
+    }
+
+    #[test]
+    fn stable_next_actions_render_exact_commands() {
+        let org = OrgResponse {
+            id: "org-id".to_string(),
+            name: Some("Example".to_string()),
+            slug: Some("example".to_string()),
+            plan: None,
+            spend_cap: None,
+            current_period_spend_cents: None,
+            spend_cap_exceeded: None,
+        };
+        assert_eq!(
+            next_action(OrganizationSsoNextAction::OpenSsoSetup, &org),
+            "run 'floo orgs sso portal --org example'"
+        );
+        assert!(
+            next_action(OrganizationSsoNextAction::CliReauthenticateWithOrgSso, &org)
+                .contains("floo auth login --force")
+        );
+    }
+}

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -405,6 +405,319 @@ fn test_orgs_invite_json_assigns_role_and_redacts_url() {
         .stdout(predicate::str::contains("contains_secrets"));
 }
 
+fn sso_status_json() -> &'static str {
+    r#"{"id":"sso-config-1","lifecycle":"enabled","status":"active","provider_type":"saml","domains":[{"domain":"example.com","state":"verified"}],"enforcement_ready":true,"enforcement_policy":"optional","recovery_ready":true,"observed_at":"2026-08-28T12:00:00Z"}"#
+}
+
+#[test]
+fn test_orgs_sso_status_json_uses_exact_org_header() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _status = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso").as_str(),
+        )
+        .match_header("x-floo-org-id", TEST_ORG_ID)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(sso_status_json())
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "status"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""status":"active""#))
+        .stdout(predicate::str::contains(
+            r#""enforcement_policy":"optional""#,
+        ))
+        .stdout(predicate::str::contains("example.com"));
+}
+
+#[test]
+fn test_orgs_sso_doctor_json_preserves_codes_and_drops_unknown_provider_ids() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _doctor = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/doctor").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"credential_status":"not_exact_current_sso","credential_reason":"POLICY_ENFORCED_CREDENTIAL_INCOMPATIBLE","enforcement_access":"step_up_required","provider_reachability":"reachable","next_action":"CLI_REAUTHENTICATE_WITH_ORG_SSO","status":null,"workos_organization_id":"org_provider_secret"}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "doctor"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""next_action":"CLI_REAUTHENTICATE_WITH_ORG_SSO""#,
+        ))
+        .stdout(predicate::str::contains("org_provider_secret").not());
+}
+
+#[test]
+fn test_orgs_sso_doctor_healthy_json_exits_zero() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _doctor = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/doctor").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"credential_status":"exact_current_sso","credential_reason":"EXACT_CURRENT_BINDING","enforcement_access":"allowed","provider_reachability":"reachable","next_action":null,"status":{}}}"#,
+            sso_status_json()
+        ))
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "doctor"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""success":true"#))
+        .stdout(predicate::str::contains(
+            r#""enforcement_access":"allowed""#,
+        ));
+}
+
+#[test]
+fn test_orgs_sso_portal_json_returns_short_lived_url_once() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _portal = server
+        .mock(
+            "POST",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/portal-session").as_str(),
+        )
+        .match_header("x-floo-org-id", TEST_ORG_ID)
+        .match_body(Matcher::Json(serde_json::json!({})))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"id":"sso-config-1","url":"https://setup.example.test/launch/ephemeral","expires_in_seconds":300}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "portal"])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "https://setup.example.test/launch/ephemeral",
+        ))
+        .stdout(predicate::str::contains(r#""expires_in_seconds":300"#));
+}
+
+#[test]
+fn test_orgs_sso_enforce_json_returns_browser_handoff_without_opening() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _doctor = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/doctor").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"credential_status":"not_applicable","credential_reason":"SESSION_CREDENTIAL","enforcement_access":"not_required","provider_reachability":"reachable","next_action":null,"status":null}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "enforce"])
+        .env("HOME", home.path())
+        .env("FLOO_APP_URL", "https://dashboard.example.test")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"enable""#))
+        .stdout(predicate::str::contains(format!(
+            "https://dashboard.example.test/sso/manage?org={TEST_ORG_ID}&action=enable"
+        )));
+}
+
+#[test]
+fn test_orgs_sso_disable_explicit_slug_resolves_and_targets_that_org() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _orgs = server
+        .mock("GET", "/v1/orgs")
+        .match_header("x-floo-org-id", Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"orgs":[{}],"total":1}}"#, org_json()))
+        .create();
+    let _doctor = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/doctor").as_str(),
+        )
+        .match_header("x-floo-org-id", TEST_ORG_ID)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"credential_status":"not_exact_current_sso","credential_reason":"POLICY_ENFORCED_CREDENTIAL_INCOMPATIBLE","enforcement_access":"step_up_required","provider_reachability":"reachable","next_action":"CLI_REAUTHENTICATE_WITH_ORG_SSO","status":null}"#,
+        )
+        .create();
+
+    floo()
+        .args([
+            "--json",
+            "orgs",
+            "sso",
+            "enforcement",
+            "disable",
+            "--org",
+            "test-org",
+        ])
+        .env("HOME", home.path())
+        .env("FLOO_APP_URL", "https://dashboard.example.test")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action":"disable""#))
+        .stdout(predicate::str::contains(TEST_ORG_ID));
+}
+
+#[test]
+fn test_orgs_sso_doctor_error_preserves_recovery_metadata() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _doctor = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/doctor").as_str(),
+        )
+        .with_status(503)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"detail":{{"code":"SSO_UNAVAILABLE","message":"SSO is unavailable.","next_action":"USE_ORGANIZATION_SSO_RECOVERY","organization_id":"{TEST_ORG_ID}"}}}}"#
+        ))
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "doctor"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""next_action":"USE_ORGANIZATION_SSO_RECOVERY""#,
+        ))
+        .stdout(predicate::str::contains(format!(
+            r#""organization_id":"{TEST_ORG_ID}""#
+        )));
+}
+
+#[test]
+fn test_orgs_sso_explicit_unknown_org_fails_before_sso_request() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _orgs = server
+        .mock("GET", "/v1/orgs")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"orgs":[{}],"total":1}}"#, org_json()))
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "status", "--org", "another-org"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"ORG_NOT_FOUND""#));
+}
+
+#[test]
+fn test_orgs_sso_portal_non_enterprise_preserves_plan_code() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _portal = server
+        .mock(
+            "POST",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/portal-session").as_str(),
+        )
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"ENTERPRISE_SSO_REQUIRED","message":"Enterprise SSO requires an Enterprise organization plan."}}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "portal"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"ENTERPRISE_SSO_REQUIRED""#,
+        ));
+}
+
+#[test]
+fn test_orgs_sso_doctor_restricted_identity_preserves_authority_code() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = mock_org_me(&mut server);
+    let _doctor = server
+        .mock(
+            "GET",
+            format!("/v1/organizations/{TEST_ORG_ID}/sso/doctor").as_str(),
+        )
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"detail":{"code":"CONTROL_PLANE_ACCESS_REQUIRED","message":"Control-plane access is required."}}"#,
+        )
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "doctor"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            r#""code":"CONTROL_PLANE_ACCESS_REQUIRED""#,
+        ));
+}
+
+#[test]
+fn test_orgs_sso_status_expired_auth_preserves_authentication_code() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _org = server
+        .mock("GET", "/v1/orgs/me")
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":{"code":"NOT_AUTHENTICATED","message":"Authentication expired."}}"#)
+        .create();
+
+    floo()
+        .args(["--json", "orgs", "sso", "status"])
+        .env("HOME", home.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""code":"NOT_AUTHENTICATED""#));
+}
+
 #[test]
 fn test_apps_list_human() {
     let mut server = Server::new();


### PR DESCRIPTION
## Summary
- add one canonical `floo orgs sso` command group for status, provider setup, enforcement handoff, policy disable, and diagnostics
- bind explicit organization selection into both the request path and `X-Floo-Org-Id`, while keeping browser-only policy proof in the dashboard
- add closed API enums, safe human/JSON output, offline auth guidance, and negative boundary regressions

## Issue Closure (Required)
Closes #251

## Changes
- add typed SSO API responses and organization-scoped client methods
- add direct short-lived portal output plus purpose-bound dashboard handoffs for enable/disable
- add doctor health exit semantics and stable next-action rendering
- document the end-to-end Enterprise SSO CLI flow in `floo docs auth`

## Test Plan
- [x] `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/espeerascend/filesys/sandbox/floo-cli/target ./scripts/test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] 11 SSO-specific mock API regressions

## Discovered Issues
None

🤖 Generated with Codex