### PR TITLE
feat: rename `floo reparo events` to `floo events list`

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1457,9 +1457,12 @@ impl FlooClient {
         self.handle_response_value(resp)
     }
 
-    // --- Reparo ---
+    // --- Agent events ---
 
-    pub fn reparo_events(&self, app_id: &str, status: Option<&str>) -> Result<Value, FlooApiError> {
+    pub fn agent_events(&self, app_id: &str, status: Option<&str>) -> Result<Value, FlooApiError> {
+        // The server route still carries the old feature name. It is internal
+        // (customers reach this through `floo events list`), so it is renamed
+        // server-side separately rather than blocking the CLI surface.
         let path = format!("/v1/apps/{app_id}/reparo/events");
         let resp = if let Some(s) = status {
             self.get_with_query(&path, &[("status", s)])?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -433,9 +433,9 @@ read-only + manual trigger; new jobs are added by editing config and deploying."
     )]
     Cron(CronCommands),
 
-    /// Manage Reparo auto-recovery events.
+    /// Inspect agent events: failed deploys and repeating runtime errors.
     #[command(subcommand)]
-    Reparo(ReparoCommands),
+    Events(EventsCommands),
 
     /// Diagnose an app's posture in one round trip.
     #[command(
@@ -1881,9 +1881,9 @@ prod databases.")]
 }
 
 #[derive(Subcommand)]
-pub enum ReparoCommands {
-    /// List Reparo auto-recovery events for an app.
-    Events {
+pub enum EventsCommands {
+    /// List agent events for an app.
+    List {
         /// App name or ID (reads from config if omitted).
         #[arg(short, long)]
         app: Option<String>,
@@ -2692,9 +2692,9 @@ pub fn run() {
             }
         },
 
-        Commands::Reparo(sub) => match sub {
-            ReparoCommands::Events { app, status } => {
-                commands::reparo::events(app.as_deref(), status.as_deref())
+        Commands::Events(sub) => match sub {
+            EventsCommands::List { app, status } => {
+                commands::events::list(app.as_deref(), status.as_deref())
             }
         },
 

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -3,12 +3,12 @@ use std::process;
 use crate::errors::ErrorCode;
 use crate::output;
 
-pub fn events(app_flag: Option<&str>, status_filter: Option<&str>) {
+pub fn list(app_flag: Option<&str>, status_filter: Option<&str>) {
     super::require_auth();
     let client = super::init_client(None);
     let (app_id, _app_name) = super::resolve_app_from_config(&client, app_flag);
 
-    let result = match client.reparo_events(&app_id, status_filter) {
+    let result = match client.agent_events(&app_id, status_filter) {
         Ok(r) => r,
         Err(e) => {
             output::error(&e.message, &ErrorCode::from_api(&e.code), None);
@@ -17,18 +17,18 @@ pub fn events(app_flag: Option<&str>, status_filter: Option<&str>) {
     };
 
     if output::is_json_mode() {
-        output::success("Reparo events.", Some(result));
+        output::success("Agent events.", Some(result));
         return;
     }
 
     let events_arr = result.get("events").and_then(|v| v.as_array());
     let Some(events) = events_arr else {
-        output::info("No Reparo events.", None);
+        output::info("No agent events.", None);
         return;
     };
 
     if events.is_empty() {
-        output::info("No Reparo events.", None);
+        output::info("No agent events.", None);
         return;
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod doctor;
 pub mod domains;
 pub mod edge;
 pub mod env;
+pub mod events;
 pub mod feedback;
 pub mod github;
 pub mod init;
@@ -30,7 +31,6 @@ pub mod organization_sso;
 pub mod orgs;
 pub mod previews;
 pub mod releases;
-pub mod reparo;
 pub mod rollbacks;
 pub mod run;
 


### PR DESCRIPTION
## Why

Reparo was a spell name. A customer reading `floo reparo events` cannot guess what it does, so the term needed a glossary entry to be usable — and the magic-spell framing works against the brand rule about not making production infrastructure sound magical.

Marketing already dropped it, and `guides/agent-webhooks.mdx` has carried this note for a while:

> The CLI subcommand is still `floo reparo events` for now — a rename is planned.

This executes that.

## Why `events` and not `monitoring`

Monitoring observes and alerts a human: dashboards, metrics, thresholds. This detects two event classes (failed deploys, repeating runtime errors) and routes them to something that *acts*. Different job.

Calling it monitoring would also collide with `floo logs` and the analytics surfaces, and invite comparison against Datadog and Sentry on coverage we are not building.

`floo events list` says what it is. `floo deploys` already covers deploy history, so the two stay distinct.

## Changes

| Before | After |
|---|---|
| `floo reparo events --app X` | `floo events list --app X` |
| `src/commands/reparo.rs` | `src/commands/events.rs` |
| `ReparoCommands::Events` | `EventsCommands::List` |
| `client.reparo_events()` | `client.agent_events()` |
| "Reparo events." / "No Reparo events." | "Agent events." / "No agent events." |

**No deprecation window.** No external users, so the old command is removed rather than aliased.

## Deliberately unchanged

- **The server route** is still `/v1/apps/{id}/reparo/events`. Internal, reached only through this command, so it gets renamed server-side separately rather than blocking the CLI surface. Noted at the call site.
- **The `[reparo]` config-block test.** It pins that a `floo.app.toml` still carrying that dead section keeps parsing, which matters for any repo that has one.

## Verified

`cargo fmt --check` clean, clippy zero errors, 522 tests pass. Confirmed `floo events --help` renders the new surface and `floo reparo` no longer resolves:

```
error: unrecognized subcommand 'reparo'
  tip: a similar subcommand exists: 'redeploy'
```

Docs follow in getfloo/floo-docs#41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)