### PR TITLE
feat: accept a per-service dockerfile and stop guessing for workspaces

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -850,6 +850,7 @@ mod tests {
         AppServiceEntry {
             service_type: AppServiceType::Web,
             path: Some(".".into()),
+            dockerfile: None,
             repo: repo.map(String::from),
             version: None,
             plan: None,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -285,6 +285,18 @@ fn generate_dockerfile_if_needed(
         }
     }
 
+    // Say why, rather than silently skipping. A workspace repo that gets no
+    // Dockerfile and no explanation looks like init half-finished.
+    if dockerfile::is_workspace_root(project_path) {
+        output::warn(
+            "Skipped the Dockerfile: this is a workspace repository, and a generated \
+one would copy only the root manifest and fail to install shared packages. Write \
+one per service and point at it with `dockerfile` in floo.app.toml. See \
+https://getfloo.com/docs/reference/container-contract",
+        );
+        return false;
+    }
+
     let content = match dockerfile::generate_dockerfile(detection, project_path) {
         Some(c) => c,
         None => return false,

--- a/src/dockerfile.rs
+++ b/src/dockerfile.rs
@@ -144,10 +144,44 @@ fn detect_python_version(path: &Path) -> String {
     "3.13".to_string()
 }
 
+/// True when the directory is the root of a package-manager workspace.
+///
+/// The generated templates copy only the root manifest and lockfile, so a
+/// workspace whose packages import each other cannot install from them. Writing
+/// a Dockerfile that is guaranteed to fail is worse than writing none: the user
+/// debugs our guess instead of their build. See getfloo/floo#2282.
+pub fn is_workspace_root(path: &Path) -> bool {
+    if path.join("pnpm-workspace.yaml").exists() {
+        return true;
+    }
+    for manifest in ["package.json", "deno.json", "deno.jsonc"] {
+        let Ok(text) = std::fs::read_to_string(path.join(manifest)) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+            continue;
+        };
+        if value.get("workspaces").is_some() {
+            return true;
+        }
+    }
+    if let Ok(text) = std::fs::read_to_string(path.join("Cargo.toml")) {
+        if text.contains("[workspace]") {
+            return true;
+        }
+    }
+    false
+}
+
 /// Generate a Dockerfile for the detected runtime/framework.
 /// Returns None if a Dockerfile already exists (runtime == "docker") or runtime is unknown.
 pub fn generate_dockerfile(detection: &DetectionResult, project_path: &Path) -> Option<String> {
     if detection.runtime == "docker" || detection.runtime == "unknown" {
+        return None;
+    }
+
+    // A workspace needs a Dockerfile these templates cannot write.
+    if is_workspace_root(project_path) {
         return None;
     }
 
@@ -687,5 +721,89 @@ mod tests {
     fn test_detect_python_version_default() {
         let dir = TempDir::new().unwrap();
         assert_eq!(detect_python_version(dir.path()), "3.13");
+    }
+}
+
+#[cfg(test)]
+mod workspace_detection_tests {
+    use super::*;
+    use std::fs;
+
+    fn detection(runtime: &str, framework: Option<&str>) -> DetectionResult {
+        DetectionResult {
+            runtime: runtime.to_string(),
+            framework: framework.map(str::to_string),
+            confidence: "high".to_string(),
+            version: None,
+            reason: String::new(),
+        }
+    }
+
+    #[test]
+    fn pnpm_workspace_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'apps/*'\n",
+        )
+        .unwrap();
+        assert!(is_workspace_root(dir.path()));
+    }
+
+    #[test]
+    fn npm_workspaces_field_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["apps/*"]}"#,
+        )
+        .unwrap();
+        assert!(is_workspace_root(dir.path()));
+    }
+
+    #[test]
+    fn cargo_workspace_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"a\"]\n",
+        )
+        .unwrap();
+        assert!(is_workspace_root(dir.path()));
+    }
+
+    #[test]
+    fn plain_package_is_not_a_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"app","dependencies":{"express":"^4"}}"#,
+        )
+        .unwrap();
+        assert!(!is_workspace_root(dir.path()));
+    }
+
+    #[test]
+    fn generation_declines_for_a_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'apps/*'\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("package.json"), r#"{"name":"root"}"#).unwrap();
+
+        assert!(generate_dockerfile(&detection("nodejs", Some("Express")), dir.path()).is_none());
+    }
+
+    #[test]
+    fn generation_still_works_for_a_single_package_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("package.json"), r#"{"name":"app"}"#).unwrap();
+        fs::write(dir.path().join("index.js"), "").unwrap();
+
+        let content =
+            generate_dockerfile(&detection("nodejs", Some("Express")), dir.path()).unwrap();
+        assert!(content.contains("FROM node:"));
     }
 }

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -305,6 +305,12 @@ pub struct AppServiceEntry {
     pub service_type: AppServiceType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Dockerfile location relative to the repository root. Setting it moves the
+    /// build context to the root, so a service can reach files outside its own
+    /// directory. Required for workspace repos where a service imports shared
+    /// packages; without it the context is `path` and siblings are unreachable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dockerfile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -393,6 +399,7 @@ impl AppServiceEntry {
         Self {
             service_type,
             path: Some(path.into()),
+            dockerfile: None,
             repo: None,
             version: None,
             plan: None,

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -511,6 +511,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -534,6 +535,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Web,
                 path: Some("./frontend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -640,6 +642,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -775,6 +778,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -845,6 +849,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -941,6 +946,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1048,6 +1054,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend/".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1258,6 +1265,7 @@ ingress = "public"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1353,6 +1361,7 @@ ingress = "internal"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1376,6 +1385,7 @@ ingress = "internal"
             AppServiceEntry {
                 service_type: AppServiceType::Worker,
                 path: Some("./worker".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1455,6 +1465,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1535,6 +1546,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1605,6 +1617,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1628,6 +1641,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Web,
                 path: Some("./frontend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1704,6 +1718,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1823,6 +1838,7 @@ domain = "svc.example.com"
         let app_override = AppServiceEntry {
             service_type: AppServiceType::Api,
             path: Some("backend".to_string()),
+            dockerfile: None,
             repo: None,
             version: None,
             plan: None,
@@ -1869,6 +1885,7 @@ domain = "svc.example.com"
         let app_override = AppServiceEntry {
             service_type: AppServiceType::Worker,
             path: Some("jobs".to_string()),
+            dockerfile: None,
             repo: None,
             version: None,
             plan: None,
@@ -1911,6 +1928,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Api,
                 path: Some("./backend".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -1978,6 +1996,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Worker,
                 path: Some("./worker".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -2001,6 +2020,7 @@ domain = "svc.example.com"
             AppServiceEntry {
                 service_type: AppServiceType::Web,
                 path: Some("./web".to_string()),
+                dockerfile: None,
                 repo: None,
                 version: None,
                 plan: None,
@@ -2133,6 +2153,7 @@ domain = "svc.example.com"
                     AppServiceEntry {
                         service_type: AppServiceType::Web,
                         path: Some("./frontend".to_string()),
+                        dockerfile: None,
                         repo: None,
                         version: None,
                         plan: None,
@@ -2198,6 +2219,7 @@ domain = "svc.example.com"
                     AppServiceEntry {
                         service_type: AppServiceType::Web,
                         path: Some(".".to_string()),
+                        dockerfile: None,
                         repo: None,
                         version: None,
                         plan: None,


### PR DESCRIPTION
CLI half of the monorepo work. API side is getfloo/floo#2288.

## `dockerfile` on a service entry (getfloo/floo#2282)

```toml
[services.web]
path = "./apps/web"
dockerfile = "apps/web/Dockerfile"
```

Names a Dockerfile relative to the repository root. Setting it moves the build context to the root so a service can reach shared packages; leaving it unset keeps today's behavior.

## `floo init` stops writing Dockerfiles it knows will fail (getfloo/floo#2283)

The templates copy only the root manifest and lockfile:

```dockerfile
COPY package.json pnpm-lock.yaml* ./
RUN pnpm install --frozen-lockfile
```

In a workspace that cannot resolve `workspace:*`. So we detected the package manager and then wrote a Dockerfile guaranteed to fail — the user debugged our guess instead of their build, with nothing pointing at floo as the cause.

`init` now detects a workspace root and declines, with a reason:

> Skipped the Dockerfile: this is a workspace repository, and a generated one would copy only the root manifest and fail to install shared packages. Write one per service and point at it with `dockerfile` in floo.app.toml. See https://getfloo.com/docs/reference/container-contract

Detection covers `pnpm-workspace.yaml`, a `workspaces` field in `package.json` or `deno.json`, and `[workspace]` in `Cargo.toml`.

**Generation is unchanged for single-package repos.** It works well there and writing the Dockerfile for you is worth keeping. This narrows it to the cases it handles rather than removing it.

## Tests

Six. Four cover detection, one asserts generation declines for a workspace, and one asserts **single-package generation still works** — that last one is the guard that matters, because the failure mode of this change is silently disabling a feature that was fine.

## Verification

`cargo fmt --check` clean, clippy 0 errors, 528 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
