### PR TITLE
fix: report real preflight env paths once

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -2305,8 +2305,11 @@ fn generate_security_findings(
     }
 
     // Secret-shaped vars sitting in a web service's env file — they may ship to
-    // the browser. This is the finding that stamps the top-level
-    // `contains_secrets` marker on the JSON payload.
+    // the browser. Group shared env files before scanning so one root `.env`
+    // used by several web services produces one finding per key, with the real
+    // path and every affected service. This is the finding that stamps the
+    // top-level `contains_secrets` marker on the JSON payload.
+    let mut web_env_files: Vec<(PathBuf, String, Vec<String>)> = Vec::new();
     for svc in services {
         if svc.service_type != ServiceType::Web {
             continue;
@@ -2337,35 +2340,59 @@ fn generate_security_findings(
         }
         for env_filename in env_filenames {
             let env_path = svc_dir.join(env_filename);
-            if let Ok(contents) = std::fs::read_to_string(&env_path) {
-                for line in contents.lines() {
-                    let Some((key, _)) = parse_env_line(line) else {
-                        continue;
-                    };
-                    // Check against the deployed (uppercase) form: deploy-sync
-                    // uppercases keys on import, so a lowercase `stripe_secret_key`
-                    // becomes the secret STRIPE_SECRET_KEY at runtime and must be
-                    // flagged. The canonical redactor rule carries the PUBLIC_KEY /
-                    // AWS_REGION allowlist, so preflight flags exactly what
-                    // `--json` would redact — no parallel heuristic that drifts.
-                    // The message keeps the var as written for recognizability.
-                    let key_upper = key.to_uppercase();
-                    let is_frontend_var = key_upper.starts_with("VITE_")
-                        || key_upper.starts_with("NEXT_PUBLIC_")
-                        || key_upper.starts_with("REACT_APP_");
-                    if !is_frontend_var && crate::redact::env_var_key_is_secret(&key_upper) {
-                        findings.push(
-                                PreflightFinding::warning(
-                                    "SECRET_IN_WEB_SERVICE",
-                                    format!(
-                                        "Secret-looking var '{}' in {}/{} — if this is a backend secret, remove it from the web service and set it on the api service: floo env set {}=<val> --service api",
-                                        key, svc.name, env_filename, key
-                                    ),
-                                )
-                                .with_path(&svc.path),
-                            );
-                    }
+            let resolved_env_path = env_path.canonicalize().unwrap_or(env_path);
+            if let Some((_, _, affected_services)) = web_env_files
+                .iter_mut()
+                .find(|(path, _, _)| path == &resolved_env_path)
+            {
+                if !affected_services.contains(&svc.name) {
+                    affected_services.push(svc.name.clone());
                 }
+                continue;
+            }
+            if let Ok(contents) = std::fs::read_to_string(&resolved_env_path) {
+                web_env_files.push((resolved_env_path, contents, vec![svc.name.clone()]));
+            }
+        }
+    }
+
+    for (env_path, contents, mut affected_services) in web_env_files {
+        affected_services.sort();
+        let service_label = if affected_services.len() == 1 {
+            "web service"
+        } else {
+            "web services"
+        };
+        for line in contents.lines() {
+            let Some((key, _)) = parse_env_line(line) else {
+                continue;
+            };
+            // Check against the deployed (uppercase) form: deploy-sync
+            // uppercases keys on import, so a lowercase `stripe_secret_key`
+            // becomes the secret STRIPE_SECRET_KEY at runtime and must be
+            // flagged. The canonical redactor rule carries the PUBLIC_KEY /
+            // AWS_REGION allowlist, so preflight flags exactly what `--json`
+            // would redact — no parallel heuristic that drifts. The message
+            // keeps the var as written for recognizability.
+            let key_upper = key.to_uppercase();
+            let is_frontend_var = key_upper.starts_with("VITE_")
+                || key_upper.starts_with("NEXT_PUBLIC_")
+                || key_upper.starts_with("REACT_APP_");
+            if !is_frontend_var && crate::redact::env_var_key_is_secret(&key_upper) {
+                let path = env_path.to_string_lossy().into_owned();
+                findings.push(
+                    PreflightFinding::warning(
+                        "SECRET_IN_WEB_SERVICE",
+                        format!(
+                            "Secret-looking var '{}' in {} (used by {}: {}) — if this is a backend secret, remove it from this env file and set it only on the backend service that needs it.",
+                            key,
+                            env_path.display(),
+                            service_label,
+                            affected_services.join(", "),
+                        ),
+                    )
+                    .with_path(path),
+                );
             }
         }
     }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -2013,6 +2013,75 @@ ingress = "public"
         ));
 }
 
+/// Several web services may deliberately share one root env file. Preflight
+/// reports the real file once, names every affected service, and never invents
+/// a backend service for the remedy.
+#[test]
+fn test_preflight_deduplicates_shared_web_env_file_warning() {
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("floo.app.toml"),
+        r#"[app]
+name = "myapp"
+
+[services.web]
+type = "web"
+path = "."
+port = 3000
+ingress = "public"
+
+[services.blog]
+type = "web"
+path = "."
+port = 3001
+ingress = "public"
+
+[services.publisher]
+type = "web"
+path = "."
+port = 3002
+ingress = "public"
+
+[services.mcp]
+type = "api"
+path = "."
+port = 8000
+ingress = "public"
+"#,
+    )
+    .unwrap();
+    let env_path = project.path().join(".env");
+    std::fs::write(&env_path, "STRIPE_SECRET_KEY=sk_live_abc\n").unwrap();
+
+    let output = floo()
+        .args(["--json", "preflight", project.path().to_str().unwrap()])
+        .env("HOME", "/tmp/floo-test-nonexistent")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("preflight output must be JSON");
+    let secret_findings: Vec<&serde_json::Value> = payload["data"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|finding| finding["code"] == "SECRET_IN_WEB_SERVICE")
+        .collect();
+    assert_eq!(secret_findings.len(), 1);
+
+    let finding = secret_findings[0];
+    let expected_path = env_path.canonicalize().unwrap().display().to_string();
+    assert_eq!(finding["path"], expected_path);
+    let message = finding["message"].as_str().unwrap();
+    assert!(message.contains(&expected_path));
+    assert!(message.contains("used by web services: blog, publisher, web"));
+    assert!(!message.contains("web/.env"));
+    assert!(!message.contains("blog/.env"));
+    assert!(!message.contains("publisher/.env"));
+    assert!(!message.contains("--service api"));
+}
+
 /// An allowlisted public key (`PUBLIC_KEY`) must NOT be flagged as a secret —
 /// preflight's scan uses the same allowlist as the redaction boundary, so it
 /// doesn't stamp `contains_secrets` for a value the redactor would let through.


### PR DESCRIPTION
## Summary

- group secret scans by the canonical env file actually read
- report shared files once with every affected web service
- remove the hardcoded backend service remedy

## Test plan

- FLOO_TEST_CARGO=/Users/patrickdonohoe/.cargo/bin/cargo ./scripts/test

Closes getfloo/floo#2304