### PR TITLE
fix: clarify version update status

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ curl -fsSL https://getfloo.com/install.sh | FLOO_INSTALL_DIR="$HOME/.local/bin" 
 ## Updating
 
 ```bash
-# Show installed version
+# Check for updates and show the installed version
 floo version
 
 # Update to latest release

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -456,7 +456,7 @@ material, no runtime audit payloads. Those live on dedicated surfaces."
     #[command(name = "commands")]
     Discover,
 
-    /// Print installed CLI version.
+    /// Check for updates and print the installed CLI version.
     Version,
 
     /// Update the CLI binary in-place.

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -57,8 +57,12 @@ fn refresh_and_announce_skills() -> Vec<String> {
 /// Respects `FLOO_NO_UPDATE_CHECK` and `floo-local` dev builds.
 pub fn version() {
     if should_skip_network_check() {
-        emit_version(None);
+        emit_version(None, false);
         return;
+    }
+
+    if !output::is_json_mode() {
+        output::info("Checking for floo updates...", None);
     }
 
     // Call run_update unconditionally — it knows how to say "already up to
@@ -68,11 +72,11 @@ pub fn version() {
     match updater::run_update(None) {
         Ok(result) => {
             refresh_and_announce_skills();
-            emit_version(Some(&result.version));
+            emit_version(Some(&result.version), true);
         }
         Err(err) if err.code == ErrorCode::AlreadyUpToDate => {
             refresh_and_announce_skills();
-            emit_version(None);
+            emit_version(None, true);
         }
         // Release assets not yet uploaded (race between release creation and
         // the CI workflow finishing). Transient — silently skip so `floo version`
@@ -81,7 +85,7 @@ pub fn version() {
             if err.code == ErrorCode::ReleaseAssetMissing
                 || err.code == ErrorCode::ChecksumMissing =>
         {
-            emit_version(None);
+            emit_version(None, false);
         }
         Err(err) => {
             // Network/checksum/permission failure. Surface the reason so
@@ -92,7 +96,7 @@ pub fn version() {
             if let Some(sug) = &err.suggestion {
                 output::warn(sug);
             }
-            emit_version(None);
+            emit_version(None, false);
         }
     }
 }
@@ -116,7 +120,7 @@ pub fn version() {
 ///     non-empty and machine-parseable. The bare tag on stdout also
 ///     matches what users get from `git --version`, `curl --version`,
 ///     etc.
-fn emit_version(freshly_installed: Option<&str>) {
+fn emit_version(freshly_installed: Option<&str>, checked_for_updates: bool) {
     let (installed, payload) = match freshly_installed {
         Some(new_tag) => {
             let installed = display_tag(new_tag);
@@ -144,7 +148,24 @@ fn emit_version(freshly_installed: Option<&str>) {
     if !output::is_json_mode() {
         output::raw_value(&installed);
     }
-    output::success(&format!("floo {installed}"), Some(payload));
+    output::success(
+        &version_success_message(&installed, freshly_installed, checked_for_updates),
+        Some(payload),
+    );
+}
+
+fn version_success_message(
+    installed: &str,
+    freshly_installed: Option<&str>,
+    checked_for_updates: bool,
+) -> String {
+    if freshly_installed.is_some() {
+        format!("Updated floo from {} to {installed}.", display_tag(VERSION))
+    } else if checked_for_updates {
+        format!("floo {installed} is up to date.")
+    } else {
+        format!("floo {installed}")
+    }
 }
 
 pub fn update(version: Option<&str>) {
@@ -253,6 +274,25 @@ mod tests {
         assert_eq!(super::display_tag("0.4.2"), "0.4.2");
         assert_eq!(super::display_tag("v2026.04.12"), "2026.04.12");
         assert_eq!(super::display_tag(""), "");
+    }
+
+    #[test]
+    fn test_version_success_message_distinguishes_update_outcomes() {
+        assert_eq!(
+            super::version_success_message("2026.08.31", Some("v2026.08.31"), true),
+            format!(
+                "Updated floo from {} to 2026.08.31.",
+                super::display_tag(crate::constants::VERSION)
+            )
+        );
+        assert_eq!(
+            super::version_success_message("2026.08.31", None, true),
+            "floo 2026.08.31 is up to date."
+        );
+        assert_eq!(
+            super::version_success_message("2026.08.31", None, false),
+            "floo 2026.08.31"
+        );
     }
 
     /// `FLOO_NO_UPDATE_CHECK=1` MUST cause `should_skip_network_check()`

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -15,6 +15,11 @@ fn floo() -> Command {
     Command::cargo_bin("floo-local").unwrap()
 }
 
+#[allow(deprecated)]
+fn installed_floo() -> Command {
+    Command::cargo_bin("floo").unwrap()
+}
+
 /// Create temp HOME with config pointing at mock server.
 fn setup_config(server: &Server) -> TempDir {
     let home = TempDir::new().unwrap();
@@ -5729,6 +5734,47 @@ fn test_deploy_json_mode_uses_polling() {
 }
 
 // ───────────────────────── Update ─────────────────────────
+
+#[test]
+fn test_version_human_reports_up_to_date_after_successful_check() {
+    let Some(asset_name) = update_asset_name() else {
+        return;
+    };
+
+    let mut server = Server::new();
+    let release = serde_json::json!({
+        "tag_name": "v0.0.0-dev",
+        "assets": [
+            {"name": asset_name, "browser_download_url": "https://example.com/binary"},
+            {"name": format!("{asset_name}.sha256"), "browser_download_url": "https://example.com/checksum"},
+            {"name": format!("{asset_name}.sig"), "browser_download_url": "https://example.com/signature"}
+        ],
+    });
+    let release_mock = server
+        .mock("GET", "/releases/latest")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(release.to_string())
+        .create();
+
+    let home = TempDir::new().unwrap();
+    let install_dir = TempDir::new().unwrap();
+    let install_path = install_dir.path().join("floo");
+
+    installed_floo()
+        .arg("version")
+        .env("HOME", home.path())
+        .env("FLOO_UPDATE_API_BASE", format!("{}/releases", server.url()))
+        .env("FLOO_UPDATE_TARGET_PATH", install_path.as_os_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0.0.0-dev"))
+        .stderr(predicate::str::contains("Checking for floo updates..."))
+        .stderr(predicate::str::contains("floo 0.0.0-dev is up to date."))
+        .stderr(predicate::str::contains("Updated floo from").not());
+
+    release_mock.assert();
+}
 
 #[test]
 fn test_update_json_release_lookup_failure() {


### PR DESCRIPTION
## Summary

- show when floo version is checking for updates
- distinguish an inline update from an already-current install
- keep stdout and JSON contracts unchanged
- align help and README wording with the live update check

## Verification

- full scripts/test suite: 531 unit, 149 CLI, and 183 mock/API tests passed
- focused live-check regression uses a mocked release endpoint and an installed-name floo binary