### PR TITLE
feat(projects): create, list, and clone managed apps without a GitHub account

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,31 @@ floo edge policy check 203.0.113.7 --env prod
 
 All commands are invoked with the production alias: `floo`.
 
+### Managed projects without a GitHub account
+
+With a floo API key, create a managed app with hosted, invite-only login and
+postgres, then clone its source into your workspace:
+
+```bash
+floo projects create client-portal
+floo projects list
+floo projects clone client-portal
+cd client-portal
+# Read AGENTS.md before editing, then commit and push with git.
+floo deploys watch --app client-portal
+```
+
+Create starts the first deploy and prints the watch command without waiting.
+Clone accepts a project name or app ID and an optional destination directory.
+It configures git only in the cloned repository, using the absolute path of the
+current floo binary. Keep that binary in place for later fetches and pushes.
+The helper fetches one-hour tokens per git operation through floo; no GitHub
+account or stored GitHub credential is needed. Only the floo API key is stored.
+Inherited credential helpers are reset for the repository to prevent caching.
+
 ## Agent / programmatic use
 
-Every command supports `--json` for structured output:
+User-facing commands support `--json` for structured output:
 
 ```bash
 # JSON to stdout, human output to stderr
@@ -96,6 +118,10 @@ floo redeploy --json 2>/dev/null | jq '.data.deploy.url'
 # Success: {"success": true, "data": {...}}
 # Error:   {"success": false, "error": {"code": "...", "message": "...", "suggestion": "..."}}
 ```
+
+The internal `floo projects git-credential get` command is used by git and emits
+only git's credential protocol, even with `--json`. Its `store` and `erase`
+operations are no-ops. Never capture its password output in logs or files.
 
 ## Building from source
 

--- a/plugin/skills/floo/SKILL.md
+++ b/plugin/skills/floo/SKILL.md
@@ -23,6 +23,17 @@ For automation, pass `--json`. JSON responses go to stdout; human output goes to
 
 ## Deploy invariant
 
+For an app without a user-owned GitHub repo, use `floo projects create <name>`,
+`floo projects list`, and `floo projects clone <name-or-id> [dir]`; check
+`floo projects --help` for details. Create starts the first deploy; follow the
+printed watch command. After cloning, read the project's `AGENTS.md` before
+editing. Keep the floo binary at its installed path: the repo-local git helper
+uses that absolute path and fetches one-hour tokens through floo per operation.
+Only the floo API key is stored; never cache GitHub tokens or configure global
+git credentials. The internal `floo projects git-credential get` is used by git,
+emits a plaintext password protocol rather than JSON, and must not be logged.
+Its `store` and `erase` operations do nothing.
+
 Deploys are git-driven:
 
 - A push or merge to the connected branch deploys dev.

--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -23,6 +23,17 @@ For automation, pass `--json`. JSON responses go to stdout; human output goes to
 
 ## Deploy invariant
 
+For an app without a user-owned GitHub repo, use `floo projects create <name>`,
+`floo projects list`, and `floo projects clone <name-or-id> [dir]`; check
+`floo projects --help` for details. Create starts the first deploy; follow the
+printed watch command. After cloning, read the project's `AGENTS.md` before
+editing. Keep the floo binary at its installed path: the repo-local git helper
+uses that absolute path and fetches one-hour tokens through floo per operation.
+Only the floo API key is stored; never cache GitHub tokens or configure global
+git credentials. The internal `floo projects git-credential get` is used by git,
+emits a plaintext password protocol rather than JSON, and must not be logged.
+Its `store` and `erase` operations do nothing.
+
 Deploys are git-driven:
 
 - A push or merge to the connected branch deploys dev.

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -292,6 +292,40 @@ impl FlooClient {
         self.handle_response(resp)
     }
 
+    // --- Managed projects ---
+
+    pub fn create_project(&self, name: &str) -> Result<ProjectResponse, FlooApiError> {
+        let response = self.post_json("/v1/projects", &serde_json::json!({ "name": name }))?;
+        self.handle_response(response)
+    }
+
+    pub fn list_projects(&self) -> Result<ListProjectsResponse, FlooApiError> {
+        self.handle_response(self.get("/v1/projects")?)
+    }
+
+    /// The projects API exposes a list endpoint, not a single-project GET.
+    pub fn get_project(&self, name_or_id: &str) -> Result<ProjectResponse, FlooApiError> {
+        self.list_projects()?
+            .projects
+            .into_iter()
+            .find(|project| project.name == name_or_id || project.app_id == name_or_id)
+            .ok_or_else(|| {
+                FlooApiError::new(
+                    404,
+                    "PROJECT_NOT_FOUND",
+                    format!("Project '{name_or_id}' not found."),
+                )
+            })
+    }
+
+    pub fn project_git_token(&self, app_id: &str) -> Result<ProjectGitTokenResponse, FlooApiError> {
+        let response = self.post_json(
+            &format!("/v1/projects/{app_id}/git-token"),
+            &serde_json::json!({}),
+        )?;
+        self.handle_response(response)
+    }
+
     // --- Org ---
 
     pub fn list_orgs(&self) -> Result<ListOrgsResponse, FlooApiError> {

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -2,6 +2,32 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+// --- Managed projects ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectResponse {
+    pub app_id: String,
+    pub name: String,
+    pub app_url: String,
+    pub repo_full_name: String,
+    pub clone_url: String,
+    pub default_branch: String,
+    pub first_deploy_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListProjectsResponse {
+    pub projects: Vec<ProjectResponse>,
+}
+
+// Deliberately no Debug: this credential belongs only on git's password line.
+#[derive(Serialize, Deserialize)]
+pub struct ProjectGitTokenResponse {
+    pub token: String,
+    pub expires_at: String,
+    pub clone_url: String,
+}
+
 // --- Auth ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -274,6 +274,20 @@ dirty local files are not uploaded."
     #[command(subcommand)]
     Orgs(OrgsCommands),
 
+    /// Create, list, and clone managed apps without a GitHub account.
+    #[command(
+        subcommand,
+        after_help = "\
+Examples:
+  floo projects create client-portal      Create an app with hosted login and postgres
+  floo projects list --json               Find managed projects
+  floo projects clone client-portal       Clone, then read AGENTS.md
+
+Clones use a repo-local credential helper at the current floo binary's absolute
+path. Git fetches one-hour push tokens through floo; tokens are never cached."
+    )]
+    Projects(ProjectsCommands),
+
     /// Manage billing and spend caps.
     #[command(subcommand)]
     Billing(BillingCommands),
@@ -612,6 +626,30 @@ pub enum SpendCapCommands {
     Set {
         /// Spend cap amount in dollars (e.g., 20.00). Use 0 for no cap.
         amount: f64,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ProjectsCommands {
+    /// Create and deploy a managed app with hosted, invite-only login and postgres.
+    Create {
+        /// Project name.
+        name: String,
+    },
+    /// List managed projects in the current organization.
+    List,
+    /// Clone a managed project and configure credentials only in that repository.
+    Clone {
+        /// Project name or app ID.
+        name_or_id: String,
+        /// Destination directory (defaults to the project name).
+        dir: Option<PathBuf>,
+    },
+    /// Credential helper used by git; stdout is the git protocol, even with --json.
+    #[command(hide = true)]
+    GitCredential {
+        #[arg(value_parser = ["get", "store", "erase"])]
+        operation: String,
     },
 }
 
@@ -2188,6 +2226,14 @@ pub fn run() {
         crate::redact::set_reveal_secrets(true);
     }
 
+    // Git's protocol must stay quiet and never stage/apply updates or emit JSON.
+    // Fallthrough and store/erase also work without authentication.
+    if let Commands::Projects(ProjectsCommands::GitCredential { operation }) = &cli.command {
+        output::set_json_mode(false);
+        commands::projects::git_credential(operation);
+        return;
+    }
+
     // Phase 2: Always apply staged updates (safe for any command, including --json)
     if !crate::config::is_local_binary() {
         crate::version_check::apply_staged_update(VERSION);
@@ -2345,6 +2391,17 @@ pub fn run() {
             BillingCommands::Upgrade { plan } => commands::billing::upgrade(plan),
             BillingCommands::Usage { period } => commands::billing::usage(&period),
             BillingCommands::Contact => commands::billing::contact(),
+        },
+
+        Commands::Projects(sub) => match sub {
+            ProjectsCommands::Create { name } => commands::projects::create(&name),
+            ProjectsCommands::List => commands::projects::list(),
+            ProjectsCommands::Clone { name_or_id, dir } => {
+                commands::projects::clone(&name_or_id, dir.as_deref())
+            }
+            ProjectsCommands::GitCredential { operation } => {
+                commands::projects::git_credential(&operation)
+            }
         },
 
         Commands::Orgs(sub) => match sub {

--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -209,6 +209,9 @@ mod tests {
         tree_paths(&build_tree(), "", &mut paths);
         // Real commands the hand-maintained index used to omit (#1160).
         for real in [
+            "projects create",
+            "projects list",
+            "projects clone",
             "storage",
             "doctor",
             "services add",
@@ -226,6 +229,7 @@ mod tests {
         }
         // The index used to invent `apps status`; the real command is `apps show`.
         assert!(paths.contains("apps show"), "index is missing `apps show`");
+        assert!(!paths.contains("projects git-credential"));
         assert!(
             !paths.contains("apps status"),
             "index lists phantom command `apps status`"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod notifications;
 pub mod organization_sso;
 pub mod orgs;
 pub mod previews;
+pub mod projects;
 pub mod releases;
 pub mod rollbacks;
 pub mod run;

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -1,0 +1,272 @@
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::process::{self, Command, Stdio};
+
+use crate::api_client::FlooClient;
+use crate::config::load_config;
+use crate::errors::{ErrorCode, FlooApiError};
+use crate::output;
+
+fn fail(error: FlooApiError) -> ! {
+    let next = if error.status_code == 401 || error.code == "NOT_AUTHENTICATED" {
+        "next: floo auth login"
+    } else {
+        "next: floo projects list"
+    };
+    let hint = error
+        .extra
+        .as_ref()
+        .and_then(|extra| extra.get("hint"))
+        .and_then(|hint| hint.as_str());
+    let suggestion = match hint {
+        Some(hint) => format!("{hint}\n{next}"),
+        None => next.to_string(),
+    };
+    output::error_with_details(
+        &error.message,
+        &ErrorCode::from_api(&error.code),
+        Some(&suggestion),
+        error.extra.as_ref(),
+    );
+    process::exit(1);
+}
+
+fn client() -> FlooClient {
+    let config = load_config();
+    if config.api_key.is_none() {
+        fail(FlooApiError::new(
+            401,
+            "NOT_AUTHENTICATED",
+            "Not logged in.",
+        ));
+    }
+    FlooClient::new(Some(config)).unwrap_or_else(|error| fail(error))
+}
+
+pub fn create(name: &str) {
+    let project = client()
+        .create_project(name)
+        .unwrap_or_else(|error| fail(error));
+    let next = format!("floo projects clone {}", shell_quote(&project.name));
+    let watch = project
+        .first_deploy_id
+        .as_ref()
+        .map(|_| format!("floo deploys watch --app {}", shell_quote(&project.name)));
+    let mut data = output::to_value(&project);
+    data["login"] = serde_json::json!("hosted, invite-only");
+    data["database"] = serde_json::json!("postgres");
+    data["next"] = serde_json::json!(next);
+    if let Some(watch) = &watch {
+        data["watch"] = serde_json::json!(watch);
+    }
+    if output::is_json_mode() {
+        output::success("Project created.", Some(data));
+        return;
+    }
+    output::success("Project created.", None);
+    output::info(
+        &format!(
+            "app: {}\nurl: {}\nlogin: hosted, invite-only\ndatabase: postgres\nrepo: {}",
+            project.name, project.app_url, project.clone_url
+        ),
+        None,
+    );
+    if let Some(watch) = watch {
+        output::info(&format!("follow first deploy: {watch}"), None);
+    }
+    output::info(&format!("next: {next}"), None);
+}
+
+pub fn list() {
+    let result = client().list_projects().unwrap_or_else(|error| fail(error));
+    let rows = result
+        .projects
+        .iter()
+        .map(|project| {
+            vec![
+                project.name.clone(),
+                project.app_url.clone(),
+                project.clone_url.clone(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    output::table(
+        &["NAME", "URL", "REPO"],
+        &rows,
+        Some(output::to_value(&result)),
+    );
+}
+
+// Git runs ! helpers through a POSIX shell, including Git for Windows. Quote
+// the executable as one shell word: workspace paths may contain spaces or '.
+fn shell_quote(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"_./-".contains(&byte))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+pub fn clone(name_or_id: &str, dir: Option<&Path>) {
+    let project = client()
+        .get_project(name_or_id)
+        .unwrap_or_else(|error| fail(error));
+    // Only pass credential-free managed HTTPS URLs to git. This also prevents
+    // clone URLs from invoking an arbitrary git transport or storing userinfo.
+    let app_id = project
+        .clone_url
+        .strip_prefix("https://github.com/")
+        .and_then(managed_app_id);
+    if !app_id.is_some_and(|id| id.eq_ignore_ascii_case(&project.app_id)) {
+        fail(FlooApiError::new(
+            0,
+            "INVALID_RESPONSE",
+            "Project clone URL must be a managed GitHub HTTPS repository matching the app ID.",
+        ));
+    }
+    let executable = std::env::current_exe()
+        .unwrap_or_else(|error| fail(FlooApiError::new(0, "FILE_ERROR", error.to_string())));
+    let executable = executable
+        .to_str()
+        .unwrap_or_else(|| {
+            fail(FlooApiError::new(
+                0,
+                "INVALID_PATH",
+                "The floo binary path must be valid Unicode for git's credential helper.",
+            ))
+        })
+        .to_owned();
+    #[cfg(windows)]
+    let executable = executable.replace('\\', "/");
+    let helper = format!(
+        "credential.helper=!{} projects git-credential",
+        shell_quote(&executable)
+    );
+    let dir = dir.unwrap_or_else(|| Path::new(&project.name));
+    let result = Command::new("git")
+        .arg("clone")
+        // Reset inherited helper lists so credential-store/keychains never see
+        // the token during git's subsequent credential approval operation.
+        .args(["-c", "credential.helper=", "-c", &helper])
+        .args(["-c", "credential.useHttpPath=true"])
+        .arg("--")
+        .arg(&project.clone_url)
+        .arg(dir)
+        // Preserve floo's single-JSON-object stdout contract.
+        .stdout(Stdio::from(io::stderr()))
+        .status();
+    match result {
+        Ok(status) if status.success() => {}
+        result => {
+            let message = match result {
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    "Git is not installed or is not on PATH. Install git in your workspace."
+                        .to_string()
+                }
+                Err(error) => format!("Failed to run git clone: {error}"),
+                Ok(status) => format!("git clone failed ({status}). Check the git error above."),
+            };
+            output::error(
+                &message,
+                &ErrorCode::from_api("GIT_CLONE_FAILED"),
+                Some(&format!(
+                    "next: floo projects clone {} {}",
+                    shell_quote(name_or_id),
+                    shell_quote(&dir.to_string_lossy())
+                )),
+            );
+            process::exit(1);
+        }
+    }
+    output::success(
+        &format!("directory: {}\nnext: read AGENTS.md", dir.display()),
+        Some(serde_json::json!({ "directory": dir, "project": project, "next": "read AGENTS.md" })),
+    );
+}
+
+fn managed_app_id(path: &str) -> Option<String> {
+    let (org, repo) = path.split_once('/')?;
+    if org.is_empty()
+        || !org
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return None;
+    }
+    let repo = repo.strip_suffix(".git").unwrap_or(repo);
+    let (org_id, app_id) = repo.strip_prefix("floo-")?.split_once('-')?;
+    if [org_id, app_id]
+        .iter()
+        .any(|id| id.len() != 32 || !id.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        return None;
+    }
+    Some(
+        format!(
+            "{}-{}-{}-{}-{}",
+            &app_id[..8],
+            &app_id[8..12],
+            &app_id[12..16],
+            &app_id[16..20],
+            &app_id[20..]
+        )
+        .to_ascii_lowercase(),
+    )
+}
+
+fn credential_app_id(input: impl BufRead) -> io::Result<Option<String>> {
+    let (mut protocol, mut host, mut path) = (None, None, None);
+    for line in input.lines() {
+        let line = line?;
+        if line.is_empty() {
+            break;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            return Ok(None);
+        };
+        let field = match key {
+            "protocol" => &mut protocol,
+            "host" => &mut host,
+            "path" => &mut path,
+            _ => continue,
+        };
+        if field.replace(value.to_string()).is_some() {
+            return Ok(None);
+        }
+    }
+    Ok(
+        if protocol.as_deref() == Some("https") && host.as_deref() == Some("github.com") {
+            path.as_deref().and_then(managed_app_id)
+        } else {
+            None
+        },
+    )
+}
+
+pub fn git_credential(operation: &str) {
+    if operation != "get" {
+        return;
+    }
+    let app_id = credential_app_id(io::stdin().lock()).unwrap_or_else(|_| {
+        fail(FlooApiError::new(
+            0,
+            "FILE_ERROR",
+            "Failed to read git credential request.",
+        ))
+    });
+    let Some(app_id) = app_id else { return };
+    let credential = client()
+        .project_git_token(&app_id)
+        .unwrap_or_else(|error| fail(error));
+    output::git_credentials(&credential.token).unwrap_or_else(|_| {
+        fail(FlooApiError::new(
+            0,
+            "INVALID_RESPONSE",
+            "Failed to write git credentials: invalid token or closed output.",
+        ))
+    });
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -298,6 +298,23 @@ pub fn raw_value(value: &str) {
     println!("{value}");
 }
 
+/// Git is the sole consumer of this plaintext credential. Never route it through
+/// JSON, human output, logging, or persistent config. Validate before any write
+/// so a malformed token cannot inject additional credential protocol fields.
+pub fn git_credentials(token: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    if token.is_empty() || token.chars().any(char::is_control) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Invalid git credential response",
+        ));
+    }
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "username=x-access-token\npassword={token}\n")?;
+    stdout.flush()
+}
+
 pub fn warn(message: &str) {
     if !is_json_mode() {
         eprintln!("  {} {}", "\u{26a0}".yellow(), message);

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -828,6 +828,25 @@ mod snapshots {
         );
     }
 
+    /// Managed-project credentials must also be protected by the JSON boundary.
+    #[test]
+    fn project_git_token_response_is_redacted_if_serialized() {
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        let _g = lock_default_redact();
+        // The helper uses a dedicated git protocol writer, never print_json.
+        // Guard the boundary if a future command serializes the typed response.
+        let response = crate::api_types::ProjectGitTokenResponse {
+            token: "supersecretvaluethatshouldnotleak".to_string(),
+            expires_at: "2026-09-09T13:00:00Z".to_string(),
+            clone_url: "https://github.com/floo-managed/repo.git".to_string(),
+        };
+        let out = through_print_json(json!({ "success": true, "data": response }));
+        assert!(collect_leaks(&out).is_empty());
+        assert_eq!(out["data"]["token"], REDACTED_PLACEHOLDER);
+        assert_eq!(out["contains_secrets"], true);
+    }
+
     /// `floo auth token` — stored API key.
     #[test]
     fn floo_auth_token_api_key_redacted_by_default() {

--- a/tests/projects_mock_api_tests.rs
+++ b/tests/projects_mock_api_tests.rs
@@ -1,0 +1,596 @@
+use assert_cmd::Command;
+use mockito::{Matcher, Server};
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const APP_ID: &str = "01234567-89ab-cdef-0123-456789abcdef";
+const REPO: &str =
+    "floo-managed/floo-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-0123456789abcdef0123456789abcdef";
+const TOKEN: &str = "ghs_mock_ephemeral_project_token";
+
+fn project() -> Value {
+    json!({
+        "app_id": APP_ID,
+        "name": "client-portal",
+        "app_url": "https://client-portal.example.test",
+        "repo_full_name": REPO,
+        "clone_url": format!("https://github.com/{REPO}.git"),
+        "default_branch": "main",
+        "first_deploy_id": null,
+    })
+}
+
+fn setup(server: &Server) -> TempDir {
+    let home = TempDir::new().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        json!({
+            "api_key": "floo_test123",
+            "api_url": server.url(),
+            "default_org": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        })
+        .to_string(),
+    )
+    .unwrap();
+    home
+}
+
+fn isolated(command: &mut Command, home: &TempDir) {
+    command
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env("FLOO_CONFIG_DIR", home.path())
+        .env_remove("FLOO_API_URL")
+        .env("FLOO_NO_UPDATE_CHECK", "1")
+        .env_remove("FORCE_COLOR");
+}
+
+#[allow(deprecated)]
+fn floo(home: &TempDir) -> Command {
+    let mut command = Command::cargo_bin("floo-local").unwrap();
+    isolated(&mut command, home);
+    command
+}
+
+fn list_mock(server: &mut Server, projects: Vec<Value>) -> mockito::Mock {
+    server
+        .mock("GET", "/v1/projects")
+        .match_header("authorization", "Bearer floo_test123")
+        .match_header("x-floo-org-id", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        .with_status(200)
+        .with_body(json!({"projects": projects}).to_string())
+        .create()
+}
+
+fn token_mock(server: &mut Server, token: &str) -> mockito::Mock {
+    server
+        .mock("POST", format!("/v1/projects/{APP_ID}/git-token").as_str())
+        .match_header("authorization", "Bearer floo_test123")
+        .match_header("x-floo-org-id", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        .with_status(200)
+        .with_body(
+            json!({
+                "token": token,
+                "expires_at": "2026-09-09T13:00:00Z",
+                "clone_url": project()["clone_url"],
+            })
+            .to_string(),
+        )
+        .create()
+}
+
+#[test]
+fn create_prints_project_block_and_followup_without_waiting() {
+    let mut server = Server::new();
+    let home = setup(&server);
+    let mut created = project();
+    created["first_deploy_id"] = json!("first-deploy-id");
+    let mock = server
+        .mock("POST", "/v1/projects")
+        .match_header("authorization", "Bearer floo_test123")
+        .match_header("x-floo-org-id", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        .match_body(Matcher::Json(json!({"name": "client-portal"})))
+        .with_status(201)
+        .with_body(created.to_string())
+        .create();
+    floo(&home)
+        .args(["projects", "create", "client-portal"])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains("app: client-portal"))
+        .stderr(predicate::str::contains(
+            "url: https://client-portal.example.test",
+        ))
+        .stderr(predicate::str::contains("login: hosted, invite-only"))
+        .stderr(predicate::str::contains("database: postgres"))
+        .stderr(predicate::str::contains(format!(
+            "repo: https://github.com/{REPO}.git"
+        )))
+        .stderr(predicate::str::contains(
+            "floo deploys watch --app client-portal",
+        ))
+        .stderr(predicate::str::contains(
+            "next: floo projects clone client-portal",
+        ));
+    mock.assert();
+}
+
+#[test]
+fn create_json_is_one_object_and_watch_is_optional() {
+    for first_deploy in [None, Some("deploy-id")] {
+        let mut server = Server::new();
+        let home = setup(&server);
+        let mut created = project();
+        created["first_deploy_id"] = json!(first_deploy);
+        let mock = server
+            .mock("POST", "/v1/projects")
+            .with_status(201)
+            .with_body(created.to_string())
+            .create();
+        let result = floo(&home)
+            .args(["projects", "create", "client-portal", "--json"])
+            .assert()
+            .success()
+            .stderr("")
+            .get_output()
+            .stdout
+            .clone();
+        let result: Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(result["success"], true);
+        assert_eq!(result["data"]["app_id"], APP_ID);
+        assert_eq!(result["data"]["login"], "hosted, invite-only");
+        assert_eq!(result["data"]["database"], "postgres");
+        assert_eq!(result["data"]["next"], "floo projects clone client-portal");
+        assert_eq!(
+            result["data"].get("watch").is_some(),
+            first_deploy.is_some()
+        );
+        mock.assert();
+    }
+}
+
+#[test]
+fn list_renders_name_url_repo_and_empty_json_list() {
+    let mut server = Server::new();
+    let home = setup(&server);
+    let mock = list_mock(&mut server, vec![project()]);
+    floo(&home)
+        .args(["projects", "list"])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains("NAME"))
+        .stderr(predicate::str::contains("client-portal"))
+        .stderr(predicate::str::contains(
+            "https://client-portal.example.test",
+        ))
+        .stderr(predicate::str::contains(REPO));
+    mock.assert();
+    mock.remove();
+    let mock = list_mock(&mut server, vec![]);
+    let output = floo(&home)
+        .args(["projects", "list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output).unwrap()["data"]["projects"],
+        json!([])
+    );
+    mock.assert();
+}
+
+#[test]
+fn credential_get_only_emits_password_protocol_and_fetches_each_time() {
+    let mut server = Server::new();
+    let home = setup(&server);
+    let config_before = std::fs::read(home.path().join("config.json")).unwrap();
+    for suffix in ["", ".git"] {
+        let mock = token_mock(&mut server, TOKEN);
+        floo(&home)
+            .args(["projects", "git-credential", "get", "--json"])
+            .write_stdin(format!("protocol=https\nhost=github.com\npath={REPO}{suffix}\nusername=ignored\n\npath=ignored-after-blank\n"))
+            .assert()
+            .success()
+            .stdout(format!("username=x-access-token\npassword={TOKEN}\n\n"))
+            .stderr("");
+        mock.assert();
+        mock.remove();
+    }
+    assert_eq!(
+        std::fs::read(home.path().join("config.json")).unwrap(),
+        config_before
+    );
+    assert_eq!(std::fs::read_dir(home.path()).unwrap().count(), 1);
+}
+
+#[test]
+fn credential_ignores_nonmatching_requests_without_authentication() {
+    let home = TempDir::new().unwrap();
+    let matching = format!("protocol=https\nhost=github.com\npath={REPO}.git\n\n");
+    let requests = [
+        String::new(),
+        matching.replace("https", "http"),
+        matching.replace("github.com", "github.com.evil.test"),
+        matching.replace("github.com", "github.com:443"),
+        matching.replace(REPO, "customer/ordinary-repo"),
+        matching.replace(REPO, &format!("{REPO}/extra")),
+        matching.replace(REPO, &format!("/{REPO}")),
+        matching.replace("0123456789abcdef0123456789abcdef", "not-hex"),
+        matching.replace(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "gggggggggggggggggggggggggggggggg",
+        ),
+        matching.replace(".git", ".git?query=1"),
+        matching.replace(".git", ".git.git"),
+        "protocol=https\nhost=github.com\n\n".to_string(),
+        matching.replace("host=github.com", "host=github.com\nhost=github.com"),
+        matching.replace("protocol=https", "malformed"),
+    ];
+    for request in requests {
+        floo(&home)
+            .args(["projects", "git-credential", "get"])
+            .write_stdin(request)
+            .assert()
+            .success()
+            .stdout("")
+            .stderr("");
+    }
+}
+
+#[test]
+fn credential_store_and_erase_are_noops() {
+    let home = TempDir::new().unwrap();
+    for operation in ["store", "erase"] {
+        floo(&home)
+            .args(["projects", "git-credential", operation, "--json"])
+            .write_stdin(format!(
+                "protocol=https\nhost=github.com\npath={REPO}.git\npassword={TOKEN}\n\n"
+            ))
+            .assert()
+            .success()
+            .stdout("")
+            .stderr("");
+    }
+    assert_eq!(std::fs::read_dir(home.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn credential_rejects_protocol_injection_without_printing_token() {
+    for token in [
+        "secret\npassword=injected",
+        "secret\rfield=injected",
+        "secret\0",
+        "",
+    ] {
+        let mut server = Server::new();
+        let home = setup(&server);
+        let mock = token_mock(&mut server, token);
+        floo(&home)
+            .args(["projects", "git-credential", "get"])
+            .write_stdin(format!(
+                "protocol=https\r\nhost=github.com\r\npath={REPO}\r\n\r\n"
+            ))
+            .assert()
+            .failure()
+            .stdout("")
+            .stderr(predicate::str::contains("secret").not())
+            .stderr(predicate::str::contains("next: floo projects list"));
+        mock.assert();
+    }
+}
+
+#[test]
+fn project_api_errors_preserve_codes_messages_and_hints() {
+    for (status, code) in [
+        (503, "MANAGED_PROJECTS_DISABLED"),
+        (403, "MANAGED_REPO_NOT_OWNED"),
+        (404, "PROJECT_NOT_FOUND"),
+    ] {
+        let mut server = Server::new();
+        let home = setup(&server);
+        let mock = server.mock("POST", "/v1/projects")
+            .with_status(status)
+            .with_body(json!({"detail": {"code": code, "message": "Project unavailable.", "hint": "Contact your organization admin."}}).to_string())
+            .expect(2)
+            .create();
+        floo(&home)
+            .args(["projects", "create", "client-portal"])
+            .assert()
+            .failure()
+            .stdout("")
+            .stderr(predicate::str::contains("Project unavailable."))
+            .stderr(predicate::str::contains("Contact your organization admin."))
+            .stderr(predicate::str::contains("next: floo projects list\n"));
+        let output = floo(&home)
+            .args(["projects", "create", "client-portal", "--json"])
+            .assert()
+            .failure()
+            .get_output()
+            .stdout
+            .clone();
+        let output: Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(output["error"]["code"], code);
+        assert_eq!(output["error"]["hint"], "Contact your organization admin.");
+        assert!(output["error"]["suggestion"]
+            .as_str()
+            .unwrap()
+            .ends_with("next: floo projects list"));
+        mock.assert();
+    }
+}
+
+#[test]
+fn credential_api_error_keeps_stdout_empty_even_in_json_mode() {
+    let mut server = Server::new();
+    let home = setup(&server);
+    let mock = server.mock("POST", format!("/v1/projects/{APP_ID}/git-token").as_str())
+        .with_status(403)
+        .with_body(json!({"detail": {"code": "MANAGED_REPO_NOT_OWNED", "message": "Repository is not owned.", "hint": "Check your organization."}}).to_string())
+        .create();
+    floo(&home)
+        .args(["projects", "git-credential", "get", "--json"])
+        .write_stdin(format!("protocol=https\nhost=github.com\npath={REPO}\n\n"))
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("Repository is not owned."))
+        .stderr(predicate::str::contains("Check your organization."))
+        .stderr(predicate::str::contains("next: floo projects list"));
+    mock.assert();
+}
+
+#[test]
+fn clone_missing_project_and_missing_git_have_next_commands() {
+    let mut server = Server::new();
+    let home = setup(&server);
+    let mock = list_mock(&mut server, vec![]);
+    floo(&home)
+        .args(["projects", "clone", "missing", "--json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("PROJECT_NOT_FOUND"))
+        .stdout(predicate::str::contains("next: floo projects list"));
+    mock.assert();
+    mock.remove();
+    let mock = list_mock(&mut server, vec![project()]);
+    floo(&home)
+        .env("PATH", home.path())
+        .args(["projects", "clone", APP_ID])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "Git is not installed or is not on PATH",
+        ))
+        .stderr(predicate::str::contains(format!(
+            "next: floo projects clone {APP_ID}"
+        )));
+    mock.assert();
+}
+
+#[cfg(unix)]
+mod git_tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn git_shim(home: &TempDir) -> std::path::PathBuf {
+        let bin = home.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let git = bin.join("git");
+        std::fs::write(&git, "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GIT_ARGS\"\necho 'mock git progress'\nexit \"${GIT_EXIT:-0}\"\n").unwrap();
+        std::fs::set_permissions(&git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        bin
+    }
+
+    fn clone_args(home: &TempDir) -> Vec<String> {
+        std::fs::read_to_string(home.path().join("git-args"))
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn clone_uses_repo_local_config_for_name_and_id_and_preserves_json_stdout() {
+        let mut server = Server::new();
+        let home = setup(&server);
+        let bin = git_shim(&home);
+        for (name_or_id, dir) in [
+            ("client-portal", None),
+            (APP_ID, Some("destination with spaces")),
+        ] {
+            let mock = list_mock(&mut server, vec![project()]);
+            let mut command = floo(&home);
+            let executable = command.get_program().to_string_lossy().to_string();
+            command
+                .env("PATH", &bin)
+                .env("GIT_ARGS", home.path().join("git-args"))
+                .args(["projects", "clone", name_or_id, "--json"]);
+            if let Some(dir) = dir {
+                command.arg(dir);
+            }
+            let output = command
+                .assert()
+                .success()
+                .stderr(predicate::str::contains("mock git progress"))
+                .get_output()
+                .stdout
+                .clone();
+            let output: Value = serde_json::from_slice(&output).unwrap();
+            let expected_dir = dir.unwrap_or("client-portal");
+            assert_eq!(output["data"]["directory"], expected_dir);
+            assert_eq!(output["data"]["next"], "read AGENTS.md");
+            let args = clone_args(&home);
+            assert_eq!(args[0..4], ["clone", "-c", "credential.helper=", "-c"]);
+            assert_eq!(
+                args[4],
+                format!("credential.helper=!{executable} projects git-credential")
+            );
+            assert_eq!(args[5..8], ["-c", "credential.useHttpPath=true", "--"]);
+            assert_eq!(args[8], project()["clone_url"]);
+            assert_eq!(args[9], expected_dir);
+            mock.assert();
+            mock.remove();
+        }
+    }
+
+    #[test]
+    fn clone_git_failure_is_reported_with_retry_command() {
+        let mut server = Server::new();
+        let home = setup(&server);
+        let bin = git_shim(&home);
+        let mock = list_mock(&mut server, vec![project()]);
+        floo(&home)
+            .env("PATH", bin)
+            .env("GIT_ARGS", home.path().join("git-args"))
+            .env("GIT_EXIT", "128")
+            .args(["projects", "clone", "client-portal"])
+            .assert()
+            .failure()
+            .stdout("")
+            .stderr(predicate::str::contains("git clone failed"))
+            .stderr(predicate::str::contains(
+                "next: floo projects clone client-portal client-portal",
+            ));
+        mock.assert();
+    }
+
+    #[test]
+    fn clone_rejects_credential_urls_and_non_managed_transports_before_git() {
+        for url in [
+            "https://token@github.com/owner/repo",
+            "ext::arbitrary-command",
+            "ssh://github.com/owner/repo",
+            "https://github.com/owner/ordinary-repo",
+        ] {
+            let mut server = Server::new();
+            let home = setup(&server);
+            let bin = git_shim(&home);
+            let mut project = project();
+            project["clone_url"] = json!(url);
+            let mock = list_mock(&mut server, vec![project]);
+            floo(&home)
+                .env("PATH", bin)
+                .env("GIT_ARGS", home.path().join("git-args"))
+                .args(["projects", "clone", "client-portal"])
+                .assert()
+                .failure()
+                .stdout("")
+                .stderr(predicate::str::contains("Project clone URL must be"))
+                .stderr(predicate::str::contains(url).not());
+            assert!(!home.path().join("git-args").exists());
+            mock.assert();
+        }
+    }
+
+    // Real git only operates on an empty local repository here. All HTTP calls
+    // go to mockito; no fetch, push, or external host is contacted.
+    #[test]
+    #[allow(deprecated)]
+    fn git_executes_quoted_workspace_helper_and_never_approves_to_inherited_helpers() {
+        let mut server = Server::new();
+        let home = setup(&server);
+        let bin = git_shim(&home);
+        let workspace = home.path().join("agent's workspace $literal;dir");
+        std::fs::create_dir(&workspace).unwrap();
+        let executable = workspace.join("floo-local");
+        std::fs::copy(assert_cmd::cargo::cargo_bin("floo-local"), &executable).unwrap();
+        let mock = list_mock(&mut server, vec![project()]);
+        let mut command = Command::new(&executable);
+        isolated(&mut command, &home);
+        command
+            .env("PATH", bin)
+            .env("GIT_ARGS", home.path().join("git-args"))
+            .args(["projects", "clone", "client-portal"])
+            .assert()
+            .success()
+            .stdout("")
+            .stderr(predicate::str::contains(
+                "directory: client-portal\nnext: read AGENTS.md",
+            ));
+        mock.assert();
+        let args = clone_args(&home);
+        let repo = home.path().join("local-repo");
+        std::fs::create_dir(&repo).unwrap();
+        let inherited = home.path().join("inherited-helper-called");
+        std::fs::write(
+            home.path().join(".gitconfig"),
+            format!(
+                "[credential]\n\thelper = !echo called > {}\n",
+                inherited.display()
+            ),
+        )
+        .unwrap();
+        let global_before = std::fs::read(home.path().join(".gitconfig")).unwrap();
+        let git = || {
+            let mut command = Command::new("git");
+            isolated(&mut command, &home);
+            command
+                .current_dir(&repo)
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .env("GIT_CONFIG_GLOBAL", home.path().join(".gitconfig"))
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .env_remove("GIT_CONFIG_COUNT")
+                .env_remove("GIT_CONFIG_PARAMETERS")
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE");
+            command
+        };
+        git().arg("init").assert().success();
+        for config in [&args[2], &args[4], &args[6]] {
+            let (key, value) = config.split_once('=').unwrap();
+            git()
+                .args(["config", "--local", "--add", key, value])
+                .assert()
+                .success();
+        }
+        let token = token_mock(&mut server, TOKEN);
+        let input = format!("protocol=https\nhost=github.com\npath={REPO}.git\n\n");
+        let result = git()
+            .args(["credential", "fill"])
+            .write_stdin(input)
+            .assert()
+            .success()
+            .stderr("")
+            .get_output()
+            .stdout
+            .clone();
+        let result_text = String::from_utf8(result.clone()).unwrap();
+        assert_eq!(result_text.matches(TOKEN).count(), 1);
+        assert!(result_text
+            .lines()
+            .any(|line| line == format!("password={TOKEN}")));
+        token.assert();
+        git()
+            .args(["credential", "approve"])
+            .write_stdin(result.clone())
+            .assert()
+            .success()
+            .stdout("")
+            .stderr("");
+        git()
+            .args(["credential", "reject"])
+            .write_stdin(result)
+            .assert()
+            .success()
+            .stdout("")
+            .stderr("");
+        assert!(
+            !inherited.exists(),
+            "inherited helpers must never receive tokens"
+        );
+        assert_eq!(
+            std::fs::read(home.path().join(".gitconfig")).unwrap(),
+            global_before
+        );
+        assert!(!std::fs::read_to_string(repo.join(".git/config"))
+            .unwrap()
+            .contains(TOKEN));
+        assert!(!home.path().join(".git-credentials").exists());
+    }
+}


### PR DESCRIPTION
## What

The shell-and-git half of managed projects (getfloo/floo#2534). An agent runs:

```
floo projects create client-portal   # live app: hosted login, postgres, repo; first deploy started
floo projects clone client-portal    # git clone with a repo-local credential helper
floo projects list
```

`clone` sets `credential.helper` in the cloned repo only, pointing at the current floo binary's absolute path, so it works when floo is installed into an agent workspace that is not on PATH. The hidden `floo projects git-credential get` implements git's credential protocol: it derives the app id from the managed repo name, asks floo for a one-hour repo-scoped token, and prints it to git. Nothing GitHub-related is ever stored; the only persisted secret remains the floo API key. Every error ends with the next command.

Depends on the API in getfloo/floo (PR to follow); all API calls are mocked here.

## Deliberately not built

Export, HTTP file read/commit commands, an MCP server, token caching, global git config changes, changes to `floo init` or `floo deploy`.

## Verified by running

```
unset FORCE_COLOR; scripts/test
```

fmt, clippy with `-D warnings`, and cargo test pass, including 14 new integration tests for create output, clone's git invocation, credential-protocol parsing, non-matching-path fallthrough, token non-leakage, and error-hint passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYtERRRFio5HGYEYAx47i2
