### PR TITLE
fix(db): drop the dead [app] agent_mode setting and its migrate error text

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -24,7 +24,6 @@ fn build_deploy_body(
     framework: Option<&str>,
     services: Option<&[ServiceConfig]>,
     access_mode: Option<&str>,
-    agent_mode: Option<&str>,
     auth_redirect_uris: Option<&[String]>,
     cron_jobs: Option<&[crate::project_config::CronJobEntry]>,
     github_config: Option<&crate::project_config::GitHubConfig>,
@@ -50,9 +49,6 @@ fn build_deploy_body(
     }
     if let Some(mode) = access_mode {
         body["access_mode"] = Value::String(mode.to_string());
-    }
-    if let Some(mode) = agent_mode {
-        body["agent_mode"] = Value::String(mode.to_string());
     }
     if let Some(uris) = auth_redirect_uris {
         body["auth_redirect_uris"] = serde_json::to_value(uris).map_err(|e| {
@@ -552,7 +548,6 @@ impl FlooClient {
         framework: Option<&str>,
         services: Option<&[ServiceConfig]>,
         access_mode: Option<&str>,
-        agent_mode: Option<&str>,
         auth_redirect_uris: Option<&[String]>,
         cron_jobs: Option<&[crate::project_config::CronJobEntry]>,
         github_config: Option<&crate::project_config::GitHubConfig>,
@@ -563,7 +558,6 @@ impl FlooClient {
             framework,
             services,
             access_mode,
-            agent_mode,
             auth_redirect_uris,
             cron_jobs,
             github_config,
@@ -1530,18 +1524,8 @@ mod tests {
             preview_environments: Some(true),
             preview_ttl_hours: Some(48),
         };
-        let body = build_deploy_body(
-            "nodejs",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&gh),
-            false,
-        )
-        .expect("body builds");
+        let body = build_deploy_body("nodejs", None, None, None, None, None, Some(&gh), false)
+            .expect("body builds");
         let obj = body.as_object().expect("body is a JSON object");
 
         assert_eq!(obj.get("deploy_on_push"), Some(&Value::Bool(true)));
@@ -1564,18 +1548,8 @@ mod tests {
             preview_environments: Some(true),
             preview_ttl_hours: Some(24),
         };
-        let body = build_deploy_body(
-            "python",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&gh),
-            false,
-        )
-        .expect("body builds");
+        let body = build_deploy_body("python", None, None, None, None, None, Some(&gh), false)
+            .expect("body builds");
         let obj = body.as_object().expect("body is a JSON object");
 
         assert!(!obj.contains_key("preview_environments"), "{body}");
@@ -1592,18 +1566,8 @@ mod tests {
             preview_environments: None,
             preview_ttl_hours: None,
         };
-        let body = build_deploy_body(
-            "nodejs",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&gh),
-            false,
-        )
-        .expect("body builds");
+        let body = build_deploy_body("nodejs", None, None, None, None, None, Some(&gh), false)
+            .expect("body builds");
         assert_eq!(body.get("deploy_on_push"), Some(&Value::Bool(false)));
     }
 }

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -21,7 +21,7 @@ const QUERY_LIMIT_RANGE: std::ops::RangeInclusive<u32> = 1..=10_000;
 /// A malformed request must fail with a floo-shaped error that honors `--json`
 /// — never reach the API to bounce back a raw Pydantic/FastAPI validation blob,
 /// and never execute under `--dry-run`. Empty/whitespace SQL is caught here too
-/// so it surfaces as "query is empty" rather than the API's agent-mode DDL gate
+/// so it surfaces as "query is empty" rather than the API's key-scope DDL check
 /// (an empty string classifies as DDL server-side). Pure and unit-tested so the
 /// preview and the real run share one notion of "valid".
 fn validate_query_args(sql: &str, limit: u32) -> Result<(), FlooError> {
@@ -305,24 +305,7 @@ pub fn migrate(app_flag: Option<&str>, env: &str) {
     let result = match client.db_migrate(&app_id, env) {
         Ok(r) => r,
         Err(e) => {
-            let suggestion = match e.code.as_str() {
-                "AGENT_MODE_DDL_BLOCKED" => Some(
-                    "Migrations run DDL, which requires agent_mode = \"autonomous\". \
-                     Set agent_mode in [app] in floo.app.toml (or omit it to default \
-                     to autonomous), commit, then push to redeploy before re-running.",
-                ),
-                "AGENT_MODE_READONLY" => Some(
-                    "Agent mode is \"readonly\". Set agent_mode = \"autonomous\" in \
-                     [app] in floo.app.toml to run migrations.",
-                ),
-                "AGENT_MODE_SUPERVISED" => Some(
-                    "Agent mode is \"supervised\", which blocks prod migrations. \
-                     Run against --env dev, or set agent_mode = \"autonomous\" in \
-                     [app] in floo.app.toml.",
-                ),
-                _ => None,
-            };
-            output::error(&e.message, &ErrorCode::from_api(&e.code), suggestion);
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
             process::exit(1);
         }
     };

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -14,8 +14,8 @@ use crate::detection::{detect_for_services, DetectionResult};
 use crate::errors::{ErrorCode, FlooApiError};
 use crate::output;
 use crate::project_config::{
-    self, validate_service_name, AppAccessMode, AppAgentMode, AppSource, ServiceConfig,
-    ServiceIngress, ServiceType,
+    self, validate_service_name, AppAccessMode, AppSource, ServiceConfig, ServiceIngress,
+    ServiceType,
 };
 use crate::resolve::resolve_app;
 
@@ -1070,10 +1070,6 @@ pub fn deploy(
                 .and_then(|c| c.app.access_mode)
         });
 
-    // Extract agent_mode from [app] section
-    let agent_mode: Option<AppAgentMode> =
-        resolved.app_config.as_ref().and_then(|c| c.app.agent_mode);
-
     // Extract auth redirect URIs from [auth] toml section
     let auth_redirect_uris: Option<Vec<String>> = resolved
         .app_config
@@ -1116,7 +1112,6 @@ pub fn deploy(
         detection.framework.as_deref(),
         svc_slice,
         access_mode.as_ref().map(|m| m.as_str()),
-        agent_mode.as_ref().map(|m| m.as_str()),
         auth_redirect_uris.as_deref(),
         cron_jobs_arg,
         github_config,
@@ -3506,7 +3501,6 @@ port = 8000
                     "python",
                     None,
                     Some(&services),
-                    None,
                     None,
                     None,
                     None,

--- a/src/commands/github.rs
+++ b/src/commands/github.rs
@@ -1061,7 +1061,6 @@ fn run_initial_deploy(
         detection.framework.as_deref(),
         None,  // API discovers services from GitHub tarball
         None,  // access_mode
-        None,  // agent_mode
         None,  // auth_redirect_uris
         None,  // cron_jobs
         None,  // github_config

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -375,7 +375,6 @@ fn init_non_interactive(
         app: AppFileAppSection {
             name: app_name.clone(),
             access_mode: None,
-            agent_mode: None,
         },
         auth: None,
         github: None,
@@ -554,7 +553,6 @@ fn init_interactive(
         app: AppFileAppSection {
             name: app_name.clone(),
             access_mode: None,
-            agent_mode: None,
         },
         auth: None,
         github: None,

--- a/src/project_config/app_config.rs
+++ b/src/project_config/app_config.rs
@@ -293,32 +293,12 @@ impl AppAccessMode {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum AppAgentMode {
-    Readonly,
-    Supervised,
-    Autonomous,
-}
-
-impl AppAgentMode {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            AppAgentMode::Readonly => "readonly",
-            AppAgentMode::Supervised => "supervised",
-            AppAgentMode::Autonomous => "autonomous",
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppFileAppSection {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_mode: Option<AppAccessMode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub agent_mode: Option<AppAgentMode>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1140,7 +1120,6 @@ type = "mysql"
             app: AppFileAppSection {
                 name: "roundtrip-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,

--- a/src/project_config/discover.rs
+++ b/src/project_config/discover.rs
@@ -573,7 +573,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -681,7 +680,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -749,7 +747,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -818,7 +815,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -890,7 +886,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -988,7 +983,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1026,7 +1020,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1097,7 +1090,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1315,7 +1307,6 @@ ingress = "public"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1437,7 +1428,6 @@ ingress = "internal"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1518,7 +1508,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1600,7 +1589,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1697,7 +1685,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1776,7 +1763,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -1995,7 +1981,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -2089,7 +2074,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "my-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -2179,7 +2163,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "test-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,
@@ -2248,7 +2231,6 @@ domain = "svc.example.com"
             app: AppFileAppSection {
                 name: "test-app".to_string(),
                 access_mode: None,
-                agent_mode: None,
             },
             auth: None,
             github: None,

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -49,8 +49,8 @@ fn extract_unknown_field(msg: &str) -> Option<&str> {
 #[cfg(test)]
 pub use app_config::AppServiceType;
 pub use app_config::{
-    load_app_config, write_app_config_with_header, AppAccessMode, AppAgentMode, AppFileAppSection,
-    AppFileConfig, AppServiceEntry, GitHubConfig,
+    load_app_config, write_app_config_with_header, AppAccessMode, AppFileAppSection, AppFileConfig,
+    AppServiceEntry, GitHubConfig,
 };
 pub use discover::{
     discover_managed_services, discover_services, filter_services, ManagedServiceDeclaration,


### PR DESCRIPTION
## What changed
`[app] agent_mode` is no longer accepted in `floo.app.toml`, `floo deploy` no longer sends it, and `floo db migrate` no longer prints the `AGENT_MODE_*` suggestions that told users to set it. A leftover `agent_mode = ...` line now fails as an unknown `[app]` field, which is the honest outcome for config that did nothing.

## Why
getfloo/floo#2516: the setting was only ever sent by `floo deploy`, push deploys never applied it, and the API defaulted to `supervised`, so the migrate error's instructions could not work and cost an 11-minute redeploy cycle for nothing. The API-side gate is deleted in the companion floo PR; this removes the CLI half.

## Review and scope
Risk: routine. Pure deletion of a dead config surface. Older CLIs sending `agent_mode` are still accepted by the API (Pydantic ignores unknown body fields), so ordering against the API PR does not matter.

## Files reviewers should scrutinize
- `src/project_config/app_config.rs` (field and enum removed under `deny_unknown_fields`)
- `src/commands/db.rs` (suggestion text removed)

## Verified by running
`./scripts/test` (fmt, clippy `-D warnings`, cargo test): pass. Grep for `agent_mode` returns nothing.

## Knowledge impact
None in this repo; no docs referenced the setting.

## Deliberately not building
No deprecation shim or ignored-field path for `agent_mode`; no replacement setting.

## Issue Closure (Required)
Closes getfloo/floo#2516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEckXUNCPeJz2NRNpFR3pd
