### PR TITLE
docs(skill): route agents without a GitHub account to floo projects

### DIFF
--- a/plugin/skills/floo/SKILL.md
+++ b/plugin/skills/floo/SKILL.md
@@ -39,7 +39,7 @@ Deploys are git-driven:
 - A push or merge to the connected branch deploys dev.
 - A GitHub release promotes prod.
 - The CLI never uploads source and `floo init` only writes local config.
-- `floo apps github connect` creates the app and triggers its first deploy
+- For a user-owned GitHub repo, `floo apps github connect` creates the app and triggers its first deploy
   from GitHub. Run preflight, commit, and push generated config before connect.
 - `floo redeploy` is for a no-code rebuild from connected GitHub source, such as applying changed environment values.
 
@@ -74,6 +74,7 @@ Never place credentials in source, committed `.env` files, floo TOML, logs, erro
 
 ## Topic routing
 
+- Managed projects without a GitHub account (hosted invite-only login and managed Postgres): `floo projects --help` for create, list, and clone; https://getfloo.com/agents.md for the full workflow.
 - Setup and first deploy: `floo docs quickstart`
 - Decision flow: `floo docs golden-path`
 - Config and secret behavior: `floo docs config`

--- a/skills/floo/SKILL.md
+++ b/skills/floo/SKILL.md
@@ -39,7 +39,7 @@ Deploys are git-driven:
 - A push or merge to the connected branch deploys dev.
 - A GitHub release promotes prod.
 - The CLI never uploads source and `floo init` only writes local config.
-- `floo apps github connect` creates the app and triggers its first deploy
+- For a user-owned GitHub repo, `floo apps github connect` creates the app and triggers its first deploy
   from GitHub. Run preflight, commit, and push generated config before connect.
 - `floo redeploy` is for a no-code rebuild from connected GitHub source, such as applying changed environment values.
 
@@ -74,6 +74,7 @@ Never place credentials in source, committed `.env` files, floo TOML, logs, erro
 
 ## Topic routing
 
+- Managed projects without a GitHub account (hosted invite-only login and managed Postgres): `floo projects --help` for create, list, and clone; https://getfloo.com/agents.md for the full workflow.
 - Setup and first deploy: `floo docs quickstart`
 - Decision flow: `floo docs golden-path`
 - Config and secret behavior: `floo docs config`


### PR DESCRIPTION
## What changed
The bundled floo skill (and its plugin mirror) gains a Topic routing line for managed projects pointing at `floo projects --help` and https://getfloo.com/agents.md, and the `floo apps github connect` bullet is qualified as the path for a user-owned GitHub repo.

## Why
Agents that load the skill were routed to the GitHub-connect path even when the user has no GitHub account. `floo projects` (#278, v2026.09.12) is that path; the skill now names it.

## Verified by running
`scripts/test` in the worktree: formatting, clippy, all tests including the installed/plugin router equality check and the clap/guidance consistency check, pass.

## Deliberately not building
- No Rust or README changes.
- The recipe itself lives at getfloo.com/agents.md (getfloo/floo #2589); the skill routes, it does not teach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FY1WDsvZSWYp4bD52H8UUP
