### PR TITLE
fix(cli): point first-deploy hints at git push, not floo redeploy

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,10 +189,7 @@ Examples:
   floo redeploy                            Redeploy from current project directory
   floo redeploy --service api              Redeploy specific services only
 
-Note: The primary way to deploy is `git push`. Use `floo redeploy` when you
-need to apply env var changes or rebuild the unchanged GitHub commit. If a
-no-rebuild restart reports an unavailable immutable contract, run the exact
-`--rebuild` command it returns.")]
+Note: Deploys are triggered by `git push`. Use `floo redeploy` to apply env var changes or rebuild the unchanged GitHub commit once the app has a dev deploy. If a no-rebuild restart reports an unavailable immutable contract, run the exact `--rebuild` command it returns.")]
     Redeploy {
         /// Project directory (only needed when --app is not provided).
         #[arg(default_value = ".")]
@@ -246,7 +243,7 @@ Examples:
   floo deploys watch --app my-app           Stream deploy progress
   floo deploys rollback my-app abc123       Rollback to a previous deploy
 
-Note: To trigger a deploy, use `floo redeploy` or push to GitHub.
+Note: Push to the connected GitHub branch to deploy. `floo redeploy` restarts an app that already has a dev deploy; it cannot run the first one.
 `floo deploy ...` is a backwards-compatible alias for `floo deploys ...`."
     )]
     Deploys(DeploysSubcommands),
@@ -872,7 +869,7 @@ pub enum GitHubCommands {
         #[arg(long)]
         skip_env_check: bool,
 
-        /// Skip triggering a deploy after connecting.
+        /// Connect without deploying. The first deploy runs on the next push to the connected branch; `floo redeploy` cannot start it.
         #[arg(long)]
         no_deploy: bool,
 

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -10,8 +10,7 @@ use crate::output;
 use crate::project_config;
 use serde::Serialize;
 
-const DEPLOY_HINT: &str =
-    "Push a commit to trigger a deploy with the updated env vars, or run: floo redeploy";
+const DEPLOY_HINT: &str = "Push a commit to deploy with the updated env vars. Once the app has a dev deploy, `floo redeploy` applies them without a code change.";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -681,7 +680,7 @@ pub fn set(
                                 results.len(),
                                 e.message
                             ),
-                            Some("Wait for the active deploy to finish, then run `floo redeploy`."),
+                            Some("Wait for the active deploy to finish, then push a commit or run `floo redeploy`."),
                         ),
                         "RESTART_DISPATCH_FAILED" => (
                             RestartState::AttemptCreated,

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -431,7 +431,10 @@ pub fn connect(
     // Phase 4: Deploy and wait (unless --no-deploy)
     if no_deploy {
         output::success(
-            &format!("Connected {name} to {repo} (branch: {connected_branch})"),
+            &format!(
+                "Connected {name} to {repo} (branch: {connected_branch}). \
+                 Push a commit to `{connected_branch}` to run the first deploy."
+            ),
             Some(serde_json::json!({
                 "connected": true,
                 "app": name,
@@ -497,7 +500,7 @@ pub fn connect(
             output::error_with_data(
                 &format!("Connected {name} to {repo} but deploy failed."),
                 &ErrorCode::DeployFailed,
-                Some("Run `floo redeploy` to retry."),
+                Some("Fix the failure and push a commit to retry. `floo redeploy` only restarts an app that already has a dev deploy."),
                 Some(serde_json::json!({
                     "connected": true,
                     "app": name,


### PR DESCRIPTION
## What changed

Every CLI hint that recommended `floo redeploy` now names git push as the deploy trigger and qualifies `redeploy` as a restart of an app that already has a dev deploy. The `--no-deploy` success message tells the user to push a commit to the connected branch to run the first deploy. JSON payloads are unchanged.

Strings touched:
- `deploys --help` and `redeploy --help` notes
- `--no-deploy` flag help
- `env set` success hint and deploy-in-progress hint
- `apps github connect` `--no-deploy` success line and deploy-failed recovery hint

## Why

getfloo/floo#2303: `--no-deploy` is the right choice for an app that needs secrets before first boot, but `floo redeploy` cannot bootstrap a deploy, and the CLI advertised it at exactly the moment it was guaranteed to fail.

## Verified by running

```
unset FORCE_COLOR; cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
```
All green (526 unit tests, 189 and 151 integration tests).

## Deliberately not building

- `--no-deploy` stays; the synthetics runbook depends on it.
- No API call in `env set` to detect deploy state, no `floo deploys trigger`.
- Companion PRs: getfloo/floo#2522 (API error text), getfloo/floo-docs#50 (customer docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMdAFaYwRxEMeDFcaNq8t7
