### PR TITLE
fix: make skill refresh idempotent

### DIFF
--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -1,6 +1,6 @@
 use std::fs;
-use std::io::Write;
-use std::path::PathBuf;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::process;
 
 use colored::Colorize;
@@ -180,7 +180,40 @@ pub fn install(path: Option<PathBuf>, print: bool) {
     }
 }
 
-/// Refresh all tracked skill files. Returns the list of paths that were refreshed.
+/// Write embedded content only when the file is missing or differs on disk.
+fn write_if_changed(path: &Path, content: &str) -> io::Result<bool> {
+    if fs::read(path).is_ok_and(|existing| existing == content.as_bytes()) {
+        return Ok(false);
+    }
+
+    fs::write(path, content)?;
+    Ok(true)
+}
+
+/// Refresh one tracked skill bundle. Returns whether any bundled file changed.
+fn refresh_skill_bundle(path: &Path) -> io::Result<bool> {
+    let mut changed = write_if_changed(path, SKILL_CONTENT)?;
+
+    if let Some(parent) = path.parent() {
+        for (skill_name, skill_content) in PLUGIN_SKILLS {
+            let skill_dir = parent.join(skill_name);
+            let _ = fs::create_dir_all(&skill_dir);
+            let skill_path = skill_dir.join("SKILL.md");
+            match write_if_changed(&skill_path, skill_content) {
+                Ok(plugin_changed) => changed |= plugin_changed,
+                Err(e) => {
+                    if !output::is_json_mode() {
+                        eprintln!("  Warning: failed to refresh {skill_name} skill: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(changed)
+}
+
+/// Refresh changed tracked skill bundles. Returns the list of paths that changed.
 /// Removes stale paths (directories that no longer exist) from tracking.
 /// Reports errors for write failures without removing those paths.
 pub fn refresh_skill_files() -> Vec<String> {
@@ -204,24 +237,12 @@ pub fn refresh_skill_files() -> Vec<String> {
             continue;
         }
 
-        match fs::write(&path, SKILL_CONTENT) {
-            Ok(()) => {
-                refreshed.push(path_str.clone());
-                still_valid.push(path_str.clone());
-
-                // Refresh plugin skills as sibling directories
-                if let Some(parent) = path.parent() {
-                    for (skill_name, skill_content) in PLUGIN_SKILLS {
-                        let skill_dir = parent.join(skill_name);
-                        let _ = fs::create_dir_all(&skill_dir);
-                        let skill_path = skill_dir.join("SKILL.md");
-                        if let Err(e) = fs::write(&skill_path, skill_content) {
-                            if !output::is_json_mode() {
-                                eprintln!("  Warning: failed to refresh {skill_name} skill: {e}");
-                            }
-                        }
-                    }
+        match refresh_skill_bundle(&path) {
+            Ok(changed) => {
+                if changed {
+                    refreshed.push(path_str.clone());
                 }
+                still_valid.push(path_str.clone());
             }
             Err(e) => {
                 // Write failed but directory exists — keep tracking, report error
@@ -421,6 +442,37 @@ mod tests {
                 "{name} skill frontmatter name mismatch"
             );
         }
+    }
+
+    #[test]
+    fn test_skill_bundle_refresh_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_path = dir.path().join("SKILL.md");
+
+        assert!(refresh_skill_bundle(&skill_path).unwrap());
+        assert_eq!(fs::read_to_string(&skill_path).unwrap(), SKILL_CONTENT);
+        for (name, content) in PLUGIN_SKILLS {
+            assert_eq!(
+                fs::read_to_string(dir.path().join(name).join("SKILL.md")).unwrap(),
+                *content
+            );
+        }
+
+        assert!(!refresh_skill_bundle(&skill_path).unwrap());
+    }
+
+    #[test]
+    fn test_skill_bundle_refresh_repairs_plugin_drift_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_path = dir.path().join("SKILL.md");
+        refresh_skill_bundle(&skill_path).unwrap();
+
+        let plugin_path = dir.path().join("floo-services").join("SKILL.md");
+        fs::write(&plugin_path, "stale skill").unwrap();
+
+        assert!(refresh_skill_bundle(&skill_path).unwrap());
+        assert_eq!(fs::read_to_string(plugin_path).unwrap(), SKILL_SERVICES);
+        assert!(!refresh_skill_bundle(&skill_path).unwrap());
     }
 
     #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5760,6 +5760,31 @@ fn test_version_human_reports_up_to_date_after_successful_check() {
     let home = TempDir::new().unwrap();
     let install_dir = TempDir::new().unwrap();
     let install_path = install_dir.path().join("floo");
+    let skill_dir = home.path().join("skills").join("floo");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    let skill_path = skill_dir.join("SKILL.md");
+    std::fs::write(&skill_path, include_str!("../skills/floo/SKILL.md")).unwrap();
+    for (name, content) in [
+        (
+            "floo-services",
+            include_str!("../plugin/skills/floo-services/SKILL.md"),
+        ),
+        (
+            "floo-security",
+            include_str!("../plugin/skills/floo-security/SKILL.md"),
+        ),
+    ] {
+        let plugin_dir = skill_dir.join(name);
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(plugin_dir.join("SKILL.md"), content).unwrap();
+    }
+    let config_dir = home.path().join(".floo");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.json"),
+        serde_json::json!({"skill_paths": [skill_path]}).to_string(),
+    )
+    .unwrap();
 
     installed_floo()
         .arg("version")
@@ -5771,6 +5796,7 @@ fn test_version_human_reports_up_to_date_after_successful_check() {
         .stdout(predicate::str::contains("0.0.0-dev"))
         .stderr(predicate::str::contains("Checking for floo updates..."))
         .stderr(predicate::str::contains("floo 0.0.0-dev is up to date."))
+        .stderr(predicate::str::contains("Refreshed agent skill").not())
         .stderr(predicate::str::contains("Updated floo from").not());
 
     release_mock.assert();


### PR DESCRIPTION
## Summary
- compare tracked main and companion skill files with embedded content before writing
- announce a refresh only when at least one file in the bundle changes
- cover repeated up-to-date version checks and companion-skill drift

## Tests
- FLOO_TEST_CARGO=/Users/patrickdonohoe/.cargo/bin/cargo ./scripts/test