### PR TITLE
fix: stop naming the cloud substrate in CLI output and bundled docs

### DIFF
--- a/docs/offline/config.md
+++ b/docs/offline/config.md
@@ -44,7 +44,7 @@ floo Config Files
   [services.worker]
   type = "worker"
   path = "."                          # same build as web -> same Dockerfile + CMD
-  port = 3000                          # required even for workers (Cloud Run needs a port)
+  port = 3000                          # required even for workers (the runtime needs a port)
   ingress = "internal"                # no public HTTP
   command = "bundle exec sidekiq"     # REQUIRED: without it the worker boots the web command
 
@@ -73,7 +73,7 @@ floo Config Files
   dev_command      - command to run locally for `floo dev`
                      e.g., "npm run dev", "uvicorn app.main:app --reload"
 
-  migrate_command  - optional command run as a Cloud Run Job after every
+  migrate_command  - optional command run as a one-off job after every
                      deploy (against the dev schema) and after every promote
                      (against the prod schema). Non-fatal: a failure is logged
                      but does not block the deploy from going live.

--- a/docs/offline/django.md
+++ b/docs/offline/django.md
@@ -84,7 +84,7 @@ headers with HTTP_ and uppercases them):
 
 ## Gotchas
 
-  - /healthz is reserved by Cloud Run - use /health
+  - /healthz is reserved by floo - use /health
   - Bind to 0.0.0.0 in gunicorn
   - DEBUG=False in prod (the default above is False)
   - DJANGO_SECRET_KEY must be set or sessions can be forged

--- a/docs/offline/edge.md
+++ b/docs/offline/edge.md
@@ -25,7 +25,7 @@ JSON output is stable for agents:
   floo edge routes list --app my-app --env prod --json 2>/dev/null |
     jq '.data.routes[] | {host, path_prefix, access_mode, api_key_enabled, required_scope}'
 
-The output deliberately omits raw Cloud Run backend URLs. Treat floo hosts and
+The output deliberately omits raw internal backend URLs. Treat floo hosts and
 custom domains as the public contract.
 
 ## Edge policy (IP/CIDR firewall, Team plan)

--- a/docs/offline/egress.md
+++ b/docs/offline/egress.md
@@ -1,7 +1,7 @@
 floo Egress and Networking
 
 floo puts your app behind the floo gateway for inbound traffic. Your app's
-outbound traffic uses Cloud Run's normal internet egress today.
+outbound traffic uses floo's normal internet egress today.
 
 ## Inbound traffic
 
@@ -9,9 +9,9 @@ outbound traffic uses Cloud Run's normal internet egress today.
     -> *.on.getfloo.com or custom domain
     -> floo gateway
     -> edge policy and managed auth
-    -> your Cloud Run app service
+    -> your app service
 
-Do not expose or depend on raw *.run.app backend URLs. Treat floo hosts and
+Do not expose or depend on raw backend URLs. Treat floo hosts and
 custom domains as the public contract.
 
 Inspect the live route table with:

--- a/docs/offline/express.md
+++ b/docs/offline/express.md
@@ -64,7 +64,7 @@ won't get set behind floo's edge.
 
 ## Gotchas
 
-  - /healthz is reserved by Cloud Run - use /health
+  - /healthz is reserved by floo - use /health
   - app.listen(port, "0.0.0.0", ...) explicitly
   - app.set("trust proxy", true) is required
   - SESSION_SECRET required for cookie-session

--- a/docs/offline/fastapi.md
+++ b/docs/offline/fastapi.md
@@ -10,7 +10,7 @@ published guide.
   ...
   CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
-Bind to 0.0.0.0 - 127.0.0.1 won't accept Cloud Run traffic.
+Bind to 0.0.0.0 - floo cannot reach 127.0.0.1.
 
 ## 2. floo init + deploy
 
@@ -64,7 +64,7 @@ Then a FastAPI dependency:
 
 ## Gotchas
 
-  - /healthz is reserved by Cloud Run - use /health
+  - /healthz is reserved by floo - use /health
   - Bind to 0.0.0.0
   - Don't mix asyncpg and psycopg2 - pick one
   - X-Forwarded-Proto: build absolute URLs from forwarded scheme

--- a/docs/offline/nextjs.md
+++ b/docs/offline/nextjs.md
@@ -8,7 +8,7 @@ code in the published guide.
 
 Set output: "standalone" in next.config.js, then a multi-stage Dockerfile
 ending with `CMD ["node", "server.js"]`. Set HOSTNAME=0.0.0.0 (Next.js
-standalone defaults to localhost - Cloud Run won't reach it).
+standalone defaults to localhost - floo cannot reach it).
 
 ## 2. NEXT_PUBLIC_* build-arg trap
 
@@ -64,7 +64,7 @@ Then in a Server Component or Route Handler:
 
 ## Gotchas
 
-  - /healthz is reserved by Cloud Run - use /health
+  - /healthz is reserved by floo - use /health
   - HOSTNAME=0.0.0.0 (standalone defaults to localhost)
   - NEXT_PUBLIC_* changes require floo redeploy --rebuild
   - output: "standalone" in next.config.js

--- a/docs/offline/previews.md
+++ b/docs/offline/previews.md
@@ -62,7 +62,7 @@ The resource key is shaped `type:name`, for example `postgres:default`,
 `redis:cache`, or `storage:uploads`. Reset is preview-scoped and fails closed
 with the API's named blocker when a provider cannot reset that resource yet.
 
-`floo previews delete` tears down preview-owned Cloud Run services, managed
+`floo previews delete` tears down preview-owned services, managed
 resources, gateway routes, and env vars. Dev and prod are untouched.
 
 ## Related commands

--- a/docs/offline/quickstart.md
+++ b/docs/offline/quickstart.md
@@ -92,7 +92,7 @@ floo Quickstart - End-to-End Walkthrough
 
   floo dev --app my-app
 
-  Runs your service locally with live Cloud SQL access and the same env vars
+  Runs your service locally with live managed Postgres access and the same env vars
   as the deployed version. Requires dev_command set on the service in floo.app.toml.
 
 ## What Creates What

--- a/docs/offline/rails.md
+++ b/docs/offline/rails.md
@@ -9,7 +9,7 @@ Rails 7.1+ ships a production Dockerfile from `rails new`. Otherwise:
 
   bin/rails generate dockerfile
 
-Bind to 0.0.0.0 (not localhost). Cloud Run only routes traffic to
+Bind to 0.0.0.0 (not localhost). floo only routes traffic to
 processes bound to all interfaces. Expose the same port you set in
 floo.app.toml (3000 below).
 
@@ -51,7 +51,7 @@ Local dev server with prod-shaped env:
   floo dev --app my-rails-app
 
 Runs your dev_command locally with DATABASE_URL and other env vars
-sourced from floo. Real Cloud SQL connection, no exported credentials.
+sourced from floo. Real managed Postgres connection, no exported credentials.
 
 Add --fixture-user to test signed-in (accounts-mode) flows locally:
 
@@ -85,7 +85,7 @@ path.
   git push origin main
 
 Rails reads DATABASE_URL automatically. floo injects a normal PostgreSQL
-URI, so ActiveRecord can parse it without custom Cloud SQL socket code.
+URI, so ActiveRecord can parse it without custom socket code.
 `floo preflight` warns if a local env file still contains the old Cloud
 SQL socket-style DATABASE_URL that Ruby's URI parser rejects.
 Confirm config/database.yml has:
@@ -129,7 +129,7 @@ Add the CNAME shown in the output at your DNS provider.
 
 ## Common gotchas
 
-  - /healthz is reserved by Cloud Run - use /health or /livez
+  - /healthz is reserved by floo - use /health or /livez
   - bind: 0.0.0.0 (Rails defaults vary)
   - asset compilation runs in the Dockerfile (RAILS_SERVE_STATIC_FILES=1)
   - Rails 7+ force_ssl works correctly behind floo's edge (X-Forwarded-Proto)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -426,7 +426,7 @@ mode active?' without requiring agents to curl the gateway, parse request
 logs, and join four database tables by hand.
 
 The endpoint is intentionally narrow: no env-var values, no secret
-material, no Cloud Run audit payloads. Those live on dedicated surfaces."
+material, no runtime audit payloads. Those live on dedicated surfaces."
     )]
     Doctor(DoctorCommands),
 
@@ -1347,7 +1347,7 @@ pub enum DeploysSubcommands {
     ///
     /// Emits the latest deploy's id, commit, derived phase booleans
     /// (image_built / service_ready / host_bound), the gateway URL, and a
-    /// next recommended command — without dumping build logs, Cloud Run
+    /// next recommended command — without dumping build logs, runtime
     /// audit payloads, or env-var values. Use this from agents and
     /// scripts that need to know "what state is the deploy in?" without
     /// risking secret exfiltration through verbose log output.

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -124,7 +124,7 @@ pub fn status(app_flag: Option<&str>) {
         if let Some(runtime_url) = app.runtime_url.as_deref() {
             output::info(&format!("  Runtime URL:  {runtime_url}"), None);
             output::dim_line(
-                "              \u{21b3} direct Cloud Run URL — debug only, not for clients",
+                "              \u{21b3} direct runtime URL — debug only, not for clients",
             );
         }
         output::info(&format!("  Org:      {org_display}"), None);

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1720,7 +1720,7 @@ fn validate_preflight(
                             PreflightFinding::warning(
                                 "RAILS_DATABASE_URL_SOCKET_DSN",
                                 format!(
-                                    "Service '{}' looks like Rails and {env_label} contains a Cloud SQL socket-style DATABASE_URL. Rails parses DATABASE_URL with Ruby's URI parser before app code runs, so a host-less DSN like postgresql:///db?host=/cloudsql/... can fail at boot. Remove the stale local override or use floo's framework-compatible managed Postgres URL.",
+                                    "Service '{}' looks like Rails and {env_label} contains a socket-style DATABASE_URL. Rails parses DATABASE_URL with Ruby's URI parser before app code runs, so a host-less DSN like postgresql:///db?host=/cloudsql/... can fail at boot. Remove the stale local override or use floo's framework-compatible managed Postgres URL.",
                                     svc.name
                                 ),
                             )

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -357,7 +357,7 @@ pub fn dev(args: DevArgs) {
                 output::warn(&format!(
                     "  Postgres: authorization was accepted but the database was still \
 unreachable after {:.0}s. Starting anyway — direct connections may fail until \
-Cloud SQL finishes applying it.",
+the database finishes applying it.",
                     waited.as_secs_f32()
                 ));
             }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -447,7 +447,7 @@ mod tests {
     #[test]
     fn test_egress_topic_documents_network_boundary_contract() {
         assert!(render_overview().contains("floo docs egress"));
-        assert!(EGRESS.contains("Cloud Run's normal internet egress"));
+        assert!(EGRESS.contains("floo's normal internet egress"));
         assert!(EGRESS.contains("Stable outbound source IP"));
         assert!(EGRESS.contains("SMTP port 25"));
         assert!(EGRESS.contains("customer-side connector"));

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -195,8 +195,8 @@ captures the floo-specific gotchas that aren't obvious from the code.
   cheatsheets locally.
 - **Deploy by pushing to GitHub.** `git push` to your default branch
   triggers a dev deploy; cutting a GitHub release promotes to prod.
-  Don't shell out to `gcloud run deploy` — it bypasses the floo
-  pipeline.
+  Don't deploy with another cloud provider's CLI — it bypasses
+  the floo pipeline.
 
 ## Agent-safe deploy debugging
 
@@ -205,26 +205,25 @@ captures the floo-specific gotchas that aren't obvious from the code.
   booleans, gateway URL, next recommended command) without dumping
   build logs that may contain audit payloads. `watch` is fine for
   humans; for scripts and agents, prefer `status`.
-- **`/health` on the direct Cloud Run URL is for infrastructure
-  probes, not authenticated requests.** Cloud Run liveness/startup
+- **`/health` on the direct runtime URL is for infrastructure
+  probes, not authenticated requests.** Platform liveness/startup
   probes hit it without any session, so don't infer auth state from
   whatever can reach `/health`.
 - **Test the floo gateway URL after every deploy.** A 502 on
   `*.on.getfloo.com` (or your custom domain) means the deploy didn't
-  finalize even if the direct Cloud Run URL serves new code. `floo
+  finalize even if the direct runtime URL serves new code. `floo
   deploys status --json` reports `host_bound: false` in that state.
 
 ## If you set `access_mode = "accounts"` (or `"password"`)
 
 - **Trust `X-Floo-User-Email`, `X-Floo-User-Id`, `X-Floo-User-Name`,
   and `X-Floo-User-Role` on every request your app receives.** The
-  floo gateway is the only path into your container — Cloud Run
-  ingress is locked to `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` and
-  there's no `allUsers` invoker grant. The deploy pipeline raises if
-  that combination would somehow ship as `INGRESS_TRAFFIC_ALL`.
-- **Don't curl your `*.run.app` URL in scripts or tests.** It
-  returns 403 from Cloud Run before reaching your container — by
-  design.
+  floo gateway is the only path into your container. Ingress is
+  locked to the internal load balancer and there is no public
+  invoker grant. The deploy pipeline raises if a deploy would
+  somehow ship with public ingress.
+- **Don't curl the direct runtime URL in scripts or tests.** It
+  returns 403 before reaching your container — by design.
 - **Don't accept identity headers from any other path.** The trust
   boundary is the gateway, not the network in general. Authenticate
   inter-service or internal-cron calls separately.
@@ -566,4 +565,80 @@ fn init_interactive(
     eprintln!("        every 'git push' to your default branch deploys to dev.");
     eprintln!("  Edit floo.app.toml to configure services; run 'floo preflight' to validate.");
     output::success(&format!("Initialized app '{app_name}'."), None);
+}
+
+#[cfg(test)]
+mod substrate_naming_tests {
+    //! Customer-facing text names floo, never the cloud floo runs on.
+    //!
+    //! Naming the substrate hands the reader the premise for "just deploy on
+    //! the underlying provider yourself". See the invariant in the floo repo's
+    //! `docs/knowledge/running-the-firm/icp-and-positioning.md`.
+    //!
+    //! `AGENTS_MD_TEMPLATE` matters most: `floo init` writes it into the
+    //! customer's own repository, where their agent reads it on every task.
+
+    const BANNED: &[&str] = &[
+        "Cloud Run",
+        "cloud run",
+        "Cloud SQL",
+        "Artifact Registry",
+        "Memorystore",
+        "Google Cloud",
+        "GCP",
+        "gcloud",
+        "run.app",
+        "INGRESS_TRAFFIC",
+        "allUsers",
+    ];
+
+    fn offenders(haystack: &str) -> Vec<&'static str> {
+        BANNED
+            .iter()
+            .copied()
+            .filter(|needle| haystack.contains(needle))
+            .collect()
+    }
+
+    #[test]
+    fn agents_md_template_never_names_the_substrate() {
+        let found = offenders(super::AGENTS_MD_TEMPLATE);
+        assert!(
+            found.is_empty(),
+            "AGENTS_MD_TEMPLATE is written into customer repositories and names \
+the substrate: {found:?}"
+        );
+    }
+
+    #[test]
+    fn app_toml_header_never_names_the_substrate() {
+        let found = offenders(super::APP_TOML_HEADER);
+        assert!(
+            found.is_empty(),
+            "APP_TOML_HEADER is written into customer repositories and names \
+the substrate: {found:?}"
+        );
+    }
+
+    #[test]
+    fn bundled_offline_docs_never_name_the_substrate() {
+        // `floo docs <topic>` prints these verbatim.
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/docs/offline");
+        let mut checked = 0usize;
+        for entry in std::fs::read_dir(dir).expect("docs/offline is readable") {
+            let path = entry.expect("readable dir entry").path();
+            if path.extension().is_none_or(|ext| ext != "md") {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).expect("readable doc");
+            let found = offenders(&body);
+            assert!(
+                found.is_empty(),
+                "{} names the substrate: {found:?}",
+                path.display()
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "no offline docs were scanned from {dir}");
+    }
 }

--- a/src/commands/previews.rs
+++ b/src/commands/previews.rs
@@ -201,7 +201,7 @@ pub fn delete(app_flag: Option<&str>, preview_identifier: &str, yes: bool) {
         let risk: RiskMetadata = Tier::Two.into();
         output::dry_run_preview(
             &format!(
-                "Would delete preview sandbox '{preview}'. Cloud Run services, preview-owned resources, routes, and env vars would be torn down; dev and prod are untouched."
+                "Would delete preview sandbox '{preview}'. Preview-owned services, resources, routes, and env vars would be torn down; dev and prod are untouched."
             ),
             serde_json::json!({
                 "action": "preview_delete",

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1199,9 +1199,7 @@ ingress = "public"
         .env("HOME", "/tmp/floo-test-nonexistent")
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "Cloud SQL socket-style DATABASE_URL",
-        ))
+        .stdout(predicate::str::contains("socket-style DATABASE_URL"))
         .stdout(predicate::str::contains("Rails parses DATABASE_URL"));
 }
 


### PR DESCRIPTION
Matches the platform-side fix in getfloo/floo#2239. The CLI leaked the substrate across every customer-facing surface it owns: 30 mentions in `src/`, 18 in the bundled offline docs.

## The worst one ships into customer repositories

`AGENTS_MD_TEMPLATE` is what `floo init` writes into the customer's own repo, where their coding agent reads it on every task. It named Cloud Run six times and included:

```
Don't shell out to `gcloud run deploy` — it bypasses the floo pipeline.
...
the floo gateway is the only path into your container — Cloud Run
ingress is locked to `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` and
there's no `allUsers` invoker grant.
...
Don't curl your `*.run.app` URL in scripts or tests.
```

Provider IAM constants, quoted verbatim, in a file we hand to customers. Now:

```
the floo gateway is the only path into your container. Ingress is
locked to the internal load balancer and there is no public
invoker grant.
```

**One judgment call worth review:** the old text named `gcloud run deploy` exactly, which made the "don't bypass floo" warning concrete for an agent. It now reads "Don't deploy with another cloud provider's CLI". Slightly less specific, and I think still effective since an agent recognizes what that means. Push back if you'd rather keep the teeth.

## Bundled offline docs

18 mentions across 10 files, all printed verbatim by `floo docs <topic>`. Same wording as the web docs so the two surfaces agree: `/healthz is reserved by floo`, `floo only routes traffic to processes bound to all interfaces`, `Real managed Postgres connection`.

## Printed strings

- `floo apps` runtime-URL hint: "direct Cloud Run URL" -> "direct runtime URL"
- `floo previews delete` dry-run text
- `floo dev` Postgres-timeout warning: "until Cloud SQL finishes applying it" -> "until the database finishes applying it"
- Rails socket-DSN preflight finding (kept the literal `/cloudsql/...` example, since that is the actual DSN shape a customer may have; dropped it from the prose)
- Two clap help texts reachable from `--help`

## Regression guard

`src/commands/init.rs` gains tests covering `AGENTS_MD_TEMPLATE`, `APP_TOML_HEADER`, and every file in `docs/offline/`. Mirrors `api/tests/test_customer_facing_substrate.py` from getfloo/floo#2239.

I verified the guard fails rather than passing vacuously: appending "This runs on Cloud Run." to `docs/offline/edge.md` produces

```
docs/offline/edge.md names the substrate: ["Cloud Run"]
```

## Deliberately unchanged

- **`ApiService.cloud_run_url`** — the wire field name shared with the API, so renaming is a cross-repo contract change. Tracked in getfloo/floo#2254 with the other `cloud_run_*` identifiers. It derives `Serialize`, so it can reach `--json` consumers.
- **Internal `//` and `///` comments.** No customer sees them, and the repo is open source anyway.

## Verification

`cargo fmt --check` clean, `clippy --all-targets` zero errors, 503 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
