### PR TITLE
feat: add floo orgs list with the current org marked

### DIFF
--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -101,6 +101,8 @@ pub struct OrgResponse {
     pub id: String,
     pub name: Option<String>,
     pub slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub my_role: Option<String>,
     pub plan: Option<String>,
     pub spend_cap: Option<u64>,
     pub current_period_spend_cents: Option<u64>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -655,6 +655,9 @@ pub enum ProjectsCommands {
 
 #[derive(Subcommand)]
 pub enum OrgsCommands {
+    /// List your organizations and mark the server-resolved current org.
+    List,
+
     /// Manage org members.
     #[command(subcommand)]
     Members(MembersCommands),
@@ -2405,6 +2408,7 @@ pub fn run() {
         },
 
         Commands::Orgs(sub) => match sub {
+            OrgsCommands::List => commands::orgs::list(),
             OrgsCommands::Members(members_sub) => match members_sub {
                 MembersCommands::List => commands::orgs::list_members(),
                 MembersCommands::SetRole { user_id, role } => {

--- a/src/commands/organization_sso.rs
+++ b/src/commands/organization_sso.rs
@@ -434,6 +434,7 @@ mod tests {
             id: "org-id".to_string(),
             name: Some("Example".to_string()),
             slug: Some("example".to_string()),
+            my_role: None,
             plan: None,
             spend_cap: None,
             current_period_spend_cents: None,

--- a/src/commands/orgs.rs
+++ b/src/commands/orgs.rs
@@ -27,6 +27,24 @@ pub fn list() {
             )
         });
 
+    if result.orgs.is_empty() {
+        if !output::is_json_mode() {
+            if let Some(warning) = &warning {
+                output::warn(warning);
+            }
+        }
+        output::info(
+            "No organization memberships found.",
+            Some(serde_json::json!({
+                "orgs": [],
+                "total": result.total,
+                "current_org_id": null,
+                "warning": warning,
+            })),
+        );
+        return;
+    }
+
     // Resolve through the same client and headers as other API calls. Neither
     // the saved preference nor membership order is authoritative on its own.
     let current = match client.get_org_me() {
@@ -67,10 +85,6 @@ pub fn list() {
             ),
             None,
         );
-        if result.orgs.is_empty() {
-            output::info("No organization memberships found.", None);
-            return;
-        }
     }
 
     let rows = result

--- a/src/commands/orgs.rs
+++ b/src/commands/orgs.rs
@@ -4,6 +4,101 @@ use crate::config::{load_config, save_config};
 use crate::errors::ErrorCode;
 use crate::output;
 
+pub fn list() {
+    super::require_auth();
+    let config = load_config();
+    let client = super::init_client(Some(config.clone()));
+
+    let result = match client.list_orgs() {
+        Ok(result) => result,
+        Err(e) => {
+            output::error(&e.message, &ErrorCode::from_api(&e.code), None);
+            process::exit(1);
+        }
+    };
+
+    let warning = config
+        .default_org
+        .as_deref()
+        .filter(|id| !result.orgs.iter().any(|org| org.id == *id))
+        .map(|id| {
+            format!(
+                "Saved default org '{id}' is not in your organization memberships. Run 'floo orgs switch <slug-or-id>' to select an available org."
+            )
+        });
+
+    // Resolve through the same client and headers as other API calls. Neither
+    // the saved preference nor membership order is authoritative on its own.
+    let current = match client.get_org_me() {
+        Ok(org) => org,
+        Err(e) => {
+            output::error(
+                &e.message,
+                &ErrorCode::from_api(&e.code),
+                warning.as_deref(),
+            );
+            process::exit(1);
+        }
+    };
+
+    let orgs: Vec<_> = result
+        .orgs
+        .iter()
+        .map(|org| {
+            serde_json::json!({
+                "name": org.name,
+                "slug": org.slug,
+                "id": org.id,
+                "role": org.my_role,
+                "current": org.id == current.id,
+            })
+        })
+        .collect();
+
+    if !output::is_json_mode() {
+        if let Some(warning) = &warning {
+            output::warn(warning);
+        }
+        output::info(
+            &format!(
+                "Current org: {} ({})",
+                current.display_name().unwrap_or(&current.id),
+                current.id
+            ),
+            None,
+        );
+        if result.orgs.is_empty() {
+            output::info("No organization memberships found.", None);
+            return;
+        }
+    }
+
+    let rows = result
+        .orgs
+        .iter()
+        .map(|org| {
+            vec![
+                org.name.as_deref().unwrap_or("-").to_string(),
+                org.slug.as_deref().unwrap_or("-").to_string(),
+                org.id.clone(),
+                org.my_role.as_deref().unwrap_or("-").to_string(),
+                if org.id == current.id { "*" } else { "" }.to_string(),
+            ]
+        })
+        .collect::<Vec<_>>();
+
+    output::table(
+        &["NAME", "SLUG", "ID", "ROLE", "CURRENT"],
+        &rows,
+        Some(serde_json::json!({
+            "orgs": orgs,
+            "total": result.total,
+            "current_org_id": current.id,
+            "warning": warning,
+        })),
+    );
+}
+
 pub fn list_members() {
     super::require_auth();
     let client = super::init_client(None);

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -499,45 +499,79 @@ fn test_orgs_list_current_memberships_and_read_only_config() {
 }
 
 #[test]
-fn test_orgs_list_empty_memberships_keeps_server_current_org() {
-    for json_mode in [false, true] {
-        let mut server = Server::new();
-        let home = setup_config(&server);
-        let config_path = home.path().join(".floo-local/config.json");
-        let before = std::fs::read(&config_path).unwrap();
-        let memberships = server
-            .mock("GET", "/v1/orgs")
-            .with_status(200)
-            .with_body(r#"{"orgs":[],"total":0}"#)
-            .create();
-        let current = mock_org_me(&mut server);
-        let mut cmd = floo();
-        cmd.args(["orgs", "list"])
-            .env("HOME", home.path())
-            .env_remove("FLOO_CONFIG_DIR")
-            .env_remove("FLOO_API_URL");
-        if json_mode {
-            cmd.arg("--json");
+fn test_orgs_list_empty_memberships_skips_current_org_lookup() {
+    for saved in [None, Some("org-stale")] {
+        for json_mode in [false, true] {
+            let mut server = Server::new();
+            let home = setup_config(&server);
+            let config_path = home.path().join(".floo-local/config.json");
+            if let Some(saved) = saved {
+                let mut config: serde_json::Value =
+                    serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+                config["default_org"] = saved.into();
+                std::fs::write(&config_path, config.to_string()).unwrap();
+            }
+            let before = std::fs::read(&config_path).unwrap();
+            let memberships = server
+                .mock("GET", "/v1/orgs")
+                .match_header(
+                    "x-floo-org-id",
+                    saved.map_or(Matcher::Missing, |id| Matcher::Exact(id.to_string())),
+                )
+                .with_status(200)
+                .with_body(r#"{"orgs":[],"total":0}"#)
+                .expect(1)
+                .create();
+            // With no memberships, resolving a current org would fail. It must
+            // not be requested at all, even with a stale saved preference.
+            let current = server
+                .mock("GET", "/v1/orgs/me")
+                .with_status(403)
+                .with_body(
+                    r#"{"detail":{"code":"ORG_ACCESS_DENIED","message":"No organization."}}"#,
+                )
+                .expect(0)
+                .create();
+            let mut cmd = floo();
+            cmd.args(["orgs", "list"])
+                .env("HOME", home.path())
+                .env_remove("FLOO_CONFIG_DIR")
+                .env_remove("FLOO_API_URL");
+            if json_mode {
+                cmd.arg("--json");
+            }
+            let assertion = cmd.assert().success();
+            let output = assertion.get_output();
+            let warning = saved.map(|id| format!(
+                "Saved default org '{id}' is not in your organization memberships. Run 'floo orgs switch <slug-or-id>' to select an available org."
+            ));
+            if json_mode {
+                let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+                assert_eq!(
+                    value,
+                    serde_json::json!({
+                        "success": true,
+                        "data": {
+                            "orgs": [], "total": 0, "current_org_id": null, "warning": warning
+                        }
+                    })
+                );
+                assert!(output.stderr.is_empty());
+            } else {
+                assert!(output.stdout.is_empty());
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                assert!(stderr.contains("No organization memberships found."));
+                assert!(!stderr.contains("Current org:"));
+                if let Some(warning) = warning {
+                    assert!(stderr.contains(&warning));
+                } else {
+                    assert!(!stderr.contains("Saved default org"));
+                }
+            }
+            memberships.assert();
+            current.assert();
+            assert_eq!(std::fs::read(&config_path).unwrap(), before);
         }
-        let assertion = cmd.assert().success();
-        let output = assertion.get_output();
-        if json_mode {
-            let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-            assert_eq!(
-                value["data"],
-                serde_json::json!({
-                    "orgs": [], "total": 0, "current_org_id": TEST_ORG_ID, "warning": null
-                })
-            );
-        } else {
-            assert!(output.stdout.is_empty());
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            assert!(stderr.contains("No organization memberships found."));
-            assert!(stderr.contains(&format!("Current org: test-org ({TEST_ORG_ID})")));
-        }
-        memberships.assert();
-        current.assert();
-        assert_eq!(std::fs::read(&config_path).unwrap(), before);
     }
 }
 

--- a/tests/mock_api_tests.rs
+++ b/tests/mock_api_tests.rs
@@ -382,6 +382,219 @@ fn test_billing_usage_period_scopes_derived_fields() {
         .stdout(predicate::str::contains("current_period_spend_cents").not());
 }
 
+// Each invocation starts a fresh CLI process with output modes reset.
+#[test]
+fn test_orgs_list_current_memberships_and_read_only_config() {
+    // Put the API default second, so choosing the first membership cannot pass.
+    // Also exercise a server resolution differing from a valid saved preference.
+    for (saved, current_id) in [
+        (None, "org-second"),
+        (Some("org-first"), "org-first"),
+        (Some("org-first"), "org-second"),
+        (Some("org-stale"), "org-second"),
+    ] {
+        for json_mode in [false, true] {
+            let mut server = Server::new();
+            let home = setup_config(&server);
+            let config_path = home.path().join(".floo-local/config.json");
+            let mut config: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+            if let Some(saved) = saved {
+                config["default_org"] = saved.into();
+            }
+            config["unknown_preserved_field"] = "keep me".into();
+            std::fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+            let before = std::fs::read(&config_path).unwrap();
+            let header = saved.map_or(Matcher::Missing, |id| Matcher::Exact(id.to_string()));
+            let memberships = server
+                .mock("GET", "/v1/orgs")
+                .match_header("authorization", "Bearer floo_test123")
+                .match_header("x-floo-org-id", header.clone())
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(r#"{"orgs":[{"id":"org-first","name":"First Org","slug":"first","my_role":"admin"},{"id":"org-second","name":"Second Org","slug":"second"}],"total":2}"#)
+                .expect(1)
+                .create();
+            let current = server
+                .mock("GET", "/v1/orgs/me")
+                .match_header("authorization", "Bearer floo_test123")
+                .match_header("x-floo-org-id", header)
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(serde_json::json!({"id": current_id}).to_string())
+                .expect(1)
+                .create();
+
+            let mut cmd = floo();
+            cmd.args(["orgs", "list"])
+                .env("HOME", home.path())
+                .env_remove("FLOO_CONFIG_DIR")
+                .env_remove("FLOO_API_URL")
+                .env_remove("FORCE_COLOR");
+            if json_mode {
+                cmd.arg("--json");
+            }
+            let assertion = cmd.assert().success();
+            let output = assertion.get_output();
+            let stale = saved == Some("org-stale");
+            if json_mode {
+                // Parsing the entire stdout rejects multiple JSON envelopes.
+                let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+                assert_eq!(value["success"], true);
+                let data = &value["data"];
+                assert_eq!(
+                    data["orgs"],
+                    serde_json::json!([
+                        {"id":"org-first", "name":"First Org", "slug":"first", "role":"admin", "current": current_id == "org-first"},
+                        {"id":"org-second", "name":"Second Org", "slug":"second", "role":null, "current": current_id == "org-second"}
+                    ])
+                );
+                assert_eq!(data["total"], 2);
+                assert_eq!(data["current_org_id"], current_id);
+                if stale {
+                    let warning = data["warning"].as_str().unwrap();
+                    assert!(warning.contains("org-stale"));
+                    assert!(warning.contains("not in your organization memberships"));
+                    assert!(warning.contains("floo orgs switch"));
+                } else {
+                    assert!(data["warning"].is_null());
+                }
+                assert!(output.stderr.is_empty());
+            } else {
+                assert!(output.stdout.is_empty());
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                assert!(stderr.contains(&format!("Current org: {current_id} ({current_id})")));
+                assert!(stderr.contains("CURRENT"));
+                for id in ["org-first", "org-second"] {
+                    let row = stderr
+                        .lines()
+                        .find(|line| line.contains('│') && line.contains(id))
+                        .unwrap();
+                    assert_eq!(row.contains('*'), id == current_id);
+                    if id == "org-first" {
+                        assert!(
+                            row.contains("First Org")
+                                && row.contains("first")
+                                && row.contains("admin")
+                        );
+                    } else {
+                        assert!(
+                            row.contains("Second Org")
+                                && row.contains("second")
+                                && row.contains('-')
+                        );
+                    }
+                }
+                assert_eq!(
+                    stderr.contains("not in your organization memberships"),
+                    stale
+                );
+                assert_eq!(stderr.contains("floo orgs switch"), stale);
+            }
+            memberships.assert();
+            current.assert();
+            assert_eq!(std::fs::read(&config_path).unwrap(), before);
+        }
+    }
+}
+
+#[test]
+fn test_orgs_list_empty_memberships_keeps_server_current_org() {
+    for json_mode in [false, true] {
+        let mut server = Server::new();
+        let home = setup_config(&server);
+        let config_path = home.path().join(".floo-local/config.json");
+        let before = std::fs::read(&config_path).unwrap();
+        let memberships = server
+            .mock("GET", "/v1/orgs")
+            .with_status(200)
+            .with_body(r#"{"orgs":[],"total":0}"#)
+            .create();
+        let current = mock_org_me(&mut server);
+        let mut cmd = floo();
+        cmd.args(["orgs", "list"])
+            .env("HOME", home.path())
+            .env_remove("FLOO_CONFIG_DIR")
+            .env_remove("FLOO_API_URL");
+        if json_mode {
+            cmd.arg("--json");
+        }
+        let assertion = cmd.assert().success();
+        let output = assertion.get_output();
+        if json_mode {
+            let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(
+                value["data"],
+                serde_json::json!({
+                    "orgs": [], "total": 0, "current_org_id": TEST_ORG_ID, "warning": null
+                })
+            );
+        } else {
+            assert!(output.stdout.is_empty());
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains("No organization memberships found."));
+            assert!(stderr.contains(&format!("Current org: test-org ({TEST_ORG_ID})")));
+        }
+        memberships.assert();
+        current.assert();
+        assert_eq!(std::fs::read(&config_path).unwrap(), before);
+    }
+}
+
+#[test]
+fn test_orgs_list_stale_default_resolution_error_does_not_guess_or_write() {
+    for json_mode in [false, true] {
+        let mut server = Server::new();
+        let home = setup_config(&server);
+        let config_path = home.path().join(".floo-local/config.json");
+        let config = serde_json::json!({
+            "api_key": "floo_test123", "api_url": server.url(), "default_org": "org-stale"
+        });
+        std::fs::write(&config_path, config.to_string()).unwrap();
+        let before = std::fs::read(&config_path).unwrap();
+        let memberships = server
+            .mock("GET", "/v1/orgs")
+            .match_header("x-floo-org-id", "org-stale")
+            .with_status(200)
+            .with_body(format!(r#"{{"orgs":[{}],"total":1}}"#, org_json()))
+            .create();
+        let current = server
+            .mock("GET", "/v1/orgs/me")
+            .match_header("x-floo-org-id", "org-stale")
+            .with_status(403)
+            .with_body(r#"{"detail":{"code":"ORG_ACCESS_DENIED","message":"Organization access denied."}}"#)
+            .create();
+        let mut cmd = floo();
+        cmd.args(["orgs", "list"])
+            .env("HOME", home.path())
+            .env_remove("FLOO_CONFIG_DIR")
+            .env_remove("FLOO_API_URL");
+        if json_mode {
+            cmd.arg("--json");
+        }
+        let assertion = cmd.assert().failure();
+        let output = assertion.get_output();
+        let diagnostic = if json_mode {
+            let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(value["success"], false);
+            assert_eq!(value["error"]["message"], "Organization access denied.");
+            assert!(value.get("data").is_none());
+            value["error"]["suggestion"].as_str().unwrap().to_string()
+        } else {
+            assert!(output.stdout.is_empty());
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            assert!(!stderr.contains("Current org:"));
+            stderr
+        };
+        assert!(diagnostic.contains("org-stale"));
+        assert!(diagnostic.contains("not in your organization memberships"));
+        assert!(diagnostic.contains("floo orgs switch"));
+        memberships.assert();
+        current.assert();
+        assert_eq!(std::fs::read(&config_path).unwrap(), before);
+    }
+}
+
 #[test]
 fn test_orgs_invite_json_assigns_role_and_redacts_url() {
     // #1161: `orgs invite` resolves the current org, POSTs email + role in one


### PR DESCRIPTION
## Summary
- New `floo orgs list`: memberships with name, slug, id, role, and a marker on the server-resolved current org; `--json` adds `current` per org and `current_org_id`.
- A saved `default_org` that is not among memberships is called out with a pointer to `floo orgs switch`. Read-only; config is never written.

## Issue Closure (Required)
Closes getfloo/floo#2536

## Changes
- src/cli.rs, src/commands/orgs.rs: the subcommand, using the existing `list_orgs` and `get_org_me` client calls.
- src/api_types.rs: `my_role` on `OrgResponse` (the API already returns it).
- tests/mock_api_tests.rs: current marker with and without a saved default, stale default, JSON shape, config unchanged.

## Test Plan
- [x] `export PATH="$HOME/.cargo/bin:$PATH"; unset FORCE_COLOR; ./scripts/test` — pass

## Discovered Issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143i9M5mBwxZP33hHSHuK6b
