### PR TITLE
fix: scan tracked files in the brand-case test

### DIFF
--- a/tests/brand_case_test.rs
+++ b/tests/brand_case_test.rs
@@ -1,22 +1,48 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const CAPITALIZED_PRODUCT_NAME: &str = concat!("Fl", "oo");
 
-fn collect_files(directory: &Path, files: &mut Vec<PathBuf>) {
-    for entry in fs::read_dir(directory).expect("read repository directory") {
-        let entry = entry.expect("read repository entry");
-        let path = entry.path();
-        let file_name = entry.file_name();
+/// Every file Git tracks, and nothing else.
+///
+/// A directory walk that skips only `.git` and `target` still descends into
+/// `.claude/worktrees/`, where this repo keeps its agent worktrees. Those hold
+/// older checkouts of this same repository, so the walk reported their stale
+/// capitalizations as violations of the current tree. That failed for anyone
+/// using a worktree while passing in CI, where a fresh clone has no such
+/// directory.
+///
+/// Asking Git keeps the scan to what the repository actually ships, and needs
+/// no exclusion list to maintain as new tooling directories appear.
+fn tracked_files(root: &Path) -> Vec<PathBuf> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z"])
+        .current_dir(root)
+        .output()
+        .expect("run `git ls-files` from the repository root");
 
-        if path.is_dir() {
-            if file_name != ".git" && file_name != "target" {
-                collect_files(&path, files);
-            }
-        } else if path.is_file() {
-            files.push(path);
-        }
-    }
+    assert!(
+        output.status.success(),
+        "`git ls-files` failed in {}: {}",
+        root.display(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("`git ls-files` emits UTF-8 paths");
+    let files: Vec<PathBuf> = stdout
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| root.join(entry))
+        .collect();
+
+    assert!(
+        !files.is_empty(),
+        "`git ls-files` returned no files in {}; the scan would pass vacuously",
+        root.display()
+    );
+
+    files
 }
 
 fn has_non_protocol_product_name(line: &str) -> bool {
@@ -36,8 +62,7 @@ fn has_non_protocol_product_name(line: &str) -> bool {
 #[test]
 fn product_name_is_lowercase_across_the_cli_repository() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut files = Vec::new();
-    collect_files(root, &mut files);
+    let files = tracked_files(root);
 
     let mut violations = Vec::new();
     for path in files {


### PR DESCRIPTION
## Problem

`product_name_is_lowercase_across_the_cli_repository` walks the filesystem from `CARGO_MANIFEST_DIR`, excluding only two directories:

```rust
if file_name != ".git" && file_name != "target" {
```

So it descends into `.claude/worktrees/`, where this repo keeps agent worktrees. Those contain older checkouts of this same repository, and their stale `Floo` capitalizations get reported as violations of the current tree:

```
the floo product name must be lowercase; protocol header names are the only exception:
.claude/worktrees/1770-localhost-diagnostics/Cargo.toml:5: description = "CLI for Floo — deploy, manage, and observe web apps"
.claude/worktrees/1770-localhost-diagnostics/LICENSE:3: Copyright (c) 2026 Floo Contributors
...
```

Every violation was inside that directory. The real tree has zero.

**The failure mode is the bad part.** CI clones fresh, so there is no `.claude/worktrees/` and the test passes. It fails only for developers working in a worktree, which is this repo's normal workflow. Green remotely, red locally, on clean code. I hit it immediately after merging #255.

## Fix

Enumerate with `git ls-files -z`.

This covers exactly what the repository ships. It needs no exclusion list to maintain as new tooling directories appear, and it cannot wander into an untracked checkout again. A failed or empty `git ls-files` aborts with a clear message rather than letting the assertion pass vacuously over zero files.

## Verified both directions

Appending `# Deploy on Floo today.` to a tracked file still fails, with the path and line:

```
docs/offline/edge.md:72: # Deploy on Floo today.
```

An untracked file containing `Floo` is ignored, which is the whole point.

`cargo fmt --check` clean, clippy zero errors, 522 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
