### PR TITLE
fix: show the edge hostname as the service URL, not the Cloud Run origin

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -495,6 +495,15 @@ pub struct ApiService {
     pub service_type: Option<String>,
     pub status: Option<String>,
     pub ingress: Option<String>,
+    /// The address clients actually use: the floo edge hostname for the
+    /// selected environment, or an active custom domain. The server resolves
+    /// it (`compute_service_display_urls`), which never returns a raw Cloud
+    /// Run host. `None` when the service has no public surface — internal
+    /// ingress, a worker/cron type, or an environment with no live surface.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Direct Cloud Run origin behind the edge.
+    /// Debug-only — clients should hit `url` (the gateway URL).
     pub cloud_run_url: Option<String>,
     pub port: Option<u64>,
     #[serde(default)]

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -82,7 +82,12 @@ pub fn list(app: Option<&str>, env: &str) {
             s.service_type.as_deref().unwrap_or("-").to_string(),
             s.status.as_deref().unwrap_or("-").to_string(),
             s.ingress.as_deref().unwrap_or("-").to_string(),
-            s.cloud_run_url.as_deref().unwrap_or("-").to_string(),
+            // The edge hostname, never `cloud_run_url` — that column is a
+            // debug origin, and it is not env-scoped, so a column labelled
+            // "URL" was pointing users past the gateway at (usually) the dev
+            // origin. Services with no public surface get an em dash, like
+            // the managed rows below.
+            s.url.as_deref().unwrap_or("\u{2014}").to_string(),
         ]);
     }
     for ms in &managed_services {
@@ -195,7 +200,7 @@ fn render_app_service(svc: &crate::api_types::ApiService, service_name: &str, ap
     let svc_type = svc.service_type.as_deref().unwrap_or("-");
     let status = svc.status.as_deref().unwrap_or("-");
     let ingress = svc.ingress.as_deref().unwrap_or("-");
-    let url = svc.cloud_run_url.as_deref().unwrap_or("-");
+    let url = svc.url.as_deref().unwrap_or("\u{2014}");
     let port = svc
         .port
         .map(|p| p.to_string())
@@ -224,6 +229,10 @@ fn render_app_service(svc: &crate::api_types::ApiService, service_name: &str, ap
     output::info(&format!("  Status:  {status}"), None);
     output::info(&format!("  Ingress: {ingress}"), None);
     output::info(&format!("  URL:     {url}"), None);
+    if let Some(runtime_url) = svc.cloud_run_url.as_deref() {
+        output::info(&format!("  Runtime URL:  {runtime_url}"), None);
+        output::dim_line("              \u{21b3} direct runtime URL — debug only, not for clients");
+    }
     output::info(&format!("  Port:    {port}"), None);
     output::info("  Configured resources:", None);
     output::info(&format!("    CPU:              {cpu}"), None);

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -146,7 +146,20 @@ fn mock_services_single_for_env(server: &mut Server, environment: Option<&str>) 
         .match_query(Matcher::AllOf(query))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"services":[{"id":"svc-web-1","name":"web","type":"web","status":"live","cloud_run_url":"https://web.floo.app","port":3000,"cpu":"2","memory":"1Gi","max_instances":10,"min_instances":1,"instances":null,"max_request_body_mb":32,"runtime_plan":{"environment":"dev","service_type":"web","availability":"warm","declared":{"cpu":"2","memory":"1Gi","min_instances":1,"max_instances":10,"instances":null},"effective":{"cpu":"2","memory":"1Gi","min_instances":1,"max_instances":10,"instances":null},"sources":{"cpu":"configured","memory":"configured","min_instances":"configured","max_instances":"configured","instances":null},"cpu_allocation":"request_based","cpu_allocation_reason":"http_request_scoped","warnings":[]}}]}"#)
+        .with_body(r#"{"services":[{"id":"svc-web-1","name":"web","type":"web","status":"live","url":"https://my-app-dev-web.on.getfloo.com","cloud_run_url":"https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app","port":3000,"cpu":"2","memory":"1Gi","max_instances":10,"min_instances":1,"instances":null,"max_request_body_mb":32,"runtime_plan":{"environment":"dev","service_type":"web","availability":"warm","declared":{"cpu":"2","memory":"1Gi","min_instances":1,"max_instances":10,"instances":null},"effective":{"cpu":"2","memory":"1Gi","min_instances":1,"max_instances":10,"instances":null},"sources":{"cpu":"configured","memory":"configured","min_instances":"configured","max_instances":"configured","instances":null},"cpu_allocation":"request_based","cpu_allocation_reason":"http_request_scoped","warnings":[]}}]}"#)
+        .create()
+}
+
+/// Mock GET managed-services with an empty set — `services list` always calls it.
+fn mock_managed_services_empty(server: &mut Server) -> Mock {
+    server
+        .mock(
+            "GET",
+            format!("/v1/apps/{TEST_APP_ID}/managed-services").as_str(),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"managed_services":[],"total":0}"#)
         .create()
 }
 
@@ -4007,6 +4020,84 @@ fn test_services_list_partial_view_when_managed_services_fetch_fails() {
 }
 
 #[test]
+fn test_services_list_human_shows_edge_host_not_cloud_run_origin() {
+    // Regression: the URL column used to render `cloud_run_url`, telling users
+    // to hit the Cloud Run origin directly and bypass the gateway. The column
+    // is the edge hostname the server resolved; the origin is not in the table.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_services_single_env(&mut server, "dev");
+    let _managed = mock_managed_services_empty(&mut server);
+
+    floo()
+        .args(["services", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("my-app-dev-web.on.getfloo.com"))
+        .stderr(predicate::str::contains(".run.app").not());
+}
+
+#[test]
+fn test_services_list_human_renders_em_dash_when_service_has_no_public_url() {
+    // A worker has no public surface, so the server sends `url: null` while
+    // still reporting the internal Cloud Run origin. The table must show an
+    // em dash rather than falling back to the origin.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = server
+        .mock("GET", format!("/v1/apps/{TEST_APP_ID}/services").as_str())
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("per_page".into(), "100".into()),
+            Matcher::UrlEncoded("environment".into(), "dev".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"services":[{"id":"svc-worker-1","name":"worker","type":"worker","status":"live","ingress":"internal","url":null,"cloud_run_url":"https://floo-my-app-dev-worker-l3txcgkazq-uc.a.run.app","port":null}]}"#,
+        )
+        .create();
+    let _managed = mock_managed_services_empty(&mut server);
+
+    floo()
+        .args(["services", "list", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("worker"))
+        .stderr(predicate::str::contains("\u{2014}"))
+        .stderr(predicate::str::contains(".run.app").not());
+}
+
+#[test]
+fn test_services_show_human_labels_cloud_run_origin_as_debug_only() {
+    // `services show` keeps the origin — operators need it — but under its own
+    // label and caveat, never as the service's URL.
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let _resolve = mock_resolve_app(&mut server);
+    let _services = mock_services_single_env(&mut server, "dev");
+
+    floo()
+        .args(["services", "show", "web", "--app", TEST_APP_NAME])
+        .env("HOME", home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "URL:     https://my-app-dev-web.on.getfloo.com",
+        ))
+        .stderr(predicate::str::contains(
+            "Runtime URL:  https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app",
+        ))
+        .stderr(predicate::str::contains(
+            "direct runtime URL — debug only, not for clients",
+        ));
+}
+
+#[test]
 fn test_services_list_empty_when_no_services_of_either_kind() {
     let mut server = Server::new();
     let home = setup_config(&server);
@@ -4132,7 +4223,11 @@ fn test_services_show_user_managed() {
     assert_eq!(json["success"], true);
     let service = &json["data"];
     assert_eq!(service["name"], "web");
-    assert_eq!(service["cloud_run_url"], "https://web.floo.app");
+    assert_eq!(service["url"], "https://my-app-dev-web.on.getfloo.com");
+    assert_eq!(
+        service["cloud_run_url"],
+        "https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app"
+    );
     assert_eq!(service["cpu"], "2");
     assert_eq!(service["memory"], "1Gi");
     assert_eq!(service["max_instances"], 10);


### PR DESCRIPTION
Reported as CLI feedback `50b3a92f`: `floo services list` prints raw Cloud Run origin URLs as the service URL with no caveat, while the proper edge hostnames already exist and are only visible via `floo edge routes list`.

## The defect

Both `services list` (the `URL` column) and `services show` (the `URL:` line) rendered `cloud_run_url`. That is the raw Cloud Run origin — the substrate floo otherwise never exposes to customers — and it is the wrong address twice over:

1. **It bypasses the edge.** A client that hits the origin directly skips managed auth, app-scoped API-key enforcement, path routing, and the platform's response-header contract.
2. **It is not environment-scoped.** `cloud_run_url` is a single last-write-wins column on the shared service row. `enrich_service_responses` env-scopes `url` and `status` but passes `cloud_run_url` through untouched, so `--env prod` never changed it. Dev deploys run on every merge to `main` and prod releases are rare, so the value shown was usually the **dev** origin no matter which environment was asked for.

Point 2 is the same defect getfloo/floo#2268 hit from the release lane, recorded in `docs/knowledge/domains/observability.md` ("Do NOT resolve the origin from the platform API's `services.cloud_run_url`"). This is that rule being broken by a second consumer.

## The fix

The correct value already exists on the wire. `ServiceResponse.url` is resolved server-side by `compute_service_display_urls`, which returns the env-scoped gateway host or an active custom domain and is contractually forbidden from returning a `*.run.app` address. The CLI simply never deserialized the field.

- `ApiService` gains `url`; `cloud_run_url` is documented as the debug-only origin. This mirrors the existing `App` / `App.runtime_url` pair.
- The list table's `URL` column and `services show`'s `URL:` line render `url`. A service with no public surface — internal ingress, a `worker`/`cron` type, or a non-live environment — renders an em dash rather than leaking an unreachable origin.
- `services show` keeps the origin under its own `Runtime URL:` label with the same *"direct runtime URL — debug only, not for clients"* caveat `apps show` already uses. `--json` carries both fields, so nothing is lost for agents or scripts.

Before / after for `services list --env prod` on a multi-service app:

```
  URL
  https://floo-my-app-dev-web-l3txcgkazq-uc.a.run.app   ← origin, and the *dev* one
  https://my-app-web.on.getfloo.com                     ← after
```

## Tests

Three regression tests, each verified to fail against the old rendering before being kept:

- `test_services_list_human_shows_edge_host_not_cloud_run_origin`
- `test_services_list_human_renders_em_dash_when_service_has_no_public_url`
- `test_services_show_human_labels_cloud_run_origin_as_debug_only`

The shared services fixture previously used `https://web.floo.app` as its `cloud_run_url`, which is not origin-shaped; it now carries a realistic edge host plus a real `*.run.app` origin, so "the URL column contains no `.run.app`" is a meaningful assertion.

`./scripts/test` green (fmt + clippy + 1885 tests).

A companion one-sentence knowledge update lands in `getfloo/floo`.