### PR TITLE
fix: keep the API's owning-org hint on app lookup misses

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -87,10 +87,29 @@ pub(crate) fn require_auth() {
 pub(crate) fn resolve_app_or_exit(client: &FlooClient, app_name: &str) -> App {
     match crate::resolve::resolve_app(client, app_name) {
         Ok(a) => a,
-        Err(e) => {
+        Err(mut e) => {
             // Normalize 404 codes, but preserve the API's message and details:
             // an app in another org may carry a membership-gated owning-org hint.
             if e.is_not_found() {
+                // Enrich only the generic name-miss error, and only when it is
+                // displayed. Create-on-miss callers of resolve_app don't need
+                // this request. Preserve richer errors from the list endpoint.
+                if !crate::resolve::is_uuid_identifier(app_name)
+                    && e.code == "APP_NOT_FOUND"
+                    && e.message == "App not found."
+                    && e.extra.is_none()
+                {
+                    // Uses the same org header as the name lookup. A failed org
+                    // request must not mask the original app-not-found error.
+                    let org = client
+                        .get_org_me()
+                        .ok()
+                        .map(|org| format!("org '{}'", org.display_name().unwrap_or(&org.id)))
+                        .unwrap_or_else(|| "the current org".to_string());
+                    e.message = format!(
+                        "App '{app_name}' not found in {org}. Run 'floo orgs list' to see your organizations, or 'floo orgs switch <slug>' to search another org."
+                    );
+                }
                 output::error_with_details(
                     &e.message,
                     &ErrorCode::AppNotFound,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -88,13 +88,14 @@ pub(crate) fn resolve_app_or_exit(client: &FlooClient, app_name: &str) -> App {
     match crate::resolve::resolve_app(client, app_name) {
         Ok(a) => a,
         Err(e) => {
-            // A 404 from resolving a single app means the app doesn't exist;
-            // match on status, not a drift-prone code string (see is_not_found).
+            // Normalize 404 codes, but preserve the API's message and details:
+            // an app in another org may carry a membership-gated owning-org hint.
             if e.is_not_found() {
-                output::error(
-                    &format!("App '{app_name}' not found."),
+                output::error_with_details(
+                    &e.message,
                     &ErrorCode::AppNotFound,
                     Some("Check the app name or ID and try again."),
+                    e.extra.as_ref(),
                 );
             } else {
                 output::error(&e.message, &ErrorCode::from_api(&e.code), None);

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,11 +1,10 @@
 use crate::api_client::FlooClient;
-use crate::api_types::{App, ListAppsResponse, OrgResponse};
+use crate::api_types::{App, ListAppsResponse};
 use crate::errors::FlooApiError;
 
 trait AppResolverClient {
     fn get_app(&self, app_id: &str) -> Result<App, FlooApiError>;
     fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError>;
-    fn get_org_me(&self) -> Result<OrgResponse, FlooApiError>;
 }
 
 impl AppResolverClient for FlooClient {
@@ -16,13 +15,9 @@ impl AppResolverClient for FlooClient {
     fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError> {
         FlooClient::list_apps(self, page, per_page)
     }
-
-    fn get_org_me(&self) -> Result<OrgResponse, FlooApiError> {
-        FlooClient::get_org_me(self)
-    }
 }
 
-fn is_uuid_identifier(identifier: &str) -> bool {
+pub(crate) fn is_uuid_identifier(identifier: &str) -> bool {
     if identifier.len() != 36 {
         return false;
     }
@@ -45,14 +40,17 @@ fn is_uuid_identifier(identifier: &str) -> bool {
     true
 }
 
-fn match_app_from_list_response(list_response: &ListAppsResponse, identifier: &str) -> Option<App> {
+fn match_app_from_list_response(
+    list_response: &ListAppsResponse,
+    identifier: &str,
+) -> Result<App, FlooApiError> {
     for app in &list_response.apps {
         if app.name == identifier {
-            return Some(app.clone());
+            return Ok(app.clone());
         }
     }
 
-    None
+    Err(FlooApiError::new(404, "APP_NOT_FOUND", "App not found."))
 }
 
 fn resolve_app_with_client<C: AppResolverClient>(
@@ -66,22 +64,7 @@ fn resolve_app_with_client<C: AppResolverClient>(
 
     // Name lookup via list for non-UUID identifiers.
     let response = client.list_apps(1, 100)?;
-    match_app_from_list_response(&response, identifier).ok_or_else(|| {
-        // This uses the same org header as list_apps. Resolve the display name
-        // only on a miss, and don't let a failed org lookup mask the app error.
-        let org = client
-            .get_org_me()
-            .ok()
-            .map(|org| format!("org '{}'", org.display_name().unwrap_or(&org.id)))
-            .unwrap_or_else(|| "the current org".to_string());
-        FlooApiError::new(
-            404,
-            "APP_NOT_FOUND",
-            format!(
-                "App '{identifier}' not found in {org}. Run 'floo orgs list' to see your organizations, or 'floo orgs switch <slug>' to search another org."
-            ),
-        )
-    })
+    match_app_from_list_response(&response, identifier)
 }
 
 pub fn resolve_app(client: &FlooClient, identifier: &str) -> Result<App, FlooApiError> {
@@ -140,14 +123,6 @@ mod tests {
     }
 
     impl AppResolverClient for FakeClient {
-        fn get_org_me(&self) -> Result<OrgResponse, FlooApiError> {
-            Err(FlooApiError::new(
-                503,
-                "API_ERROR",
-                "Org lookup unavailable",
-            ))
-        }
-
         fn get_app(&self, app_id: &str) -> Result<App, FlooApiError> {
             self.app_lookup_calls.borrow_mut().push(app_id.to_string());
             match &self.app_lookup_result {
@@ -293,6 +268,8 @@ mod tests {
 
     #[test]
     fn returns_app_not_found_when_name_lookup_misses() {
+        crate::output::set_json_mode(false);
+        crate::output::set_dry_run_mode(false);
         let client = FakeClient::new(
             FakeClient::err_app(404, "APP_NOT_FOUND", "App not found."),
             FakeClient::ok_list(make_list(vec![make_app("id-1", "other-app")])),
@@ -302,5 +279,7 @@ mod tests {
 
         assert_eq!(error.status_code, 404);
         assert_eq!(error.code, "APP_NOT_FOUND");
+        assert_eq!(error.message, "App not found.");
+        assert!(error.extra.is_none());
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,10 +1,11 @@
 use crate::api_client::FlooClient;
-use crate::api_types::{App, ListAppsResponse};
+use crate::api_types::{App, ListAppsResponse, OrgResponse};
 use crate::errors::FlooApiError;
 
 trait AppResolverClient {
     fn get_app(&self, app_id: &str) -> Result<App, FlooApiError>;
     fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError>;
+    fn get_org_me(&self) -> Result<OrgResponse, FlooApiError>;
 }
 
 impl AppResolverClient for FlooClient {
@@ -14,6 +15,10 @@ impl AppResolverClient for FlooClient {
 
     fn list_apps(&self, page: u32, per_page: u32) -> Result<ListAppsResponse, FlooApiError> {
         FlooClient::list_apps(self, page, per_page)
+    }
+
+    fn get_org_me(&self) -> Result<OrgResponse, FlooApiError> {
+        FlooClient::get_org_me(self)
     }
 }
 
@@ -40,17 +45,14 @@ fn is_uuid_identifier(identifier: &str) -> bool {
     true
 }
 
-fn match_app_from_list_response(
-    list_response: &ListAppsResponse,
-    identifier: &str,
-) -> Result<App, FlooApiError> {
+fn match_app_from_list_response(list_response: &ListAppsResponse, identifier: &str) -> Option<App> {
     for app in &list_response.apps {
         if app.name == identifier {
-            return Ok(app.clone());
+            return Some(app.clone());
         }
     }
 
-    Err(FlooApiError::new(404, "APP_NOT_FOUND", "App not found."))
+    None
 }
 
 fn resolve_app_with_client<C: AppResolverClient>(
@@ -64,7 +66,22 @@ fn resolve_app_with_client<C: AppResolverClient>(
 
     // Name lookup via list for non-UUID identifiers.
     let response = client.list_apps(1, 100)?;
-    match_app_from_list_response(&response, identifier)
+    match_app_from_list_response(&response, identifier).ok_or_else(|| {
+        // This uses the same org header as list_apps. Resolve the display name
+        // only on a miss, and don't let a failed org lookup mask the app error.
+        let org = client
+            .get_org_me()
+            .ok()
+            .map(|org| format!("org '{}'", org.display_name().unwrap_or(&org.id)))
+            .unwrap_or_else(|| "the current org".to_string());
+        FlooApiError::new(
+            404,
+            "APP_NOT_FOUND",
+            format!(
+                "App '{identifier}' not found in {org}. Run 'floo orgs list' to see your organizations, or 'floo orgs switch <slug>' to search another org."
+            ),
+        )
+    })
 }
 
 pub fn resolve_app(client: &FlooClient, identifier: &str) -> Result<App, FlooApiError> {
@@ -123,6 +140,14 @@ mod tests {
     }
 
     impl AppResolverClient for FakeClient {
+        fn get_org_me(&self) -> Result<OrgResponse, FlooApiError> {
+            Err(FlooApiError::new(
+                503,
+                "API_ERROR",
+                "Org lookup unavailable",
+            ))
+        }
+
         fn get_app(&self, app_id: &str) -> Result<App, FlooApiError> {
             self.app_lookup_calls.borrow_mut().push(app_id.to_string());
             match &self.app_lookup_result {

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5240,6 +5240,7 @@ fn test_deploy_watch_coalesced_superseded_descendant_is_non_failure_terminal() {
 fn test_deploy_new_app_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
+    let org = server.mock("GET", "/v1/orgs/me").expect(0).create();
 
     // Create a temp project with package.json for detection and service config
     let project = TempDir::new().unwrap();
@@ -5293,6 +5294,7 @@ fn test_deploy_new_app_json() {
         .stdout(predicate::str::contains(r#""app""#))
         .stdout(predicate::str::contains(r#""deploy""#))
         .stdout(predicate::str::contains(r#""detection""#));
+    org.assert();
 }
 
 #[test]
@@ -5747,6 +5749,50 @@ fn test_apps_show_uuid_preserves_owning_org_hint() {
     lookup.assert();
     list.assert();
     org.assert();
+}
+
+#[test]
+fn test_apps_show_server_not_found_errors_skip_org_enrichment() {
+    for (identifier, path, message) in [
+        (
+            "11111111-1111-1111-1111-111111111111",
+            "/v1/apps/11111111-1111-1111-1111-111111111111",
+            "App not found.",
+        ),
+        (
+            TEST_APP_NAME,
+            "/v1/apps",
+            "App list unavailable in this organization; contact your administrator.",
+        ),
+    ] {
+        let mut server = Server::new();
+        let home = setup_config(&server);
+        let lookup = server
+            .mock("GET", path)
+            .match_query(Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "detail": {"code": "APP_NOT_FOUND", "message": message}
+                })
+                .to_string(),
+            )
+            .create();
+        let org = server.mock("GET", "/v1/orgs/me").expect(0).create();
+
+        let result = floo()
+            .args(["--json", "apps", "show", identifier])
+            .env("HOME", home.path())
+            .assert()
+            .failure();
+        let output: serde_json::Value =
+            serde_json::from_slice(&result.get_output().stdout).unwrap();
+        assert_eq!(output["error"]["code"], "APP_NOT_FOUND");
+        assert_eq!(output["error"]["message"], message);
+        lookup.assert();
+        org.assert();
+    }
 }
 
 #[test]
@@ -7869,6 +7915,7 @@ fn mock_connect_unauthorized(server: &mut Server) -> Mock {
 fn test_failed_connect_removes_the_app_it_created() {
     let mut server = Server::new();
     let home = setup_config(&server);
+    let org = server.mock("GET", "/v1/orgs/me").expect(0).create();
 
     let lookup = mock_app_lookup_miss(&mut server);
     let create = server
@@ -7907,6 +7954,7 @@ fn test_failed_connect_removes_the_app_it_created() {
     create.assert();
     connect.assert();
     delete.assert();
+    org.assert();
 }
 
 #[test]

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -5686,15 +5686,149 @@ fn test_deploy_failed_json_includes_logs_and_suggestion() {
 // ───────────────────────── App Not Found ─────────────────────────
 
 #[test]
+fn test_apps_show_uuid_preserves_owning_org_hint() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    let app_id = "11111111-1111-1111-1111-111111111111";
+    let message = "This app is in your other organization 'Other Org'. Switch in the dashboard, or run `floo orgs switch other-org`.";
+    let owning_org = serde_json::json!({
+        "id": "other-org-id",
+        "slug": "other-org",
+        "name": "Other Org",
+    });
+    let lookup = server
+        .mock("GET", format!("/v1/apps/{app_id}").as_str())
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "detail": {
+                    "code": "APP_NOT_FOUND",
+                    "message": message,
+                    "owning_org": owning_org,
+                }
+            })
+            .to_string(),
+        )
+        .expect(2)
+        .create();
+    let list = server
+        .mock("GET", "/v1/apps")
+        .match_query(Matcher::Any)
+        .expect(0)
+        .create();
+    let org = server.mock("GET", "/v1/orgs/me").expect(0).create();
+
+    for json_mode in [false, true] {
+        let mut command = floo();
+        if json_mode {
+            command.arg("--json");
+        }
+        let result = command
+            .args(["apps", "show", app_id])
+            .env("HOME", home.path())
+            .env("NO_COLOR", "1")
+            .env_remove("FORCE_COLOR")
+            .assert()
+            .failure();
+        if json_mode {
+            let output: serde_json::Value =
+                serde_json::from_slice(&result.get_output().stdout).unwrap();
+            assert_eq!(output["success"], false);
+            assert_eq!(output["error"]["code"], "APP_NOT_FOUND");
+            assert_eq!(output["error"]["message"], message);
+            assert_eq!(output["error"]["owning_org"], owning_org);
+        } else {
+            result
+                .stdout(predicate::str::is_empty())
+                .stderr(predicate::str::contains(format!("Error: {message}\n")));
+        }
+    }
+    lookup.assert();
+    list.assert();
+    org.assert();
+}
+
+#[test]
+fn test_apps_show_name_miss_names_searched_org() {
+    let mut server = Server::new();
+    let home = setup_config(&server);
+    // Pin both requests to the selected org, which may differ from the user's
+    // default org. A miss must describe the same scope as the app list.
+    std::fs::write(
+        home.path().join(".floo-local/config.json"),
+        serde_json::json!({
+            "api_key": "floo_test123",
+            "api_url": server.url(),
+            "default_org": TEST_ORG_ID,
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let org = server
+        .mock("GET", "/v1/orgs/me")
+        .match_header("X-Floo-Org-Id", TEST_ORG_ID)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(org_json())
+        .expect(4)
+        .create();
+    let message = "App 'nonexistent' not found in org 'test-org'. Run 'floo orgs list' to see your organizations, or 'floo orgs switch <slug>' to search another org.";
+
+    for apps in [
+        r#"{"apps":[]}"#.to_string(),
+        format!(r#"{{"apps":[{}]}}"#, app_json()),
+    ] {
+        let list = server
+            .mock("GET", "/v1/apps")
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page".into(), "1".into()),
+                Matcher::UrlEncoded("per_page".into(), "100".into()),
+            ]))
+            .match_header("X-Floo-Org-Id", TEST_ORG_ID)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(apps)
+            .expect(2)
+            .create();
+        for json_mode in [false, true] {
+            let mut command = floo();
+            if json_mode {
+                command.arg("--json");
+            }
+            let result = command
+                .args(["apps", "show", "nonexistent"])
+                .env("HOME", home.path())
+                .env("NO_COLOR", "1")
+                .env_remove("FORCE_COLOR")
+                .assert()
+                .failure();
+            if json_mode {
+                let output: serde_json::Value =
+                    serde_json::from_slice(&result.get_output().stdout).unwrap();
+                assert_eq!(output["error"]["code"], "APP_NOT_FOUND");
+                assert_eq!(output["error"]["message"], message);
+            } else {
+                result
+                    .stdout(predicate::str::is_empty())
+                    .stderr(predicate::str::contains(format!("Error: {message}\n")));
+            }
+        }
+        list.assert();
+    }
+    org.assert();
+}
+
+#[test]
 fn test_app_not_found_json() {
     let mut server = Server::new();
     let home = setup_config(&server);
 
-    let _m_get = server
-        .mock("GET", "/v1/apps/nonexistent")
-        .with_status(404)
+    let org = server
+        .mock("GET", "/v1/orgs/me")
+        .with_status(503)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"detail":{"code":"NOT_FOUND","message":"Not found"}}"#)
+        .with_body(r#"{"detail":{"code":"API_ERROR","message":"Org lookup unavailable"}}"#)
         .create();
 
     let _m_list = server
@@ -5713,7 +5847,13 @@ fn test_app_not_found_json() {
         .env("HOME", home.path())
         .assert()
         .failure()
-        .stdout(predicate::str::contains("APP_NOT_FOUND"));
+        .stdout(predicate::str::contains("APP_NOT_FOUND"))
+        .stdout(predicate::str::contains(
+            "App 'nonexistent' not found in the current org.",
+        ))
+        .stdout(predicate::str::contains("floo orgs list"))
+        .stdout(predicate::str::contains("floo orgs switch"));
+    org.assert();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- A UUID lookup that 404s now surfaces the API's message and `owning_org` detail (membership-gated server side) instead of a manufactured "App not found".
- A name miss says which org was searched and points to `floo orgs list` / `floo orgs switch`.

## Issue Closure (Required)
N/A: getfloo/floo#2536 closes with the sibling `floo orgs list` PR; this is the error-message half.

## Changes
- src/commands/mod.rs: preserve server 404 message and details.
- src/resolve.rs: name-miss message names the searched org (org lookup failure never masks the app error).
- tests/mock_api_tests.rs: regression coverage for both, human and `--json`.

## Test Plan
- [x] `export PATH="$HOME/.cargo/bin:$PATH"; unset FORCE_COLOR; ./scripts/test` — pass

## Discovered Issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143i9M5mBwxZP33hHSHuK6b
