### PR TITLE
fix: run automatic updates only in interactive sessions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsString;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
@@ -2027,10 +2028,13 @@ pub enum CronCommands {
 }
 
 fn should_check_version(cli: &Cli) -> bool {
-    if crate::config::is_local_binary() {
+    if cli.json || !std::io::stdout().is_terminal() {
         return false;
     }
-    if std::env::var("FLOO_NO_UPDATE_CHECK").is_ok() {
+    if crate::config::is_local_binary() || crate::config::is_dev_binary() {
+        return false;
+    }
+    if std::env::var_os("FLOO_NO_UPDATE_CHECK").is_some() {
         return false;
     }
     // Commands that drive their own update flow synchronously — skip the
@@ -2234,13 +2238,13 @@ pub fn run() {
         return;
     }
 
-    // Phase 2: Always apply staged updates (safe for any command, including --json)
-    if !crate::config::is_local_binary() {
+    // Both automatic update phases run only in interactive human sessions.
+    let do_version_check = should_check_version(&cli);
+    if do_version_check {
         crate::version_check::apply_staged_update(VERSION);
     }
 
-    // Phase 1: Spawn background check + download (non-blocking, skipped for --json/version)
-    let do_version_check = should_check_version(&cli);
+    // Spawn the background check + download under the same gate.
     let version_handle = if do_version_check {
         crate::version_check::spawn_check(VERSION)
     } else {
@@ -2846,7 +2850,7 @@ pub fn run() {
 
     // Post-command: apply any update that was downloaded during this run
     if let Some(handle) = version_handle {
-        handle.apply_and_notify(VERSION, !cli.json);
+        handle.apply_and_notify(VERSION);
     }
 }
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::process;
 
 use crate::constants::VERSION;
@@ -28,7 +29,7 @@ fn display_tag(tag: &str) -> &str {
 /// dev-stack work never attempts to auto-update over the developer's
 /// working binary.
 fn should_skip_network_check() -> bool {
-    std::env::var("FLOO_NO_UPDATE_CHECK").is_ok()
+    std::env::var_os("FLOO_NO_UPDATE_CHECK").is_some()
         || crate::config::is_local_binary()
         || crate::config::is_dev_binary()
 }
@@ -54,9 +55,10 @@ fn refresh_and_announce_skills() -> Vec<String> {
 /// `floo version || echo "floo not installed"` depend on this, and agents
 /// parsing `--json` output need a stable shape across every outcome.
 ///
-/// Respects `FLOO_NO_UPDATE_CHECK` and `floo-local` dev builds.
+/// Checks only in interactive human sessions, respecting `FLOO_NO_UPDATE_CHECK`
+/// and local/dev builds.
 pub fn version() {
-    if should_skip_network_check() {
+    if output::is_json_mode() || !std::io::stdout().is_terminal() || should_skip_network_check() {
         emit_version(None, false);
         return;
     }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -301,25 +301,31 @@ pub(crate) fn verify_release_signature(
         })
 }
 
+fn install_io_error(error: std::io::Error, path: &Path, context: &str) -> FlooError {
+    if error.kind() == std::io::ErrorKind::PermissionDenied {
+        FlooError::with_suggestion(
+            ErrorCode::UpdatePermissionDenied,
+            format!("Permission denied while writing to '{}'.", path.display()),
+            "Re-run with appropriate permissions, or reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
+        )
+    } else {
+        FlooError::new(
+            ErrorCode::UpdateInstallFailed,
+            format!("{context}: {error}"),
+        )
+    }
+}
+
 #[cfg(unix)]
 pub(crate) fn set_executable(path: &Path) -> Result<(), FlooError> {
     use std::os::unix::fs::PermissionsExt;
 
     let mut permissions = fs::metadata(path)
-        .map_err(|e| {
-            FlooError::new(
-                ErrorCode::UpdateInstallFailed,
-                format!("Failed to stat file: {e}"),
-            )
-        })?
+        .map_err(|e| install_io_error(e, path, "Failed to stat file"))?
         .permissions();
     permissions.set_mode(0o755);
-    fs::set_permissions(path, permissions).map_err(|e| {
-        FlooError::new(
-            ErrorCode::UpdateInstallFailed,
-            format!("Failed to set executable permissions: {e}"),
-        )
-    })
+    fs::set_permissions(path, permissions)
+        .map_err(|e| install_io_error(e, path, "Failed to set executable permissions"))
 }
 
 #[cfg(not(unix))]
@@ -353,12 +359,8 @@ pub(crate) fn install_binary(binary_bytes: &[u8], destination: &Path) -> Result<
         )
     })?;
 
-    fs::create_dir_all(destination_dir).map_err(|e| {
-        FlooError::new(
-            ErrorCode::UpdateInstallFailed,
-            format!("Failed to prepare destination directory: {e}"),
-        )
-    })?;
+    fs::create_dir_all(destination_dir)
+        .map_err(|e| install_io_error(e, destination, "Failed to prepare destination directory"))?;
 
     let temp_name = format!(
         ".{}.tmp-update-{}",
@@ -370,29 +372,17 @@ pub(crate) fn install_binary(binary_bytes: &[u8], destination: &Path) -> Result<
     );
     let temp_path = destination_dir.join(temp_name);
 
-    fs::write(&temp_path, binary_bytes).map_err(|e| {
-        FlooError::new(
-            ErrorCode::UpdateInstallFailed,
-            format!("Failed to write update file: {e}"),
-        )
-    })?;
-    set_executable(&temp_path)?;
-
-    fs::rename(&temp_path, destination).map_err(|e| {
+    let result = (|| {
+        fs::write(&temp_path, binary_bytes)
+            .map_err(|e| install_io_error(e, destination, "Failed to write update file"))?;
+        set_executable(&temp_path)?;
+        fs::rename(&temp_path, destination)
+            .map_err(|e| install_io_error(e, destination, "Failed to replace existing binary"))
+    })();
+    if result.is_err() {
         let _ = fs::remove_file(&temp_path);
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            FlooError::with_suggestion(
-                ErrorCode::UpdatePermissionDenied,
-                format!("Permission denied while writing to '{}'.", destination.display()),
-                "Re-run with appropriate permissions, or reinstall via curl -fsSL https://getfloo.com/install.sh | bash",
-            )
-        } else {
-            FlooError::new(
-                ErrorCode::UpdateInstallFailed,
-                format!("Failed to replace existing binary: {e}"),
-            )
-        }
-    })
+    }
+    result
 }
 
 fn run_update_with(
@@ -493,6 +483,39 @@ mod tests {
     use super::*;
     use mockito::{Matcher, Server};
     use std::sync::{Mutex, OnceLock};
+
+    #[test]
+    fn permission_errors_keep_diagnostics_and_other_errors_remain_failures() {
+        let _guard = crate::output::GLOBAL_MODE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        for context in [
+            "Failed to prepare destination directory",
+            "Failed to write update file",
+            "Failed to stat file",
+            "Failed to set executable permissions",
+            "Failed to replace existing binary",
+        ] {
+            // Inject ErrorKind directly: independent of uid, ACLs, and platform.
+            let denied = install_io_error(
+                std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+                Path::new("/install/floo"),
+                context,
+            );
+            assert_eq!(denied.code, ErrorCode::UpdatePermissionDenied);
+            assert!(denied.message.contains("/install/floo"));
+            assert!(denied.suggestion.is_some());
+            let other = install_io_error(
+                std::io::Error::from(std::io::ErrorKind::NotFound),
+                Path::new("/install/floo"),
+                context,
+            );
+            assert_eq!(other.code, ErrorCode::UpdateInstallFailed);
+            assert!(other.message.starts_with(context));
+        }
+    }
 
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
     const FAKE_BINARY_SIGNATURE_B64: &str = "asvfjb0bQYA5IrimKSPkA+BgWNHyuP3ax4H4qDQPM3jbsHL1C1fQvjmeKbgadkR3t1QxdDF+62s4pJ81LlDFzW6Iz/BXY9nUUabDSVRLVDqN9F21RWxIor/m89snTJSnanhvbh1+nJ3SeYDJSmKVBqRlNld1ACykNVBlU6eXOcD+hc2faJD4m3VSdaQvRUZsXCGTL5YzyyHV86PbUk4tYt9LQsGsa/CAA0h5TX2UMNmkk12byCh7IbV9tt58lXr3+e26+54UhjDSPX29jLcHEATDPgpnllXDGUyZLtJO1GsT7ojyWrlj18M1zvNg7el9l794HSaK8uTFq2bhvURRsGKjOe3NH13+fZYvL/azLrnvT8/zOrAbpToHVcJeuNo4DUHRJMc/U6ulykHYpeF4ebafr6JREmzOQ9VVUP8vBSco7Ocw7fCxyc77dfmZnTMGooIoifKKUhIjk9ZFIUykXU9BRRuZWVap8vNy6NHZw+EM3wxk4o+vA4/wAgAvliU5";

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -8,6 +8,7 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::config;
+use crate::errors::FlooError;
 use crate::updater;
 
 const CACHE_TTL_SECS: u64 = 900; // 15 minutes
@@ -227,6 +228,13 @@ fn download_and_stage(current_version: &str, release_json: &serde_json::Value) -
 
 /// Phase 2: Apply a previously staged update. Called at startup before command dispatch.
 pub fn apply_staged_update(current_version: &str) {
+    apply_staged_update_with(current_version, updater::install_binary);
+}
+
+fn apply_staged_update_with(
+    current_version: &str,
+    install: impl FnOnce(&[u8], &std::path::Path) -> Result<(), FlooError>,
+) {
     // Clean up orphaned .downloading files from interrupted previous runs
     clean_orphaned_downloading();
 
@@ -277,7 +285,7 @@ pub fn apply_staged_update(current_version: &str) {
         }
     };
 
-    match updater::install_binary(&binary_bytes, &install_path) {
+    match install(&binary_bytes, &install_path) {
         Ok(()) => {
             let refreshed = crate::commands::skills::refresh_skill_files();
             eprintln!("  Updated floo to {}.", meta.version);
@@ -379,23 +387,11 @@ impl VersionCheckHandle {
     /// Wait for the background download to finish, apply the update immediately,
     /// and print a notice. The current process is already finishing, so replacing
     /// the binary on disk is safe — the next `floo` invocation runs the new version.
-    pub fn apply_and_notify(self, current_version: &str, show_notice: bool) {
+    pub fn apply_and_notify(self, current_version: &str) {
         if let Ok(CheckResult::Downloaded) =
             self.rx.recv_timeout(Duration::from_millis(EXIT_WAIT_MS))
         {
             apply_staged_update(current_version);
-            if show_notice {
-                if let Some(meta) = read_staged_meta() {
-                    // staged dir still exists = apply failed, tell user
-                    eprintln!(
-                        "  floo {} downloaded but could not be applied.",
-                        meta.version
-                    );
-                    eprintln!("{MANUAL_UPDATE_HINT}");
-                } else {
-                    // staged dir cleaned up = apply succeeded (already printed by apply_staged_update)
-                }
-            }
         }
     }
 }
@@ -403,6 +399,57 @@ impl VersionCheckHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::ErrorCode;
+
+    #[test]
+    fn permission_denied_staged_update_reports_diagnostics_and_cleans_staging() {
+        let _guard = crate::output::GLOBAL_MODE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
+        const CHILD: &str = "FLOO_TEST_STAGED_PERMISSION_CHILD";
+        if std::env::var_os(CHILD).is_some() {
+            apply_staged_update_with("0.0.0", |bytes, _| {
+                assert_eq!(bytes, b"test update");
+                Err(FlooError::with_suggestion(
+                    ErrorCode::UpdatePermissionDenied,
+                    "injected permission denial",
+                    "injected manual update suggestion",
+                ))
+            });
+            assert!(!staged_dir().unwrap().exists());
+            return;
+        }
+        // Isolate config and disable libtest capture so notices reach subprocess stderr.
+        let home = tempfile::tempdir().unwrap();
+        let staged = home.path().join(STAGED_DIR_NAME);
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(staged.join(STAGED_BINARY_NAME), b"test update").unwrap();
+        fs::write(
+            staged.join(STAGED_META_NAME),
+            r#"{"version":"v9999.0.0","staged_at":0}"#,
+        )
+        .unwrap();
+        let result = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "version_check::tests::permission_denied_staged_update_reports_diagnostics_and_cleans_staging",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .env("FLOO_CONFIG_DIR", home.path())
+            .env("FLOO_UPDATE_TARGET_PATH", home.path().join("install/floo"))
+            .output()
+            .unwrap();
+        assert!(result.status.success(), "{:?}", result);
+        let stderr = String::from_utf8(result.stderr).unwrap();
+        assert_eq!(
+            stderr,
+            "  Update to floo v9999.0.0 could not be applied: injected permission denial\n  injected manual update suggestion\n"
+        );
+        assert!(!staged.exists());
+    }
 
     #[test]
     fn test_is_newer_basic() {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+mod support;
+
 use assert_cmd::Command;
 use mockito::Server;
 use predicates::prelude::*;
@@ -2962,16 +2965,193 @@ fn test_env_import_all_conflicts_with_services() {
 
 // --- Version check disabled in JSON mode ---
 
+fn stage_test_update(home: &std::path::Path, profile: &str) -> std::path::PathBuf {
+    let staged = home.join(format!(".{profile}")).join("staged-update");
+    std::fs::create_dir_all(&staged).unwrap();
+    std::fs::write(staged.join("binary"), b"test update").unwrap();
+    std::fs::write(
+        staged.join("metadata.json"),
+        r#"{"version":"v9999.0.0","staged_at":0}"#,
+    )
+    .unwrap();
+    staged
+}
+
 #[test]
+#[allow(deprecated)]
 fn test_json_mode_no_version_check_output() {
-    // In JSON mode, no version check messages should appear on stderr
-    floo()
-        .args(["--json", "version"])
-        .env("HOME", "/tmp/floo-test-version-check-json")
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Update").not())
-        .stderr(predicate::str::contains("downloaded").not());
+    for args in [
+        vec!["--json", "init", "example", "--dry-run"],
+        vec!["--json", "version"],
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let staged = stage_test_update(home.path(), "floo");
+        let target = home.path().join("install/floo");
+        let mut server = Server::new();
+        let check = server.mock("GET", "/latest").expect(0).create();
+        let result = Command::cargo_bin("floo")
+            .unwrap()
+            .args(args)
+            .current_dir(home.path())
+            .env("HOME", home.path())
+            .env_remove("FLOO_CONFIG_DIR")
+            .env_remove("FLOO_NO_UPDATE_CHECK")
+            .env("FLOO_UPDATE_TARGET_PATH", &target)
+            .env("FLOO_UPDATE_API_BASE", server.url())
+            .assert()
+            .success()
+            .stderr(predicate::str::is_empty());
+        let json: serde_json::Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+        assert_eq!(json["success"], true);
+        assert!(
+            staged.join("metadata.json").exists(),
+            "startup must not consume staging"
+        );
+        assert!(
+            !target.exists(),
+            "neither startup nor post-command may install"
+        );
+        check.assert();
+    }
+}
+
+#[test]
+#[cfg(unix)]
+#[allow(deprecated)]
+fn test_automatic_update_gate_table() {
+    use std::process::Stdio;
+    // A real stdout PTY isolates the JSON guard from the non-TTY guard.
+    for (profile, json, tty, disabled, expected) in [
+        ("floo", false, true, false, true),
+        ("floo", true, true, false, false),
+        ("floo", false, false, false, false),
+        ("floo", true, false, false, false),
+        ("floo", false, true, true, false),
+        ("floo-local", false, true, false, false),
+        ("floo-dev", false, true, false, false),
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let staged = stage_test_update(home.path(), profile);
+        // Obsolete staging is removed only if startup application runs. This
+        // also works with Cargo's 0.0.0-dev version, which cannot install updates.
+        std::fs::write(
+            staged.join("metadata.json"),
+            r#"{"version":"v0.0.0","staged_at":0}"#,
+        )
+        .unwrap();
+        let target = home.path().join("install/floo");
+        let mut server = Server::new();
+        let check = server
+            .mock("GET", "/latest")
+            .with_status(200)
+            .with_body(r#"{"tag_name":"v0.0.0","assets":[]}"#)
+            .expect(usize::from(expected))
+            .create();
+        let (_master, slave) = support::stdout_terminal();
+        let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin(profile));
+        command
+            .args(["init", "example", "--dry-run"])
+            .current_dir(home.path())
+            .env("HOME", home.path())
+            .env_remove("FLOO_CONFIG_DIR")
+            .env_remove("FLOO_NO_UPDATE_CHECK")
+            .env("FLOO_UPDATE_TARGET_PATH", &target)
+            .env("FLOO_UPDATE_API_BASE", server.url())
+            .stdout(if tty {
+                Stdio::from(slave)
+            } else {
+                Stdio::piped()
+            })
+            .stderr(Stdio::piped());
+        if json {
+            command.arg("--json");
+        }
+        if disabled {
+            command.env("FLOO_NO_UPDATE_CHECK", "");
+        }
+        let result = command.output().unwrap();
+        let stderr = String::from_utf8(result.stderr).unwrap();
+        assert!(
+            result.status.success(),
+            "{profile}, json={json}, tty={tty}: {stderr}"
+        );
+        assert!(!target.exists());
+        assert_eq!(
+            staged.exists(),
+            !expected,
+            "{profile}, json={json}, tty={tty}, disabled={disabled}"
+        );
+        assert!(!stderr.contains("Updated floo"), "{stderr}");
+        if json {
+            assert!(stderr.is_empty(), "{stderr}");
+        }
+        check.assert();
+    }
+}
+
+#[test]
+#[cfg(unix)]
+#[allow(deprecated)]
+fn test_version_and_explicit_update_gate_table() {
+    use std::process::Stdio;
+    for (subcommand, json, tty, requests) in [
+        ("version", true, true, 0),
+        ("version", false, false, 0),
+        ("version", false, true, 1),
+        ("update", true, false, 1),
+        ("update", false, true, 1),
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let staged = stage_test_update(home.path(), "floo");
+        let target = home.path().join("install/floo");
+        let mut server = Server::new();
+        let check = server
+            .mock("GET", "/latest")
+            .with_status(200)
+            .with_body(r#"{"tag_name":"v9999.0.0","assets":[]}"#)
+            .expect(requests)
+            .create();
+        let (_master, slave) = support::stdout_terminal();
+        let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin("floo"));
+        command
+            .arg(subcommand)
+            .current_dir(home.path())
+            .env("HOME", home.path())
+            .env_remove("FLOO_CONFIG_DIR")
+            .env_remove("FLOO_NO_UPDATE_CHECK")
+            .env("FLOO_UPDATE_TARGET_PATH", &target)
+            .env("FLOO_UPDATE_API_BASE", server.url())
+            .stdout(if tty {
+                Stdio::from(slave)
+            } else {
+                Stdio::piped()
+            })
+            .stderr(Stdio::piped());
+        if json {
+            command.arg("--json");
+        }
+        let result = command.output().unwrap();
+        let stderr = String::from_utf8(result.stderr).unwrap();
+        assert_eq!(result.status.success(), subcommand == "version", "{stderr}");
+        // Neither command may consume staged data via the automatic startup path.
+        assert!(staged.exists());
+        assert!(!target.exists());
+        if json {
+            assert!(stderr.is_empty(), "{stderr}");
+            if !tty {
+                let payload: serde_json::Value = serde_json::from_slice(&result.stdout).unwrap();
+                assert_eq!(payload["error"]["code"], "RELEASE_ASSET_MISSING");
+            }
+        } else if subcommand == "update" {
+            assert!(
+                stderr.contains("No binary asset"),
+                "explicit update must retain diagnostics: {stderr}"
+            );
+        } else if !tty {
+            assert!(!stderr.contains("Checking for floo updates"), "{stderr}");
+        }
+        check.assert();
+    }
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+mod support;
+
 use assert_cmd::Command;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use mockito::{Matcher, Mock, Server};
@@ -13,11 +16,6 @@ const UPDATE_SUCCESS_SIGNATURE_B64: &str = "J6XvKzQVWSMxsnLl4sAkqMhCXAtDI7AZ/ckG
 #[allow(deprecated)]
 fn floo() -> Command {
     Command::cargo_bin("floo-local").unwrap()
-}
-
-#[allow(deprecated)]
-fn installed_floo() -> Command {
-    Command::cargo_bin("floo").unwrap()
 }
 
 /// Create temp HOME with config pointing at mock server.
@@ -6004,6 +6002,8 @@ fn test_deploy_json_mode_uses_polling() {
 // ───────────────────────── Update ─────────────────────────
 
 #[test]
+#[cfg(unix)]
+#[allow(deprecated)]
 fn test_version_human_reports_up_to_date_after_successful_check() {
     let Some(asset_name) = update_asset_name() else {
         return;
@@ -6054,18 +6054,23 @@ fn test_version_human_reports_up_to_date_after_successful_check() {
     )
     .unwrap();
 
-    installed_floo()
+    let (_master, slave) = support::stdout_terminal();
+    let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin("floo"));
+    command
         .arg("version")
         .env("HOME", home.path())
+        .env_remove("FLOO_CONFIG_DIR")
+        .env_remove("FLOO_NO_UPDATE_CHECK")
         .env("FLOO_UPDATE_API_BASE", format!("{}/releases", server.url()))
         .env("FLOO_UPDATE_TARGET_PATH", install_path.as_os_str())
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("0.0.0-dev"))
-        .stderr(predicate::str::contains("Checking for floo updates..."))
-        .stderr(predicate::str::contains("floo 0.0.0-dev is up to date."))
-        .stderr(predicate::str::contains("Refreshed agent skill").not())
-        .stderr(predicate::str::contains("Updated floo from").not());
+        .stdout(std::process::Stdio::from(slave));
+    let result = command.output().unwrap();
+    let stderr = String::from_utf8(result.stderr).unwrap();
+    assert!(result.status.success(), "{stderr}");
+    assert!(stderr.contains("Checking for floo updates..."), "{stderr}");
+    assert!(stderr.contains("floo 0.0.0-dev is up to date."), "{stderr}");
+    assert!(!stderr.contains("Refreshed agent skill"), "{stderr}");
+    assert!(!stderr.contains("Updated floo from"), "{stderr}");
 
     release_mock.assert();
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,24 @@
+#[cfg(unix)]
+pub fn stdout_terminal() -> (std::fs::File, std::fs::File) {
+    use std::os::fd::FromRawFd;
+    let mut master = -1;
+    let mut slave = -1;
+    // SAFETY: openpty receives valid output pointers and null optional settings.
+    // On success each fresh descriptor is transferred to exactly one File.
+    unsafe {
+        assert_eq!(
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut()
+            ),
+            0
+        );
+        (
+            std::fs::File::from_raw_fd(master),
+            std::fs::File::from_raw_fd(slave),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Automatic update (startup apply and background check) runs only in interactive sessions: never with `--json`, never when stdout is not a TTY, and still never for local/dev builds or with `FLOO_NO_UPDATE_CHECK`.
- Every install-step permission failure (dir prep, temp write, chmod, rename) is classified as `UpdatePermissionDenied` with the reinstall suggestion; interactive users still see it.
- Scripted `floo ... --json` output is clean on both streams.

## Issue Closure (Required)
Closes getfloo/floo#1057

## Changes
- src/cli.rs: one gate for both update phases.
- src/updater.rs: consistent permission-error classification and temp-file cleanup.
- src/version_check.rs, src/commands/update.rs: drop the redundant post-command notice; `floo version` skips the network check under the same gate.
- tests/cli_tests.rs, tests/support/mod.rs (pty helper), tests/mock_api_tests.rs: gate table tests, a subprocess regression with piped stdout and staged update metadata, and the permission-denied diagnostic test.

## Test Plan
- [x] `export PATH="$HOME/.cargo/bin:$PATH"; unset FORCE_COLOR; ./scripts/test` — pass (fmt, clippy, tests)

## Discovered Issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143i9M5mBwxZP33hHSHuK6b
