### PR TITLE
fix(config): accept max_request_body_mb in [resources] and inline services

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -3410,9 +3410,111 @@ mod tests {
             cpu: None,
             memory: None,
             max_instances,
+            max_request_body_mb: None,
             min_instances,
             instances,
             migrate_command: None,
+        }
+    }
+
+    #[test]
+    fn test_max_request_body_mb_manifest_reaches_deploy_request() {
+        output::set_json_mode(false);
+        output::set_dry_run_mode(false);
+        // Exercise all discovery paths and each level of resource precedence.
+        for (mode, global, service_file, inline, expected) in [
+            ("inline", Some(16), None, Some(32), Some(32)),
+            ("inline", Some(16), None, None, Some(16)),
+            ("inline", None, None, None, None),
+            ("delegated", Some(16), Some(24), Some(32), Some(32)),
+            ("delegated", Some(16), Some(24), None, Some(24)),
+            ("delegated", Some(16), None, None, Some(16)),
+            ("single", None, Some(32), None, Some(32)),
+            ("single", None, None, None, None),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let resource = |value: Option<u64>| {
+                value.map_or(String::new(), |v| format!("max_request_body_mb = {v}"))
+            };
+            let path = if mode == "delegated" { "api" } else { "." };
+            fs::create_dir_all(dir.path().join(path)).unwrap();
+            if mode != "single" {
+                let port = if mode == "inline" { "port = 8000" } else { "" };
+                fs::write(
+                    dir.path().join("floo.app.toml"),
+                    format!(
+                        r#"[app]
+name = "my-app"
+[resources]
+{}
+[services.api]
+type = "api"
+path = "{path}"
+{port}
+{}
+"#,
+                        resource(global),
+                        resource(inline)
+                    ),
+                )
+                .unwrap();
+            }
+            if mode != "inline" {
+                fs::write(
+                    dir.path().join(path).join("floo.service.toml"),
+                    format!(
+                        r#"[app]
+name = "my-app"
+[service]
+name = "api"
+type = "api"
+port = 8000
+[resources]
+{}
+"#,
+                        resource(service_file)
+                    ),
+                )
+                .unwrap();
+            }
+            let resolved = project_config::resolve_app_context(dir.path(), None).unwrap();
+            let services = project_config::discover_services(&resolved).unwrap();
+            assert_eq!(services.len(), 1);
+            assert_eq!(services[0].max_request_body_mb, expected, "{mode}");
+            let mut server = mockito::Server::new();
+            let mut body = serde_json::json!({
+                "runtime": "python",
+                "services": [{
+                    "name": "api", "service_type": "api", "path": path,
+                    "port": 8000, "ingress": "public"
+                }]
+            });
+            if let Some(value) = expected {
+                body["services"][0]["max_request_body_mb"] = serde_json::json!(value);
+            }
+            let request = server
+                .mock("POST", "/v1/apps/app-1/deploys")
+                .match_body(mockito::Matcher::Json(body))
+                .with_status(200)
+                .with_body(
+                    r#"{"id":"dep-1","status":"pending","created_at":"2024-01-01T00:00:00Z"}"#,
+                )
+                .create();
+            mock_client(&server.url())
+                .create_deploy(
+                    "app-1",
+                    "python",
+                    None,
+                    Some(&services),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .unwrap();
+            request.assert();
         }
     }
 

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -861,6 +861,7 @@ mod tests {
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             dev_command: dev_command.map(String::from),

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{ErrorCode, FlooError};
 
-use super::service_config::{ResourceConfig, ServiceEnvContract, ServiceIngress};
+use super::service_config::{
+    deserialize_max_request_body_mb, validate_max_request_body_mb, ResourceConfig,
+    ServiceEnvContract, ServiceIngress,
+};
 use super::SCHEMA_URL;
 
 /// A single scheduled cron job declared in `[cron.<name>]`.
@@ -351,6 +354,12 @@ pub struct AppServiceEntry {
     pub memory: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_instances: Option<u32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_max_request_body_mb"
+    )]
+    pub max_request_body_mb: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_instances: Option<u32>,
     /// Exact always-on instance count for a `worker` service (getfloo/floo#1801).
@@ -430,6 +439,7 @@ impl AppServiceEntry {
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             dev_command: None,
@@ -463,10 +473,14 @@ pub fn load_app_config(dir: &Path) -> Result<Option<AppFileConfig>, FlooError> {
 }
 
 fn validate_app_config(config: &AppFileConfig) -> Result<(), FlooError> {
+    if let Some(ref resources) = config.resources {
+        validate_max_request_body_mb(resources.max_request_body_mb)?;
+    }
     // Detect inline mode: any user-managed service has `port` set
     let has_inline = config.services.values().any(|e| e.port.is_some());
 
     for (name, entry) in &config.services {
+        validate_max_request_body_mb(entry.max_request_body_mb)?;
         // In inline mode, all services require port and path
         // (path is optional when repo is set — defaults to "." on the server)
         if has_inline {
@@ -705,6 +719,94 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_max_request_body_mb_app_manifest_round_trip_and_omission() {
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        let dir = TempDir::new().unwrap();
+        for value in [
+            None,
+            Some(1),
+            Some(32),
+            Some(super::super::service_config::MAX_REQUEST_BODY_MB_LIMIT),
+        ] {
+            let resource = value.map_or(String::new(), |v| format!("max_request_body_mb = {v}"));
+            fs::write(
+                dir.path().join(super::super::APP_CONFIG_FILE),
+                format!(
+                    r#"[app]
+name = "my-app"
+[resources]
+{resource}
+[services.api]
+type = "api"
+path = "."
+port = 8000
+{resource}
+"#
+                ),
+            )
+            .unwrap();
+            let config = load_app_config(dir.path()).unwrap().unwrap();
+            let serialized = toml::to_string(&config).unwrap();
+            assert_eq!(serialized.contains("max_request_body_mb"), value.is_some());
+            let reloaded: AppFileConfig = toml::from_str(&serialized).unwrap();
+            assert_eq!(reloaded.resources.unwrap().max_request_body_mb, value);
+            assert_eq!(reloaded.services["api"].max_request_body_mb, value);
+            let json = serde_json::to_value(&config).unwrap();
+            for resource in [&json["resources"], &json["services"]["api"]] {
+                assert_eq!(
+                    resource.get("max_request_body_mb").is_some(),
+                    value.is_some()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_max_request_body_mb_app_manifest_rejects_invalid_values() {
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        let dir = TempDir::new().unwrap();
+        let limit = super::super::service_config::MAX_REQUEST_BODY_MB_LIMIT;
+        for section in ["resources", "services.api"] {
+            for value in [
+                "0".to_string(),
+                (limit + 1).to_string(),
+                "-1".to_string(),
+                "1.5".to_string(),
+                "true".to_string(),
+                "\"32\"".to_string(),
+            ] {
+                let service = if section == "services.api" {
+                    "type = \"api\"\npath = \".\"\nport = 8000"
+                } else {
+                    ""
+                };
+                fs::write(
+                    dir.path().join(super::super::APP_CONFIG_FILE),
+                    format!(
+                        r#"[app]
+name = "my-app"
+[{section}]
+{service}
+max_request_body_mb = {value}
+"#
+                    ),
+                )
+                .unwrap();
+                let error = load_app_config(dir.path()).unwrap_err();
+                assert_eq!(error.code, ErrorCode::InvalidProjectConfig);
+                assert!(
+                    error.message.contains(&format!(
+                        "max_request_body_mb must be an integer between 1 and {limit}"
+                    )),
+                    "{section}, {value}: {error}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_load_app_config_with_edge_policy() {

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -79,6 +79,9 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
             let max_instances = entry
                 .max_instances
                 .or_else(|| global_resources.and_then(|r| r.max_instances));
+            let max_request_body_mb = entry
+                .max_request_body_mb
+                .or_else(|| global_resources.and_then(|r| r.max_request_body_mb));
             let min_instances = entry.min_instances.or_else(|| {
                 (service_type != ServiceType::Worker)
                     .then(|| global_resources.and_then(|r| r.min_instances))
@@ -95,6 +98,7 @@ pub fn discover_services(resolved: &ResolvedApp) -> Result<Vec<ServiceConfig>, F
                 cpu,
                 memory,
                 max_instances,
+                max_request_body_mb,
                 min_instances,
                 instances: entry.instances,
                 migrate_command: entry.migrate_command.clone(),
@@ -242,6 +246,7 @@ fn apply_service_file_resources(
         svc.cpu = res.cpu.clone();
         svc.memory = res.memory.clone();
         svc.max_instances = res.max_instances;
+        svc.max_request_body_mb = res.max_request_body_mb;
         svc.min_instances = (!is_worker).then_some(res.min_instances).flatten();
     }
     // Fall back to global for any fields still None
@@ -254,6 +259,9 @@ fn apply_service_file_resources(
         }
         if svc.max_instances.is_none() {
             svc.max_instances = global.max_instances;
+        }
+        if svc.max_request_body_mb.is_none() {
+            svc.max_request_body_mb = global.max_request_body_mb;
         }
         if !is_worker && svc.min_instances.is_none() {
             svc.min_instances = global.min_instances;
@@ -272,6 +280,9 @@ fn apply_app_service_overrides(svc: &mut ServiceConfig, entry: &AppServiceEntry)
     }
     if entry.max_instances.is_some() {
         svc.max_instances = entry.max_instances;
+    }
+    if entry.max_request_body_mb.is_some() {
+        svc.max_request_body_mb = entry.max_request_body_mb;
     }
     if svc.service_type != ServiceType::Worker && entry.min_instances.is_some() {
         svc.min_instances = entry.min_instances;
@@ -522,6 +533,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -546,6 +558,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -653,6 +666,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -789,6 +803,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -860,6 +875,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -957,6 +973,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1065,6 +1082,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1120,6 +1138,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 migrate_command: None,
@@ -1134,6 +1153,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 migrate_command: None,
@@ -1157,6 +1177,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 migrate_command: None,
@@ -1171,6 +1192,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 migrate_command: None,
@@ -1195,6 +1217,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 migrate_command: None,
@@ -1209,6 +1232,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 migrate_command: None,
@@ -1276,6 +1300,7 @@ ingress = "public"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1372,6 +1397,7 @@ ingress = "internal"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1396,6 +1422,7 @@ ingress = "internal"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1476,6 +1503,7 @@ domain = "svc.example.com"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1557,6 +1585,7 @@ domain = "svc.example.com"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1628,6 +1657,7 @@ domain = "svc.example.com"
                 cpu: Some("2".to_string()),
                 memory: Some("4Gi".to_string()),
                 max_instances: Some(5),
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1652,6 +1682,7 @@ domain = "svc.example.com"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1729,6 +1760,7 @@ domain = "svc.example.com"
                 cpu: Some("4".to_string()), // per-service override
                 memory: None,               // will inherit global
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -1756,6 +1788,7 @@ domain = "svc.example.com"
                 cpu: Some("1".to_string()),
                 memory: Some("2Gi".to_string()),
                 max_instances: Some(3),
+                max_request_body_mb: None,
                 min_instances: None,
             }),
             services: services_map,
@@ -1790,6 +1823,7 @@ domain = "svc.example.com"
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,
@@ -1798,6 +1832,7 @@ domain = "svc.example.com"
             cpu: Some("1".to_string()),
             memory: Some("512Mi".to_string()),
             max_instances: Some(3),
+            max_request_body_mb: None,
             min_instances: Some(1),
         };
 
@@ -1819,6 +1854,7 @@ domain = "svc.example.com"
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,
@@ -1827,12 +1863,14 @@ domain = "svc.example.com"
             cpu: Some("1".to_string()),
             memory: Some("512Mi".to_string()),
             max_instances: Some(2),
+            max_request_body_mb: None,
             min_instances: Some(0),
         };
         let service_file = Some(ResourceConfig {
             cpu: Some("2".to_string()),
             memory: None,
             max_instances: Some(4),
+            max_request_body_mb: None,
             min_instances: Some(1),
         });
         let app_override = AppServiceEntry {
@@ -1849,6 +1887,7 @@ domain = "svc.example.com"
             cpu: Some("4".to_string()),
             memory: Some("2Gi".to_string()),
             max_instances: Some(8),
+            max_request_body_mb: None,
             min_instances: Some(2),
             instances: None,
             dev_command: None,
@@ -1878,6 +1917,7 @@ domain = "svc.example.com"
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: Some(2),
             migrate_command: None,
@@ -1896,6 +1936,7 @@ domain = "svc.example.com"
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: Some(0),
             dev_command: None,
@@ -1939,6 +1980,7 @@ domain = "svc.example.com"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -2007,6 +2049,7 @@ domain = "svc.example.com"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -2031,6 +2074,7 @@ domain = "svc.example.com"
                 cpu: None,
                 memory: None,
                 max_instances: None,
+                max_request_body_mb: None,
                 min_instances: None,
                 instances: None,
                 dev_command: None,
@@ -2103,6 +2147,7 @@ domain = "svc.example.com"
                 cpu: Some("2".to_string()),
                 memory: Some("4Gi".to_string()),
                 max_instances: Some(5),
+                max_request_body_mb: None,
                 min_instances: None,
             }),
             env: None,
@@ -2164,6 +2209,7 @@ domain = "svc.example.com"
                         cpu: None,
                         memory: None,
                         max_instances: None,
+                        max_request_body_mb: None,
                         min_instances: None,
                         instances: None,
                         dev_command: None,
@@ -2230,6 +2276,7 @@ domain = "svc.example.com"
                         cpu: None,
                         memory: None,
                         max_instances: None,
+                        max_request_body_mb: None,
                         min_instances: None,
                         instances: None,
                         dev_command: None,

--- a/src/project_config/service_config.rs
+++ b/src/project_config/service_config.rs
@@ -11,6 +11,33 @@ use super::SCHEMA_URL;
 
 // --- Resource limits ---
 
+// Mirrors floo/api/app/utils/tarball.py::_MAX_REQUEST_BODY_MB_LIMIT.
+pub(super) const MAX_REQUEST_BODY_MB_LIMIT: u64 = 100;
+
+fn max_request_body_mb_error() -> String {
+    format!("max_request_body_mb must be an integer between 1 and {MAX_REQUEST_BODY_MB_LIMIT}")
+}
+
+pub(super) fn deserialize_max_request_body_mb<'de, D>(
+    deserializer: D,
+) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<u64>::deserialize(deserializer)
+        .map_err(|_| serde::de::Error::custom(max_request_body_mb_error()))
+}
+
+pub(super) fn validate_max_request_body_mb(value: Option<u64>) -> Result<(), FlooError> {
+    if value.is_some_and(|value| !(1..=MAX_REQUEST_BODY_MB_LIMIT).contains(&value)) {
+        return Err(FlooError::new(
+            ErrorCode::InvalidProjectConfig,
+            max_request_body_mb_error(),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ResourceConfig {
@@ -20,6 +47,12 @@ pub struct ResourceConfig {
     pub memory: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_instances: Option<u32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_max_request_body_mb"
+    )]
+    pub max_request_body_mb: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_instances: Option<u32>,
 }
@@ -212,6 +245,12 @@ pub struct ServiceConfig {
     pub memory: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_instances: Option<u32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_max_request_body_mb"
+    )]
+    pub max_request_body_mb: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_instances: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -329,6 +368,7 @@ impl ServiceSection {
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: self.min_instances,
             instances: self.instances,
             migrate_command: self.migrate_command.clone(),
@@ -353,6 +393,9 @@ pub fn load_service_config(dir: &Path) -> Result<Option<ServiceFileConfig>, Floo
     let config: ServiceFileConfig = toml::from_str(&content)
         .map_err(|e| super::toml_parse_error(super::SERVICE_CONFIG_FILE, e))?;
 
+    if let Some(ref resources) = config.resources {
+        validate_max_request_body_mb(resources.max_request_body_mb)?;
+    }
     if let Some(ref env) = config.env {
         env.validate(&format!("[env] in {}", super::SERVICE_CONFIG_FILE))?;
     }
@@ -417,6 +460,83 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_max_request_body_mb_service_manifest_round_trip_and_omission() {
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        let dir = TempDir::new().unwrap();
+        for value in [None, Some(1), Some(32), Some(MAX_REQUEST_BODY_MB_LIMIT)] {
+            let resource = value.map_or(String::new(), |v| format!("max_request_body_mb = {v}"));
+            fs::write(
+                dir.path().join(super::super::SERVICE_CONFIG_FILE),
+                format!(
+                    r#"[app]
+name = "my-app"
+[service]
+name = "api"
+type = "api"
+port = 8000
+[resources]
+{resource}
+"#
+                ),
+            )
+            .unwrap();
+            let config = load_service_config(dir.path()).unwrap().unwrap();
+            assert_eq!(
+                config.resources.as_ref().unwrap().max_request_body_mb,
+                value
+            );
+            let serialized = toml::to_string(&config).unwrap();
+            assert_eq!(serialized.contains("max_request_body_mb"), value.is_some());
+            let json = serde_json::to_value(&config).unwrap();
+            assert_eq!(
+                json["resources"].get("max_request_body_mb").is_some(),
+                value.is_some()
+            );
+            write_service_config(dir.path(), &config).unwrap();
+            let reloaded = load_service_config(dir.path()).unwrap().unwrap();
+            assert_eq!(reloaded.resources.unwrap().max_request_body_mb, value);
+        }
+    }
+
+    #[test]
+    fn test_max_request_body_mb_service_manifest_rejects_invalid_values() {
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        let dir = TempDir::new().unwrap();
+        for value in [
+            "0".to_string(),
+            (MAX_REQUEST_BODY_MB_LIMIT + 1).to_string(),
+            "-1".to_string(),
+            "1.5".to_string(),
+            "true".to_string(),
+            "\"32\"".to_string(),
+        ] {
+            fs::write(
+                dir.path().join(super::super::SERVICE_CONFIG_FILE),
+                format!(
+                    r#"[app]
+name = "my-app"
+[service]
+name = "api"
+type = "api"
+port = 8000
+[resources]
+max_request_body_mb = {value}
+"#
+                ),
+            )
+            .unwrap();
+            let error = load_service_config(dir.path()).unwrap_err();
+            assert_eq!(error.code, ErrorCode::InvalidProjectConfig);
+            assert!(
+                error.message.contains(&max_request_body_mb_error()),
+                "{value}: {error}"
+            );
+        }
+    }
 
     #[test]
     fn test_load_service_config_valid() {
@@ -663,6 +783,7 @@ ingress = "internal"
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,
@@ -866,6 +987,7 @@ port = 8000
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,
@@ -886,6 +1008,7 @@ port = 8000
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,
@@ -987,6 +1110,7 @@ port = 8000
             cpu: None,
             memory: None,
             max_instances: None,
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,
@@ -1009,6 +1133,7 @@ port = 8000
             cpu: Some("2".to_string()),
             memory: Some("4Gi".to_string()),
             max_instances: Some(5),
+            max_request_body_mb: None,
             min_instances: None,
             instances: None,
             migrate_command: None,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3096,3 +3096,75 @@ fn test_init_prefers_floo_env_over_dot_env() {
         "Expected .floo.env to win over .env, got:\n{app_toml}"
     );
 }
+
+#[test]
+fn test_preflight_max_request_body_mb_valid_and_invalid_manifests() {
+    for section in ["resources", "services.api", "service-file"] {
+        for value in [1, 32, 100, 0, 101] {
+            let project = tempfile::TempDir::new().unwrap();
+            let (file, manifest) = if section == "service-file" {
+                (
+                    "floo.service.toml",
+                    format!(
+                        r#"[app]
+name = "myapp"
+[service]
+name = "api"
+type = "api"
+port = 8000
+[resources]
+max_request_body_mb = {value}
+"#
+                    ),
+                )
+            } else {
+                let resource = format!("max_request_body_mb = {value}");
+                let global = if section == "resources" {
+                    resource.as_str()
+                } else {
+                    ""
+                };
+                let inline = if section == "services.api" {
+                    resource.as_str()
+                } else {
+                    ""
+                };
+                (
+                    "floo.app.toml",
+                    format!(
+                        r#"[app]
+name = "myapp"
+[resources]
+{global}
+[services.api]
+type = "api"
+path = "."
+port = 8000
+{inline}
+"#
+                    ),
+                )
+            };
+            std::fs::write(project.path().join(file), manifest).unwrap();
+            std::fs::write(project.path().join("Dockerfile"), "FROM scratch\n").unwrap();
+            let output = floo()
+                .args(["--json", "preflight", project.path().to_str().unwrap()])
+                .env("HOME", project.path())
+                .output()
+                .unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+            if (1..=100).contains(&value) {
+                assert!(output.status.success(), "{section}, {value}: {json}");
+                assert_eq!(json["data"]["valid"], true);
+            } else {
+                assert!(!output.status.success(), "{section}, {value}: {json}");
+                assert_eq!(json["success"], false);
+                assert!(
+                    json.to_string()
+                        .contains("max_request_body_mb must be an integer between 1 and 100"),
+                    "{json}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

#1494 shipped `max_request_body_mb` as a manifest-backed policy the platform parses and enforces. The CLI's `[resources]` struct is `deny_unknown_fields` and never gained the key, so the same manifest deploys on `git push` and fails `floo preflight` and `floo redeploy` with `INVALID_PROJECT_CONFIG` and a hint to run `floo update`, which cannot help because no released CLI accepted it. A customer who sets a body limit lost both commands for that app.

## What

- `max_request_body_mb: Option<u64>` on the global `[resources]`, the service-file `[resources]`, and the inline `[services.<name>]` shape, matching what the platform's parser reads.
- One shared limit constant `MAX_REQUEST_BODY_MB_LIMIT = 100`, mirrored from `floo/api/app/utils/tarball.py::_MAX_REQUEST_BODY_MB_LIMIT`, and one validator producing the platform's exact message `max_request_body_mb must be an integer between 1 and 100`, so preflight fails locally instead of at deploy.
- Inheritance follows the existing precedence (inline service override, then service file, then global) and the value reaches `services[].max_request_body_mb` on the deploy request, which `api_types.rs` already declared.

## Verified by running

- `./scripts/test`: fmt, clippy `-D warnings`, and `cargo test` pass, 1,917 test executions.
- New tests: round-trip and omission on both manifest shapes, rejection of `0` and `101`, the manifest value reaching the deploy request across inline/delegated/single layouts, and a preflight integration case for valid and invalid manifests.

## Deliberately not building

- No change to `deny_unknown_fields` or the version-skew hint; the general shape question is a separate follow-up.
- No docs edit here; the floo-docs warning is removed separately once this ships.

Closes getfloo/floo#2415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpJQW31F2Sp7NXP1u78gtU
